### PR TITLE
(fix) Registry launch error

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -18,7 +18,9 @@ RUN \
 RUN \
 	adduser -S registry && \
 	mkdir -p /var/lib/docker-registry && \
-	chown registry /var/lib/docker-registry
+	chown registry /var/lib/docker-registry && \
+	mkdir /etc/registry && \
+	chown registry /etc/registry
 
 COPY registry-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Fixes

  panic: unable to configure authorization (htpasswd): failed to open
  htpasswd path open /etc/registry: permission denied