### PR TITLE
(feat) Shutdown spawning servers

### DIFF
--- a/app/app/shared.py
+++ b/app/app/shared.py
@@ -216,6 +216,10 @@ def kill_idle_fargate():
     )
 
     for instance in instances:
+        if instance.state == 'SPAWNING':
+            set_application_stopped(instance)
+            continue
+
         logger.info('kill_idle_fargate: Attempting to find CPU usage of %s', instance)
         try:
             max_cpu, _ = application_instance_max_cpu(instance)

--- a/app/app/shared.py
+++ b/app/app/shared.py
@@ -211,7 +211,7 @@ def kill_idle_fargate():
     two_hours_ago = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=-2)
     instances = ApplicationInstance.objects.filter(
         spawner='FARGATE',
-        state='RUNNING',
+        state__in=['RUNNING', 'SPAWNING'],
         created_date__lt=two_hours_ago,
     )
 

--- a/app/app/views_application.py
+++ b/app/app/views_application.py
@@ -71,12 +71,6 @@ def get_api_visible_application_instance_by_public_host(public_host):
     )
 
 
-def get_running_applications():
-    return ApplicationInstance.objects.filter(
-        state='RUNNING',
-    )
-
-
 def api_application_dict(application_instance):
     spawner_state = get_spawner(application_instance.application_template.spawner).state(
         application_instance.spawner_application_template_options,
@@ -114,7 +108,9 @@ def applications_api_GET(request):
     return JsonResponse({
         'applications': [
             api_application_dict(application)
-            for application in get_running_applications()
+            for application in ApplicationInstance.objects.filter(
+                state='RUNNING',
+            )
         ]
     }, status=200)
 

--- a/app/app/views_application.py
+++ b/app/app/views_application.py
@@ -109,7 +109,7 @@ def applications_api_GET(request):
         'applications': [
             api_application_dict(application)
             for application in ApplicationInstance.objects.filter(
-                state='RUNNING',
+                state__in=['RUNNING', 'SPAWNING'],
             )
         ]
     }, status=200)

--- a/prometheus/fetch_targets.py
+++ b/prometheus/fetch_targets.py
@@ -39,6 +39,7 @@ async def async_main(logger, target_file, url, username, password):
                         urllib.parse.urlsplit(application['proxy_url']).hostname + ':8889'
                     ],
                 } for application in applications
+                if application['proxy_url'] is not None
             ]
             logger.debug('Saving %s to %s', file_sd_config, target_file)
             with open(target_file, 'w') as file:


### PR DESCRIPTION
If an application is in SPAWNING state for more than two hours, kill it.

Applications are only set to RUNNING on a request from the browser, so if the browser is closed before it's RUNNING, then the application will be SPAWNING forever.

The metrics are not technically required for shutting down the SPAWNING servers, but gives a bit more visibility to what's happening in Grafana

----
Background design decisions:

- The distinction between SPAWNING and RUNNING is to show different things to the user if a connection can't be made to the application. If a connection can't be made to a  SPAWNING server, the HTML page shown to the user is a nice "Starting" page. If this happens to a RUNNING application, an error page is shown. This may need to be refined/changed in future

- Some applications (i.e. JupyterLab) need the first request to the application to be from the browser to properly set cookies, so the server cannot make asynchronous requests to the application to check if it's running or not.