### PR TITLE
(feat) Bump installed pip

### DIFF
--- a/jupyterlab/Dockerfile
+++ b/jupyterlab/Dockerfile
@@ -87,7 +87,7 @@ RUN \
         'xorg-libxrender=0.9.10' && \
     conda clean -tipsy && \
     pip install \
-        pip==18.1 && \
+        pip==19.2.3 && \
     pip install \
         aiocontextvars==0.2.2 \
         sentry-sdk==0.9.0 && \


### PR DESCRIPTION
Some packages, e.g. tensorflow==2.0.0rc2, won't install with the
previous pip. Suspect it's related to the note about manylinux at
https://github.com/pypa/manylinux

> can be installed with pip 19.0 and later.