### PR TITLE
(feat) Bump datasets max connections

### DIFF
--- a/dataworkspace/dataworkspace/settings/prod.py
+++ b/dataworkspace/dataworkspace/settings/prod.py
@@ -13,7 +13,7 @@ DATABASES = {
             'ENGINE': 'django_db_geventpool.backends.postgresql_psycopg2',
             'CONN_MAX_AGE': 0,
             **database,
-            'OPTIONS': {'sslmode': 'require', 'MAX_CONNS': 20},
+            'OPTIONS': {'sslmode': 'require', 'MAX_CONNS': 100},
         }
         for database_name, database in env['DATA_DB'].items()
     }


### PR DESCRIPTION
The datasets db is a Aurora PostgreSQL db.r5.large which supports up to
1000 connections. The value changed here is for a single application
instance, of which there are two currently.

Bumping since, unlike queries to the main admin db, queries to the
datasets dbs can be long lasting, e.g. to download tables with GBs of
data.

Not bumping crazy high to allow for scaling of the application
instances, and noting that connections to the datasets dbs are performed
from the tools