### PR TITLE
Add a dataset admin action to clone selected datasets

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -66,6 +66,11 @@ class CustomDatasetQueryInline(admin.TabularInline):
     extra = 0
 
 
+def clone_dataset(modeladmin, request, queryset):
+    for dataset in queryset:
+        dataset.clone()
+
+
 @admin.register(DataSet)
 class DataSetAdmin(admin.ModelAdmin):
     form = DataSetForm
@@ -85,6 +90,7 @@ class DataSetAdmin(admin.ModelAdmin):
         SourceViewInline,
         CustomDatasetQueryInline,
     ]
+    actions = [clone_dataset]
     fieldsets = [
         (
             None,

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1,3 +1,4 @@
+import copy
 import uuid
 
 from typing import Optional, List
@@ -143,6 +144,42 @@ class DataSet(TimeStampedModel):
             self.user_access_type == 'REQUIRES_AUTHENTICATION'
             or self.datasetuserpermission_set.filter(user=user).exists()
         )
+
+    def clone(self):
+        """Create a copy of the dataset and any related objects.
+
+        New dataset is unpublished and has a name prefixed with
+        "Copy of <original dataset name>".
+
+        Related objects (excluding user permissions) are duplicated
+        for the new dataset.
+
+        """
+
+        CLONE_RELATED_FIELDS = [
+            'sourcetable',
+            'sourceview',
+            'sourcelink',
+            'customdatasetquery',
+        ]
+
+        clone = copy.copy(self)
+
+        clone.pk = None
+        clone.name = f'Copy of {self.name}'
+        clone.published = False
+        clone.save()
+
+        for related_field in CLONE_RELATED_FIELDS:
+            related_objects = [
+                copy.copy(obj) for obj in getattr(self, related_field + "_set").all()
+            ]
+            for obj in related_objects:
+                obj.pk = None
+                obj.dataset = clone
+                obj.save()
+
+        return clone
 
 
 class DataSetUserPermission(models.Model):

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -1,0 +1,35 @@
+from dataworkspace.tests import factories
+
+
+def test_clone_dataset(db):
+    ds = factories.DataSetFactory.create(published=True)
+    clone = ds.clone()
+
+    assert clone.id
+    assert clone.id != ds.id
+    assert clone.name == f'Copy of {ds.name}'
+    assert not clone.published
+
+
+def test_clone_dataset_copies_related_objects(db):
+    ds = factories.DataSetFactory.create(published=True)
+
+    factories.DataSetUserPermissionFactory(dataset=ds)
+    factories.SourceLinkFactory(dataset=ds)
+    factories.SourceViewFactory(dataset=ds)
+    factories.SourceTableFactory(dataset=ds)
+    factories.CustomDatasetQueryFactory(dataset=ds)
+
+    clone = ds.clone()
+
+    assert not clone.datasetuserpermission_set.all()
+    assert [obj.dataset for obj in clone.sourcelink_set.all()] == [clone]
+    assert [obj.dataset for obj in clone.sourceview_set.all()] == [clone]
+    assert [obj.dataset for obj in clone.sourcetable_set.all()] == [clone]
+    assert [obj.dataset for obj in clone.customdatasetquery_set.all()] == [clone]
+
+    assert ds.datasetuserpermission_set.all()
+    assert [obj.dataset for obj in ds.sourcelink_set.all()] == [ds]
+    assert [obj.dataset for obj in ds.sourceview_set.all()] == [ds]
+    assert [obj.dataset for obj in ds.sourcetable_set.all()] == [ds]
+    assert [obj.dataset for obj in ds.customdatasetquery_set.all()] == [ds]

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -50,6 +50,14 @@ class DataSetFactory(factory.django.DjangoModelFactory):
         model = 'datasets.DataSet'
 
 
+class DataSetUserPermissionFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory(UserFactory)
+    dataset = factory.SubFactory(DataSetFactory)
+
+    class Meta:
+        model = 'datasets.DataSetUserPermission'
+
+
 class SourceLinkFactory(factory.django.DjangoModelFactory):
     id = factory.LazyAttribute(lambda _: uuid.uuid4())
     dataset = factory.SubFactory(DataSetFactory)


### PR DESCRIPTION

<img width="698" alt="image" src="https://user-images.githubusercontent.com/246664/70255138-332b1100-177e-11ea-9070-37b46a04e250.png">


### Add a test factory for dataset user permission objects


### Add a model method to create a duplicate of a dataset

Using the recommended Django approach of duplicating a model instance this creates a coy of the dataset and any related tables, view, links etc.

There are a few packages available that add a general clone model mixin, but none appear to be widely used and since a general case is much more complex I'm going with a solution that hard-codes copied related objects for now.

https://docs.djangoproject.com/en/2.2/topics/db/queries/#copying-model-instances

### Add a dataset admin action to clone selected datasets

This adds an action to the drop-down admin menu.
