### PR TITLE
(feat) No underscore in bigdata directory

### DIFF
--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -16,5 +16,5 @@ mobius3 \
     --prefix ${S3_PREFIX} \
     --log-level INFO \
     --credentials-source ecs-container-endpoint \
-    --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)_bigdata/.*)' \
-    --exclude-local '(.*/\..*)|(.*(/|^)_bigdata/.*)'
+    --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)bigdata/.*)' \
+    --exclude-local '(.*/\..*)|(.*(/|^)bigdata/.*)'


### PR DESCRIPTION
The underscore is ordered after capital letters, so if we want the bigdata directory at the top, will need to have some manual code. Given we (might) want it at the top and will need manual code, then may as well have a more user-friendly name.