### PR TITLE
(feat) Don't sync _bigdata/ directories

### DIFF
--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -16,5 +16,5 @@ mobius3 \
     --prefix ${S3_PREFIX} \
     --log-level INFO \
     --credentials-source ecs-container-endpoint \
-    --exclude-remote '.*(/|^)\.checkpoints/.*' \
-    --exclude-local '.*/\..*'
+    --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)_bigdata/.*)' \
+    --exclude-local '(.*/\..*)|(.*(/|^)_bigdata/.*)'


### PR DESCRIPTION
We don't sync any _bigdata directory in either direction

- S3 -> Container to not use the 4GB space

- Container -> S3, since files that are not local would result in the
  files deleted from S3.

At the moment _any_ folder called _bigdata will not be synced for
flexibility, although it is suspected that the root _bigdata will be the
one initially encouraged.