### PR TITLE
(feat) More visibility on launched applications

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -16,11 +16,14 @@ class ApplicationInstanceAdmin(admin.ModelAdmin):
                 'owner',
                 'public_host',
                 'created_date',
+                'spawner_application_instance_id',
                 'max_cpu',
             ]
         }),
     ]
-    readonly_fields = ('owner', 'public_host', 'created_date', 'max_cpu')
+    readonly_fields = (
+        'owner', 'public_host', 'created_date', 'spawner_application_instance_id', 'max_cpu',
+    )
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
This would make it easier to determine if orphan Fargate containers can
be stopped, since running ones will be able to be matched with
information shown in spawner_application_instance_id