### PR TITLE
(feat) Shorter and more memory efficient suggested use of bigdata

### DIFF
--- a/dataworkspace/dataworkspace/templates/files.html
+++ b/dataworkspace/dataworkspace/templates/files.html
@@ -278,7 +278,6 @@ Modified by the Department for International Trade
                 <p class="govuk-body">Files in the <code>{{ :: bigdataPrefix }}</code> folder are not automatically accessible from your tools in the same way other files are. However, they can be manually accessed. For example, after uploading a file <code>bigdata/file.csv</code>, you can create a Pandas DataFrame in a JupyterLab Python notebook by running the following code.</p>
                     <code><pre>import os
 import pandas as pd
-from io import BytesIO
 import boto3
 
 client = boto3.client('s3', region_name='eu-west-2')
@@ -286,8 +285,7 @@ response = client.get_object(
   Bucket='{% endverbatim %}{{ bucket }}{% verbatim %}',
   Key=os.environ['S3_PREFIX'] + '{{ :: bigdataPrefix }}file.csv'
 )
-contents = BytesIO(response['Body'].read())
-df = pd.read_csv(contents)
+df = pd.read_csv(response['Body'])
 </pre></code>
         </div>
     </div>


### PR DESCRIPTION
Suspect that it's better for read_csv to do the `read`ing to avoid
duplicating the data in memory: important for things that are meant to
be large.