### PR TITLE
(feat) Allow delete of application instances

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -28,9 +28,6 @@ class ApplicationInstanceAdmin(admin.ModelAdmin):
     def has_add_permission(self, request):
         return False
 
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.filter(state='RUNNING')


### PR DESCRIPTION
This is to help debugging, and suspect will be used in the initial
stages of users creating their own applications