### PR TITLE
(feat) Allow immediate stop of spawning tools

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -98,7 +98,7 @@ def application_api_PATCH(request, public_host):
         return JsonResponse({}, status=400)
 
     application_instance.state = state
-    application_instance.save()
+    application_instance.save(update_fields=['state'])
 
     return JsonResponse({}, status=200)
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -212,6 +212,10 @@ class FargateSpawner():
             })
             application_instance.save(update_fields=['spawner_application_instance_id'])
 
+            application_instance.refresh_from_db()
+            if application_instance.state == 'STOPPED':
+                raise Exception('Application set to stopped before spawning complete')
+
             for _ in range(0, 60):
                 ip_address = _fargate_task_ip(options['CLUSTER_NAME'], task_arn)
                 if ip_address:
@@ -260,8 +264,8 @@ class FargateSpawner():
             return 'STOPPED'
 
     @staticmethod
-    def can_stop(_, spawner_application_id):
-        return 'task_arn' in json.loads(spawner_application_id)
+    def can_stop(_, __):
+        return True
 
     @staticmethod
     def stop(spawner_options, spawner_application_id):

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -57,11 +57,11 @@ class ProcessSpawner():
             application_instance.spawner_application_instance_id = json.dumps({
                 'process_id': proc.pid,
             })
-            application_instance.save()
+            application_instance.save(update_fields=['spawner_application_instance_id'])
 
             gevent.sleep(1)
             application_instance.proxy_url = 'http://localhost:8888/'
-            application_instance.save()
+            application_instance.save(update_fields=['proxy_url'])
         except Exception:
             logger.exception('PROCESS %s %s', application_instance_id, spawner_options)
             if proc:
@@ -210,13 +210,13 @@ class FargateSpawner():
             application_instance.spawner_application_instance_id = json.dumps({
                 'task_arn': task_arn,
             })
-            application_instance.save()
+            application_instance.save(update_fields=['spawner_application_instance_id'])
 
             for _ in range(0, 60):
                 ip_address = _fargate_task_ip(options['CLUSTER_NAME'], task_arn)
                 if ip_address:
                     application_instance.proxy_url = f'http://{ip_address}:{port}'
-                    application_instance.save()
+                    application_instance.save(update_fields=['proxy_url'])
                     return
                 gevent.sleep(3)
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -95,10 +95,6 @@ class ProcessSpawner():
             return 'STOPPED'
 
     @staticmethod
-    def can_stop(_, __):
-        return True
-
-    @staticmethod
     def stop(_, spawner_application_id):
         spawner_application_id_parsed = json.loads(spawner_application_id)
         try:
@@ -262,10 +258,6 @@ class FargateSpawner():
         except Exception:
             logger.exception('FARGATE %s %s', spawner_application_id_parsed, proxy_url)
             return 'STOPPED'
-
-    @staticmethod
-    def can_stop(_, __):
-        return True
 
     @staticmethod
     def stop(spawner_options, spawner_application_id):

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -319,10 +319,19 @@ def _fargate_task_describe(cluster_name, arn):
 
 def _fargate_task_stop(cluster_name, task_arn):
     client = boto3.client('ecs')
-    client.stop_task(
-        cluster=cluster_name,
-        task=task_arn,
-    )
+    sleep_time = 1
+    for i in range(0, 6):
+        try:
+            client.stop_task(
+                cluster=cluster_name,
+                task=task_arn,
+            )
+        except Exception:
+            gevent.sleep(sleep_time)
+            sleep_time = sleep_time * 2
+        else:
+            return
+    raise Exception('Unable to stop Fargate task {}'.format(task_arn))
 
 
 def _fargate_task_run(role_arn, cluster_name, container_name, definition_arn,

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -76,7 +76,7 @@ def stop_spawner_and_application(application_instance):
 def set_application_stopped(application_instance):
     application_instance.state = 'STOPPED'
     application_instance.single_running_or_spawning_integrity = str(application_instance.id)
-    application_instance.save()
+    application_instance.save(update_fields=['state', 'single_running_or_spawning_integrity'])
 
 
 def application_instance_max_cpu(application_instance):

--- a/dataworkspace/dataworkspace/apps/catalogue/views.py
+++ b/dataworkspace/dataworkspace/apps/catalogue/views.py
@@ -22,7 +22,6 @@ from django.views.decorators.http import require_GET
 from django.views.generic import DetailView
 
 from dataworkspace.apps.applications.models import ApplicationInstance, ApplicationTemplate
-from dataworkspace.apps.applications.spawner import get_spawner
 from dataworkspace.apps.applications.utils import stop_spawner_and_application
 from dataworkspace.apps.core.utils import table_exists, table_data
 from dataworkspace.apps.datasets.models import DataGrouping, ReferenceDataset, SourceLink, \
@@ -253,14 +252,6 @@ def root_view_GET(request):
         for application_instance in filter_api_visible_application_instances_by_owner(request.user)
     }
 
-    def can_stop(application_template):
-        application_instance = application_instances.get(application_template, None)
-        return \
-            application_instance is not None and get_spawner(application_instance.spawner).can_stop(
-                application_instance.spawner_application_template_options,
-                application_instance.spawner_application_instance_id,
-            )
-
     context = {
         'applications': [
             {
@@ -268,7 +259,6 @@ def root_view_GET(request):
                 'nice_name': application_template.nice_name,
                 'link': f'{request.scheme}://{application_template.name}-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/',
                 'instance': application_instances.get(application_template, None),
-                'can_stop': can_stop(application_template),
             }
             for application_template in ApplicationTemplate.objects.all().order_by('name')
         ],

--- a/dataworkspace/dataworkspace/apps/catalogue/views.py
+++ b/dataworkspace/dataworkspace/apps/catalogue/views.py
@@ -286,8 +286,7 @@ def root_view_POST(request):
         state__in=['RUNNING', 'SPAWNING'],
     )
 
-    if application_instance.state != 'STOPPED':
-        stop_spawner_and_application(application_instance)
+    stop_spawner_and_application(application_instance)
 
     messages.success(request, 'Stopped ' + application_instance.application_template.nice_name)
     return redirect('root')

--- a/dataworkspace/dataworkspace/templates/root.html
+++ b/dataworkspace/dataworkspace/templates/root.html
@@ -57,7 +57,7 @@
                                        style="font-weight: normal;">{{ application.nice_name }}</a>
                                 </dt>
                                 <dd class="govuk-summary-list__actions">
-                                    {% if application.instance and application.can_stop %}
+                                    {% if application.instance %}
                                         <form method="POST" style="display: inline">
                                             {% csrf_token %}
                                             <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0 btn-stop"


### PR DESCRIPTION
Stopping was only allowed when an application instance has a task_arn, which meant there was a bit of a delay from when spawning was initiated to when  the "Stop" button appeared in the UI. Now, an application can be stopped as soon as the spawning process begins, so things feel a bit more expected.

This is done as a step towards user-provided applications for visualisation, so stopping of spawning visualisation apps can be done as soon as they start. It is expected that there will probably be a bit of a repeated refinement process for these apps when developing, with multiple starts/stops of them, so making this process feel smooth and robust I suspect is important.