### PR TITLE
(feat) Data Studio connector requires an ID

### DIFF
--- a/gds-connector/src/Code.js
+++ b/gds-connector/src/Code.js
@@ -4,6 +4,13 @@
 
 function getConfig() {
   return {
+    configParams: [{
+      type: 'TEXTINPUT',
+      name: 'tableId',
+      displayName: 'Table ID',
+      placeholder: 'the-table-id',
+      helpText: 'The ID of the Data Workspace table',
+    }],
     dateRangeRequired: false,
   };
 }
@@ -19,12 +26,23 @@ function dataWorkspaceRequest(path) {
   return JSON.parse(response_text);
 }
 
-function getSchema() {
-  return dataWorkspaceRequest('api/v1/table/some-id/schema');
+function validateRequest(request) {
+   if (!request.configParams || !request.configParams.tableId) {
+      DataStudioApp.createCommunityConnector()
+        .newUserError()
+        .setText('Please enter the Table ID')
+        .throwException();
+  }
+}
+
+function getSchema(request) {
+  validateRequest(request);
+  return dataWorkspaceRequest('api/v1/table/' + request.configParams.tableId + '/schema');
 }
 
 function getData(request) {
-  return dataWorkspaceRequest('api/v1/table/some-id/rows');
+  validateRequest(request);
+  return dataWorkspaceRequest('api/v1/table/' + request.configParams.tableId + '/rows');
 }
 
 


### PR DESCRIPTION
At the moment, the backend doesn't actually use the ID, but it does
require one, and it will use in in later changes.