### PR TITLE
Added joint reference datasets description

### DIFF
--- a/dataworkspace/dataworkspace/templates/datagroup.html
+++ b/dataworkspace/dataworkspace/templates/datagroup.html
@@ -84,6 +84,9 @@
 
         {% if joint_datasets or not datasets %}
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Joint reference datasets</h2>
+            <p class="govuk-body">
+                Joint reference datasets show the defined relationship between two or more separate reference datasets.
+            </p>
         {% endif %}
         {% for set in joint_datasets %}
                 <h2 class="govuk-heading-m">

--- a/dataworkspace/dataworkspace/templates/datagroup.html
+++ b/dataworkspace/dataworkspace/templates/datagroup.html
@@ -51,7 +51,7 @@
                     </h2>
                   {% endif %}
             {% endfor %}
-	    {% if datasets and perms.datasets_dataset_add %}
+            {% if datasets and perms.datasets_dataset_add %}
                 <p>
                     <a class="govuk-link"
                        href="{% url 'admin:datasets_dataset_add' %}">[New]</a>
@@ -68,24 +68,24 @@
                     {% endif %}
                 </h2>
                 <p class="govuk-body">{{ set.short_description }}</p>
-		{% empty %}
+                {% empty %}
                 {% if not datasets %}
                     <h2 class="govuk-heading-s">
                         No reference datasets available
                     </h2>
                 {% endif %}
-	    {% endfor %}
-	    {% if reference_datasets and perms.datasets_referencedataset_add %}
+        {% endfor %}
+        {% if reference_datasets and perms.datasets_referencedataset_add %}
                 <p>
                     <a class="govuk-link"
                        href="{% url 'admin:datasets_referencedataset_add' %}">[New]</a>
                 </p>
-	    {% endif %}
+        {% endif %}
 
-	    {% if joint_datasets or not datasets %}
-	        <h2 class="govuk-heading-l govuk-!-margin-top-8">Joint reference datasets</h2>
-	    {% endif %}
-	    {% for set in joint_datasets %}
+        {% if joint_datasets or not datasets %}
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">Joint reference datasets</h2>
+        {% endif %}
+        {% for set in joint_datasets %}
                 <h2 class="govuk-heading-m">
                     <a class="govuk-link" href="{% url 'catalogue:reference_dataset' model.slug set.slug %}">
                         {{ set.name }}
@@ -95,14 +95,14 @@
                     {% endif %}
                 </h2>
                 <p class="govuk-body">{{ set.short_description }}</p>
-		{% empty %}
-	    {% endfor %}
-	    {% if joint_datasets and perms.datasets_referencedataset_add %}
+        {% empty %}
+        {% endfor %}
+        {% if joint_datasets and perms.datasets_referencedataset_add %}
                 <p>
                     <a class="govuk-link"
                        href="{% url 'admin:datasets_referencedataset_add' %}">[New]</a>
                 </p>
-	    {% endif %}
+        {% endif %}
 
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Additional Information</h2>
 


### PR DESCRIPTION
This change adds a description below the declaration of the Joint reference datasets.
Before:
<img width="540" alt="Screenshot 2019-11-13 at 14 23 07" src="https://user-images.githubusercontent.com/8222658/68772220-57814b00-0621-11ea-83db-3543e4706b16.png">
After:
<img width="698" alt="Screenshot 2019-11-13 at 14 23 27" src="https://user-images.githubusercontent.com/8222658/68772233-60721c80-0621-11ea-8fe5-42e173c1655e.png">

Note. PR contains 2 commits the first fixes the indents as the file had a mix of both tabs and spaces. 
Actual change in the second commit


