### PR TITLE
Set field definition description of linked dataset field description

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -92,11 +92,19 @@
             {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">{{ field.name }}: ID</dt>
-              <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+              {% if field.linked_reference_dataset and field.linked_reference_dataset.identifier_field %}
+                <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.identifier_field.description }}</dd>
+              {% else %}
+                <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+              {% endif %}
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">{{ field.name }}: Name</dt>
-              <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+              {% if field.linked_reference_dataset and field.linked_reference_dataset.display_name_field %}
+                <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.display_name_field.description }}</dd>
+              {% else %}
+                <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+              {% endif %}
             </div>
             {% else %}
               <div class="govuk-summary-list__row">


### PR DESCRIPTION
For joint reference datasets Instead of displaying the linked field description this changes makes it so  the description of the field on the referenced table is displayed instead.

To test
 - View any Joint reference dataset
 - Check field definitions
 - Check linked field descriptions

Before:
<img width="632" alt="Screenshot 2019-11-14 at 14 28 40" src="https://user-images.githubusercontent.com/8222658/68865906-7ba95e80-06eb-11ea-8948-8dbd78030aa8.png">

After:
<img width="581" alt="Screenshot 2019-11-14 at 14 29 08" src="https://user-images.githubusercontent.com/8222658/68865894-74825080-06eb-11ea-8513-507451d8529a.png">
