### PR TITLE
Scroll on dataset selector overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2019-12-16
+
+### Changed
+
+- Fix bug on user admin form where long dataset names were not visible 
+
+
 ## 2019-12-12
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -186,6 +186,9 @@ class AppUserAdmin(UserAdmin):
     ]
     readonly_fields = ['sso_id']
 
+    class Media:
+        css = {'all': ('data-workspace-admin.css',)}
+
     @transaction.atomic
     def save_model(self, request, obj, form, change):
         content_type = ContentType.objects.get_for_model(obj).pk

--- a/dataworkspace/dataworkspace/static/data-workspace-admin.css
+++ b/dataworkspace/dataworkspace/static/data-workspace-admin.css
@@ -52,3 +52,6 @@ table.full-width {
 .float-right {
    float: right;
 }
+.app-auth.model-user.change-form .selector-available select {
+  overflow-x: auto;
+}


### PR DESCRIPTION
### Description of change

Set overflow to allow scrolling of long dataset names on the user datasets form

### Checklist

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
