### PR TITLE
Run integration tests first so migrations are run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ docker-test-integration: docker-build
 
 
 .PHONY: docker-test
-docker-test: docker-test-unit docker-test-integration
+docker-test: docker-test-integration docker-test-unit
 
 
 .PHONY: check


### PR DESCRIPTION
This is a bit hacky that the unit tests depend on the integration tests.
But quickest/easiest thing to get the tests running.