### PR TITLE
(feat) Bump registry cluster size

### DIFF
--- a/infra/ecs_main_registry.tf
+++ b/infra/ecs_main_registry.tf
@@ -2,7 +2,7 @@ resource "aws_ecs_service" "registry" {
   name            = "${var.prefix}-registry"
   cluster         = "${aws_ecs_cluster.main_cluster.id}"
   task_definition = "${aws_ecs_task_definition.registry.arn}"
-  desired_count   = 1
+  desired_count   = 3
   launch_type     = "FARGATE"
 
   network_configuration {


### PR DESCRIPTION
It's a bit of a stab in the dark, but seeing if increasing the cluster
size of the docker registries would avoid the issue where multiple
concurrent container starts at the same time are slow.