### PR TITLE
Allow SourceLink deletion when the associated file does not exist on s3

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -22,7 +22,6 @@ from dataworkspace.apps.dw_admin.forms import (
     ReferenceDataFieldInlineForm,
     SourceLinkForm,
     DataSetForm,
-    SourceLinkFormSet,
     ReferenceDataInlineFormset,
     ReferenceDatasetForm,
 )
@@ -48,7 +47,6 @@ class DataLinkAdmin(admin.ModelAdmin):
 class SourceLinkInline(admin.TabularInline):
     template = 'admin/source_link_inline.html'
     form = SourceLinkForm
-    formset = SourceLinkFormSet
     model = SourceLink
     extra = 1
 

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -257,8 +257,9 @@ class SourceLink(TimeStampedModel):
         return True
 
     def _delete_s3_file(self):
-        client = boto3.client('s3')
-        client.delete_object(Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url)
+        if self.local_file_is_accessible():
+            client = boto3.client('s3')
+            client.delete_object(Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url)
 
     def save(
         self, force_insert=False, force_update=False, using=None, update_fields=None

--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -3,7 +3,6 @@ import csv
 from django import forms
 from django.core import validators
 from django.core.exceptions import ValidationError
-from django.forms import BaseInlineFormSet
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
 
@@ -347,21 +346,6 @@ class SourceLinkForm(forms.ModelForm):
     class Meta:
         fields = ('name', 'url', 'format', 'frequency')
         model = SourceLink
-
-
-class SourceLinkFormSet(BaseInlineFormSet):
-    def clean(self):
-        """
-        Check if local files can be accessed before we try deleting
-        them as part of model delete
-        :return:
-        """
-        to_delete = [x for x in getattr(self, 'cleaned_data', []) if x.get('DELETE')]
-        for form in to_delete:
-            link = form['id']
-            if link.link_type == link.TYPE_LOCAL:
-                if not link.local_file_is_accessible():
-                    raise ValidationError('Unable to access local file for deletion')
 
 
 class SourceLinkUploadForm(forms.ModelForm):

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2334,8 +2334,8 @@ class TestDatasetAdmin(BaseAdminTestCase):
                 '_continue': 'Save and continue editing',
             },
         )
-        self.assertContains(response, 'Unable to access local file for deletion')
-        self.assertEqual(dataset.sourcelink_set.count(), link_count)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(dataset.sourcelink_set.count(), link_count - 1)
 
     @mock.patch('dataworkspace.apps.datasets.models.boto3.client')
     def test_delete_local_source_link(self, mock_client):

--- a/dataworkspace/dataworkspace/tests/test_models.py
+++ b/dataworkspace/dataworkspace/tests/test_models.py
@@ -755,7 +755,7 @@ class TestSourceLinkModel(BaseTestCase):
                 id='158776ec-5c40-4c58-ba7c-a3425905ec45'
             ).exists()
         )
-        mock_client.assert_called_once()
+        mock_client().head_object.assert_called_once()
         mock_client().delete_object.assert_called_once_with(
             Bucket=settings.AWS_UPLOADS_BUCKET, Key=link.url
         )


### PR DESCRIPTION
This fix allows for source links to be deleted even if they don't have an associated file on s3.

We have had a couple of instances on production where a SourceLink was duplicated by an admin. When they deleted one of the duplicates the file was deleted from s3. When they then tried to download the remaining file they found that it did not exist (as it was deleted when the duplicate was removed). Deleting the remaining file would then fail because the file didn't exist in s3.