### PR TITLE
Adds list filter for data sets by data grouping

### DIFF
--- a/app/app/admin.py
+++ b/app/app/admin.py
@@ -226,6 +226,7 @@ class DataSetAdmin(admin.ModelAdmin):
 
     prepopulated_fields = {'slug': ('name',)}
     list_display = ('name', 'slug', 'short_description', 'grouping', 'published')
+    list_filter = ('grouping', )
     inlines = [
         SourceLinkInline,
         SourceTableInline,


### PR DESCRIPTION
This adds filtering for data sets admin list view by data grouping.

How to test:
- Go to http://localapps.com:8000/admin/app/dataset/
- Check filter by grouping visible, and working

https://trello.com/c/CbbxYKO8/124-admin-view-add-filter-for-data-sets-by-data-grouping