### PR TITLE
Allow for the downloading of materialized views

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -298,14 +298,16 @@ def view_exists(database, schema, view):
         cur.execute(
             """
             SELECT 1
-            FROM
-                pg_catalog.pg_views
-            WHERE
-                schemaname = %s
-            AND
-                viewname = %s
+            FROM pg_catalog.pg_views
+            WHERE schemaname = %(schema)s
+            AND viewname = %(view)s
+            UNION
+            SELECT 1
+            FROM pg_catalog.pg_matviews
+            WHERE schemaname = %(schema)s
+            AND matviewname = %(view)s
         """,
-            (schema, view),
+            {'schema': schema, 'view': view},
         )
         return bool(cur.fetchone())
 

--- a/dataworkspace/dataworkspace/tests/test_views.py
+++ b/dataworkspace/dataworkspace/tests/test_views.py
@@ -652,7 +652,7 @@ class TestSourceViewDownloadView(BaseTestCase):
             DataSet.objects.get(pk=dataset.id).number_of_downloads, download_count
         )
 
-    def test_table_download(self):
+    def test_view_download(self):
         dsn = database_dsn(settings.DATABASES_DATA['my_database'])
         with connect(dsn) as conn, conn.cursor() as cursor:
             cursor.execute(
@@ -671,6 +671,43 @@ class TestSourceViewDownloadView(BaseTestCase):
             database=factories.DatabaseFactory(memorable_name='my_database'),
             schema='public',
             view='download_test_view',
+        )
+        log_count = EventLog.objects.count()
+        download_count = dataset.number_of_downloads
+        response = self._authenticated_get(source_view.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            b''.join(response.streaming_content),
+            b'"field2","field1"\r\n1,"record1"\r\n2,"record2"\r\n"Number of rows: 2"\r\n',
+        )
+        self.assertEqual(EventLog.objects.count(), log_count + 1)
+        self.assertEqual(
+            EventLog.objects.latest().event_type,
+            EventLog.TYPE_DATASET_SOURCE_VIEW_DOWNLOAD,
+        )
+        self.assertEqual(
+            DataSet.objects.get(pk=dataset.id).number_of_downloads, download_count + 1
+        )
+
+    def test_materialized_view_download(self):
+        dsn = database_dsn(settings.DATABASES_DATA['my_database'])
+        with connect(dsn) as conn, conn.cursor() as cursor:
+            cursor.execute(
+                '''
+                CREATE TABLE if not exists download_test_table (field2 int,field1 varchar(255));
+                TRUNCATE TABLE download_test_table;
+                INSERT INTO download_test_table VALUES(1, 'record1');
+                INSERT INTO download_test_table VALUES(2, 'record2');
+                CREATE OR REPLACE MATERIALIZED VIEW materialized_test_view AS
+                SELECT * FROM download_test_table;
+                '''
+            )
+        dataset = factories.DataSetFactory(user_access_type='REQUIRES_AUTHENTICATION')
+        source_view = factories.SourceViewFactory(
+            dataset=dataset,
+            database=factories.DatabaseFactory(memorable_name='my_database'),
+            schema='public',
+            view='download_test_table',
         )
         log_count = EventLog.objects.count()
         download_count = dataset.number_of_downloads

--- a/dataworkspace/dataworkspace/tests/test_views.py
+++ b/dataworkspace/dataworkspace/tests/test_views.py
@@ -694,12 +694,13 @@ class TestSourceViewDownloadView(BaseTestCase):
         with connect(dsn) as conn, conn.cursor() as cursor:
             cursor.execute(
                 '''
-                CREATE TABLE if not exists download_test_table (field2 int,field1 varchar(255));
-                TRUNCATE TABLE download_test_table;
-                INSERT INTO download_test_table VALUES(1, 'record1');
-                INSERT INTO download_test_table VALUES(2, 'record2');
-                CREATE OR REPLACE MATERIALIZED VIEW materialized_test_view AS
-                SELECT * FROM download_test_table;
+                CREATE TABLE if not exists materialized_test_table (field2 int,field1 varchar(255));
+                TRUNCATE TABLE materialized_test_table;
+                INSERT INTO materialized_test_table VALUES(1, 'record1');
+                INSERT INTO materialized_test_table VALUES(2, 'record2');
+                DROP MATERIALIZED VIEW IF EXISTS materialized_test_view;
+                CREATE MATERIALIZED VIEW materialized_test_view AS
+                SELECT * FROM materialized_test_table;
                 '''
             )
         dataset = factories.DataSetFactory(user_access_type='REQUIRES_AUTHENTICATION')
@@ -707,7 +708,7 @@ class TestSourceViewDownloadView(BaseTestCase):
             dataset=dataset,
             database=factories.DatabaseFactory(memorable_name='my_database'),
             schema='public',
-            view='download_test_table',
+            view='materialized_test_view',
         )
         log_count = EventLog.objects.count()
         download_count = dataset.number_of_downloads


### PR DESCRIPTION
Include materialized views in checks for whether a view exists in the database or not