### PR TITLE
(feat) User provided apps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
         - --load-plugins
         - pylint_django
         - --disable=broad-except
+        - --disable=consider-using-ternary
         - --disable=duplicate-code
         - --disable=invalid-name
         - --disable=missing-docstring

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -62,7 +62,7 @@ def application_api_PUT(request, public_host):
         return JsonResponse({'message': 'Application instance already exists'}, status=409)
 
     try:
-        application_template, _ = application_template_and_data_from_host(public_host)
+        application_template, public_host_data = application_template_and_data_from_host(public_host)
     except ApplicationTemplate.DoesNotExist:
         return JsonResponse({'message': 'Application template does not exist'}, status=400)
 
@@ -81,8 +81,8 @@ def application_api_PUT(request, public_host):
 
     spawn.delay(
         application_template.spawner,
-        request.user.email, str(request.user.profile.sso_id), application_instance.id,
-        application_template.spawner_options, credentials)
+        request.user.email, str(request.user.profile.sso_id), public_host_data,
+        application_instance.id, application_template.spawner_options, credentials)
 
     return JsonResponse(api_application_dict(application_instance), status=200)
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -147,7 +147,8 @@ class FargateSpawner():
 
             database_env = {
                 f'DATABASE_DSN__{database["memorable_name"]}':
-                f'host={database["db_host"]} port={database["db_port"]} sslmode=require dbname={database["db_name"]} user={database["db_user"]} password={database["db_password"]}'
+                f'host={database["db_host"]} port={database["db_port"]} sslmode=require dbname={database["db_name"]} '
+                f'user={database["db_user"]} password={database["db_password"]}'
                 for database in db_credentials
             }
 

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -25,10 +25,15 @@ def application_template_and_data_from_host(public_host):
     # Not efficient, but we don't expect many templates. At the time of writing,
     # no more than 4 are planned
     matching = [
-        (application_template, host_data)
+        (application_template, host_data.groupdict())
         for application_template in ApplicationTemplate.objects.all()
         for host_data in [
-            re.match('^' + application_template.host_pattern.replace('<user>', '(?P<user>.*?)') + '$', public_host)
+            # Extract the data from public_host using application_template.host_pattern.
+            # For example, if
+            #   application_template.host_pattern = '<customfield>-<user>'
+            #   public_host = 'myapp-12345acd'
+            # then host_data will be {'customfield': 'myapp', 'user': '12345acd'}
+            re.match('^' + re.sub('<(.+?)>', '(?P<\\1>.*?)', application_template.host_pattern) + '$', public_host)
         ]
         if host_data
     ]

--- a/dataworkspace/dataworkspace/apps/catalogue/views.py
+++ b/dataworkspace/dataworkspace/apps/catalogue/views.py
@@ -254,7 +254,12 @@ def root_view_GET(request):
 
     def link(application_template):
         public_host = application_template.host_pattern.replace('<user>', sso_id_hex_short)
