### PR TITLE
Clear cloned dataset slug to avoid conflicts

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -168,6 +168,7 @@ class DataSet(TimeStampedModel):
 
         clone.pk = None
         clone.name = f'Copy of {self.name}'
+        clone.slug = ''
         clone.published = False
         clone.save()
 


### PR DESCRIPTION
Cloning and then immediately publishing a dataset raises an error
when trying to access either the clone or the original dataset page
since the unmodified slugs are conflicting.

We want a user to assign a new slug to a cloned dataset, so this is
clearing the slug on a cloned dataset object. This works from within
Django itself, but trying to edit or publish the dataset through the
admin interface would require the user to set a new slug.

Since this can create unpublished datasets with the same slug (which is
fine since unpublished datasets don't have a public page) we want to add
a constraint for published datasets to have unique slugs in the future.