### PR TITLE
Add a Jenkins release promotion pipeline for data-workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,65 @@
+pipeline {
+  agent none
+
+  stages {
+    stage('prepare') {
+      agent any
+      steps {
+        checkout scm
+        script {
+          pullRequestNumber = sh(
+              script: "git log -1 --pretty=%B | grep 'Merge pull request' | cut -d ' ' -f 4 | tr -cd '[[:digit:]]'",
+              returnStdout: true
+          ).trim()
+          currentBuild.displayName = "#${env.BUILD_ID} - PR #${pullRequestNumber}"
+        }
+      }
+    }
+
+
+    stage('release: dev') {
+      steps {
+        build job: "data-workspace-dev", parameters: [
+          string(name: "DockerTag", value: "master"),
+        ]
+      }
+    }
+
+
+    stage('release: staging') {
+      when {
+          expression {
+              milestone label: "release-staging"
+              input message: 'Deploy to staging?'
+              return true
+          }
+          beforeAgent true
+      }
+
+      steps {
+        build job: "data-workspace-staging", parameters: [
+          string(name: "DockerTag", value: "master"),
+        ]
+      }
+    }
+
+
+    stage('release: prod') {
+      when {
+          expression {
+              milestone label: "release-prod"
+              input message: 'Deploy to prod?'
+              return true
+          }
+          beforeAgent true
+      }
+
+      steps {
+        build job: "data-workspace-prod", parameters: [
+          string(name: "DockerTag", value: "master"),
+        ]
+      }
+    }
+
+  }
+}


### PR DESCRIPTION

<img width="764" alt="Screenshot 2019-11-07 at 17 06 43" src="https://user-images.githubusercontent.com/246664/68410694-113f6e00-0181-11ea-88fb-4caac7c4f5f3.png">


Adds a pipeline definition for running dev -> staging -> prod release
jobs with manual approval.

This ties together all recent releases to all data-workspace
environments within a single interface and would allow promoting
a specific release version between dev, staging and prod.

Approval steps take place within a "before agent" expression so that
they don't tie up an executor while waiting for user input. The inputs
are also surrounded by milestones so that previous releases are
automatically cancelled if a newer one proceeds to the next stage.