-        return f'{request.scheme}://{public_host}.{settings.APPLICATION_ROOT_DOMAIN}/'
+        # If there are some un-interpolated values, then we can't show a link to this: the app
+        # will be started by the user knowing the link ahead of time. Potentially in a future
+        # version there could be some UI to manage this.
+        return \
+            None if '<' in public_host or '>' in public_host else \
+            f'{request.scheme}://{public_host}.{settings.APPLICATION_ROOT_DOMAIN}/'
 
     context = {
         'applications': [
@@ -265,6 +270,8 @@ def root_view_GET(request):
                 'instance': application_instances.get(application_template, None),
             }
             for application_template in ApplicationTemplate.objects.all().order_by('name')
+            for application_link in [link(application_template)]
+            if application_link
         ],
         'appstream_url': settings.APPSTREAM_URL,
         'groupings': get_all_datagroups_viewmodel()

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -117,6 +117,9 @@ data "template_file" "admin_container_definitions" {
     fargate_spawner__rstudio_task_definition_arn   = "${aws_ecs_task_definition.rstudio.family}"
     fargate_spawner__pgadmin_task_definition_arn   = "${aws_ecs_task_definition.pgadmin.family}"
 
+    fargate_spawner__user_provided_task_definition_arn                        = "${aws_ecs_task_definition.user_provided.family}"
+    fargate_spawner__user_provided_task_role__policy_document_template_base64 = "${base64encode(data.aws_iam_policy_document.user_provided_access_template.json)}"
+
     zendesk_email = "${var.zendesk_email}"
     zendesk_subdomain = "${var.zendesk_subdomain}"
     zendesk_token = "${var.zendesk_token}"
@@ -212,6 +215,9 @@ data "template_file" "admin_store_db_creds_in_s3_container_definitions" {
 
     fargate_spawner__rstudio_task_definition_arn   = "${aws_ecs_task_definition.rstudio.family}:${aws_ecs_task_definition.rstudio.revision}"
     fargate_spawner__pgadmin_task_definition_arn   = "${aws_ecs_task_definition.pgadmin.family}:${aws_ecs_task_definition.pgadmin.revision}"
+
+    fargate_spawner__user_provided_task_definition_arn                        = "${aws_ecs_task_definition.user_provided.family}"
+    fargate_spawner__user_provided_task_role__policy_document_template_base64 = "${base64encode(data.aws_iam_policy_document.user_provided_access_template.json)}"
 
     zendesk_email = "${var.zendesk_email}"
     zendesk_subdomain = "${var.zendesk_subdomain}"
@@ -357,6 +363,29 @@ data "aws_iam_policy_document" "admin_run_tasks" {
       "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.notebook.family}",
       "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.rstudio.family}",
       "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.pgadmin.family}",
+      "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.user_provided.family}-*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecs:DescribeTaskDefinition",
+    ]
+
+    resources = [
+      # ECS doesn't provide more-specific permission for DescribeTaskDefinition
+      "*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecs:RegisterTaskDefinition",
+    ]
+
+    resources = [
+      # ECS doesn't provide more-specific permission for RegisterTaskDefinition
+      "*",
     ]
   }
 

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -132,6 +132,10 @@
       "value": "${notebook_task_role__assume_role_policy_document_base64}"
     },
     {
+      "name": "APPLICATION_TEMPLATES__1__SPAWNER_OPTIONS__S3_SYNC",
+      "value": "true"
+    },
+    {
       "name": "APPLICATION_TEMPLATES__1__SPAWNER_OPTIONS__S3_REGION",
       "value": "eu-west-2"
     },
@@ -224,6 +228,10 @@
       "value": "${notebook_task_role__assume_role_policy_document_base64}"
     },
     {
+      "name": "APPLICATION_TEMPLATES__2__SPAWNER_OPTIONS__S3_SYNC",
+      "value": "true"
+    },
+    {
       "name": "APPLICATION_TEMPLATES__2__SPAWNER_OPTIONS__S3_REGION",
       "value": "eu-west-2"
     },
@@ -304,6 +312,10 @@
       "value": "${notebook_task_role__assume_role_policy_document_base64}"
     },
     {
+      "name": "APPLICATION_TEMPLATES__3__SPAWNER_OPTIONS__S3_SYNC",
+      "value": "true"
+    },
+    {
       "name": "APPLICATION_TEMPLATES__3__SPAWNER_OPTIONS__S3_REGION",
       "value": "eu-west-2"
     },
