### PR TITLE
(feat) Grant privs to user's role, rather than user

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -168,7 +168,7 @@ def new_private_database_credentials(user):
                         database_obj.memorable_name,
                         schema,
                         table,
-                        db_user,
+                        db_role,
                     )
                     continue
                 logger.info(
@@ -176,17 +176,17 @@ def new_private_database_credentials(user):
                     database_obj.memorable_name,
                     schema,
                     table,
-                    db_user,
+                    db_role,
                 )
                 cur.execute(
                     sql.SQL('GRANT USAGE ON SCHEMA {} TO {};').format(
-                        sql.Identifier(schema), sql.Identifier(db_user)
+                        sql.Identifier(schema), sql.Identifier(db_role)
                     )
                 )
                 tables_sql = sql.SQL('GRANT SELECT ON {}.{} TO {};').format(
                     sql.Identifier(schema),
                     sql.Identifier(table),
-                    sql.Identifier(db_user),
+                    sql.Identifier(db_role),
                 )
                 cur.execute(tables_sql)
 


### PR DESCRIPTION
This is a bit of a stab-in-the dark attempt at addressing

  tuple concurrently updated

errors in sentry when the privs are granted on the schema.