### PR TITLE
(feat) Put your files behind a feature flag

### DIFF
--- a/dataworkspace/dataworkspace/apps/catalogue/views.py
+++ b/dataworkspace/dataworkspace/apps/catalogue/views.py
@@ -323,6 +323,7 @@ def root_view_GET(request):
             if application_link
         ],
         'appstream_url': settings.APPSTREAM_URL,
+        'your_files_enabled': settings.YOUR_FILES_ENABLED,
         'groupings': get_all_datagroups_viewmodel()
     }
     return render(request, 'root.html', context)

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -198,6 +198,8 @@ S3_POLICY_DOCUMENT_TEMPLATE = base64.b64decode(env['S3_POLICY_DOCUMENT_TEMPLATE_
 S3_PERMISSIONS_BOUNDARY_ARN = env['S3_PERMISSIONS_BOUNDARY_ARN']
 S3_ROLE_PREFIX = env['S3_ROLE_PREFIX']
 
+YOUR_FILES_ENABLED = env.get('YOUR_FILES_ENABLED', 'False') == 'True'
+
 if env.get('SENTRY_DSN') is not None:
     sentry_sdk.init(
         env['SENTRY_DSN'],

--- a/dataworkspace/dataworkspace/templates/root.html
+++ b/dataworkspace/dataworkspace/templates/root.html
@@ -69,6 +69,7 @@
                                 </dd>
                             </div>
                         {% endfor %}
+                        {% if settings.your_files_enabled %}
                         <div class="govuk-summary-list__row">
                             <dt class="govuk-summary-list__key">
                                 <a class="govuk-link" href="{% url 'files' %}"
@@ -77,6 +78,7 @@
                             <dd class="govuk-summary-list__actions">
                             </dd>
                         </div>
+                        {% endif %}
                     {% endif %}
                     {% if appstream_url != "https:///" and perms.applications.access_appstream %}
                         <div class="govuk-summary-list__row">


### PR DESCRIPTION
Technically the files page is still accessible if you know its path and are on the VPN, but in production the access to the bucket has been disabled, so you can't do anything if you get there