### PR TITLE
(fix) Fix registry for Fargate: no auth

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.9
 
 ENV \
 	LC_ALL=en_US.UTF-8 \
@@ -11,8 +11,8 @@ ENV \
 RUN \
 	apk add --no-cache \
 		ca-certificates=20190108-r0 \
-		docker-registry=2.7.1-r0 \
-		openssl=1.1.1c-r0 \
+		docker-registry=2.6.2-r0 \
+		openssl=1.1.1b-r1 \
 		tini=0.18.0-r0
 
 RUN \


### PR DESCRIPTION
The latest version appears to need authentication set, which doesn't
work in Fargate (at least, not without a bit of faff). However, we are
happy without any auth since the registry is only accessible from inside
the application VPC.