### PR TITLE
(feat) Enable terminal in JupyterLab

### DIFF
--- a/jupyterlab/jupyter_notebook_config.py
+++ b/jupyterlab/jupyter_notebook_config.py
@@ -34,5 +34,4 @@ for logger in loggers:
 c = get_config()  # pylint: disable=undefined-variable # noqa
 
 c.NotebookApp.ip = '0.0.0.0'
-c.NotebookApp.terminals_enabled = False
 c.NotebookApp.log_level = 'DEBUG'


### PR DESCRIPTION
It's enabled in rStudio, and equivalent behaviour can be done in Python
notebooks by prefixing commands with `!`, so may as well allow a more
regular terminal.