@@ -313,6 +325,94 @@
     },
     {
       "name": "APPLICATION_TEMPLATES__3__SPAWNER_OPTIONS__S3_BUCKET",
+      "value": "${notebooks_bucket}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__NAME",
+      "value": "user"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__HOST_PATTERN",
+      "value": "<tag>-<repo>-<user>"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__NICE_NAME",
+      "value": "User Provided"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER",
+      "value": "FARGATE"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_TIME",
+      "value": "30"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_HOST_PATTERN",
+      "value": "<tag>-<repo>-<user>"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__CLUSTER_NAME",
+      "value": "${fargate_spawner__task_custer_name}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__DEFINITION_ARN",
+      "value": "${fargate_spawner__user_provided_task_definition_arn}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__CONTAINER_NAME",
+      "value": "user-provided"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__CONTAINER_TAG_PATTERN",
+      "value": "<tag>-<repo>-<user>"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__SECURITY_GROUPS__1",
+      "value": "${fargate_spawner__task_security_group}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__SUBNETS__1",
+      "value": "${fargate_spawner__task_subnet}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__PORT",
+      "value": "8888"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__ROLE_PREFIX",
+      "value": "${notebook_task_role__role_prefix}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__POLICY_NAME",
+      "value": "${notebook_task_role__policy_name}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__PERMISSIONS_BOUNDARY_ARN",
+      "value": "${notebook_task_role__permissions_boundary_arn}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__POLICY_DOCUMENT_TEMPLATE_BASE64",
+      "value": "${fargate_spawner__user_provided_task_role__policy_document_template_base64}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__ASSUME_ROLE_POLICY_DOCUMENT_BASE64",
+      "value": "${notebook_task_role__assume_role_policy_document_base64}"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__S3_SYNC",
+      "value": "false"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__S3_REGION",
+      "value": "eu-west-2"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__S3_HOST",
+      "value": "s3-eu-west-2.amazonaws.com"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__4__SPAWNER_OPTIONS__S3_BUCKET",
       "value": "${notebooks_bucket}"
     },
     {

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -1,0 +1,51 @@
+resource "aws_ecs_task_definition" "user_provided" {
+  family                = "${var.prefix}-user-provided"
+  container_definitions = "${data.template_file.user_provided_container_definitions.rendered}"
+  execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
+  network_mode          = "awsvpc"
+  cpu                   = "${local.user_provided_container_cpu}"
+  memory                = "${local.user_provided_container_memory}"
+  requires_compatibilities = ["FARGATE"]
+
+
+  lifecycle {
+    ignore_changes = [
+      "revision",
+    ]
+  }
+}
+
+data "external" "user_provided_metrics_current_tag" {
+  program = ["${path.module}/task_definition_tag.sh"]
+
+  query = {
+    task_family = "${var.prefix}-user-provided"
+    container_name = "metrics"
+  }
+}
+
+data "template_file" "user_provided_container_definitions" {
+  template = "${file("${path.module}/ecs_user_provided_container_definitions.json")}"
+
+  vars {
+    container_name   = "${local.user_provided_container_name}"
+    container_cpu    = "${local.user_provided_container_cpu}"
+    container_memory = "${local.user_provided_container_memory}"
+    container_image  = "${var.user_provided_container_image}"
+
+    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+    log_region = "${data.aws_region.aws_region.name}"
+
+    sentry_dsn = "${var.sentry_dsn}"
+
+    metrics_container_image = "${var.metrics_container_image}:master"
+  }
+}
+
+data "aws_iam_policy_document" "user_provided_access_template" {
+  statement {
+    resources = ["*"]
+    actions = ["*"]
+    effect = "Deny"
+  }
+}

--- a/infra/ecs_user_provided_container_definitions.json
+++ b/infra/ecs_user_provided_container_definitions.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "${container_name}",
+    "image": "${container_image}",
+    "memoryReservation": ${container_memory - 50},
+    "cpu": ${container_cpu - 5},
+    "essential": true,
+    "ulimits": [{
+          "softLimit": 4096,
+          "hardLimit": 4096,
+          "name": "nofile"
+    }],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${log_region}",
+        "awslogs-stream-prefix": "${container_name}"
+      }
+    },
+    "environment": []
+  },
+  {
+    "name": "metrics",
+    "image": "${metrics_container_image}",
+    "memoryReservation": 50,
+    "cpu": 5,
+    "essential": true,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${log_region}",
+        "awslogs-stream-prefix": "metrics"
+      }
+    },
+    "environment": [{
+      "name": "PORT",
+      "value": "8889"
+    }]
+  }
+]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,6 +45,7 @@ variable "notebooks_bucket" {}
 variable "notebook_container_image" {}
 variable "rstudio_container_image" {}
 variable "pgadmin_container_image" {}
+variable "user_provided_container_image" {}
 
 variable "alb_access_logs_bucket" {}
 variable "alb_logs_account" {}
@@ -105,6 +106,11 @@ locals {
   notebook_container_port   = "8888"
   notebook_container_memory = 8192
   notebook_container_cpu    = 1024
+
+  user_provided_container_name   = "user-provided"
+  user_provided_container_port   = "8888"
+  user_provided_container_memory = 512
+  user_provided_container_cpu    = 256
 
   logstash_container_name       = "jupyterhub-logstash"
   logstash_alb_port             = "443"

--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -20,6 +20,13 @@ resource "aws_db_instance" "admin" {
 
   vpc_security_group_ids = ["${aws_security_group.admin_db.id}"]
   db_subnet_group_name = "${aws_db_subnet_group.admin.name}"
+
+  lifecycle {
+    ignore_changes = [
+      "snapshot_identifier",
+      "final_snapshot_identifier",
+    ]
+  }
 }
 
 resource "aws_db_subnet_group" "admin" {


### PR DESCRIPTION
Provides a bare minimum of functionality to start applications that are defined at runtime.

- An admin/ops has to push a Docker container to the Docker repo with a certain tag in the form `<some-text>-<sso-user-id>`
- That user can then start the application by going to `<some-text>-<sso-user-id>.mydomain.com/`
- The application will close after 2 hours of inactivity, or until an an admin closes it

There is deliberately no administration screen at the moment to avoid building something that we don't know is the right thing/will be useful.

The launched application does not have access to the users folder in S3: until there is a need, treating it as a bit too dangerous, e.g. it would be a bit too easy for the user to delete all their files

However, the application does have database access to the datasets, so the application could have a server-side component and make queries.

An template project that would run using this can be seen at https://github.com/uktrade/data-workspace-visualisation