### PR TITLE
Up git version to 2.22.2-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt requirements.txt
 RUN \
 	apk add --no-cache --virtual .build-deps \
 		build-base=0.5-r1 \
-		git=2.22.0-r0 \
+		git=2.22.2-r0 \
 		python3-dev=3.7.5-r1 && \
 	apk add --no-cache \
 		nginx=1.16.1-r1 \


### PR DESCRIPTION
Builds were failing due to git 2.22.0-r0 no longer being available in the alpine 3.10 repos