### PR TITLE
Display list of data fields on the dataset page

### DIFF
--- a/dataworkspace/dataworkspace/apps/catalogue/views.py
+++ b/dataworkspace/dataworkspace/apps/catalogue/views.py
@@ -30,6 +30,7 @@ from django.views.decorators.http import require_GET
 from django.views.generic import DetailView
 from psycopg2 import sql
 
+from dataworkspace import datasets_db
 from dataworkspace.apps.applications.models import (
     ApplicationInstance,
     ApplicationTemplate,
@@ -81,18 +82,47 @@ def datagroup_item_view(request, slug):
 def dataset_full_path_view(request, group_slug, set_slug):
     dataset = find_dataset(group_slug, set_slug)
 
+    source_tables = sorted(dataset.sourcetable_set.all(), key=lambda x: x.name)
+    source_views = dataset.sourceview_set.all()
+    custom_queries = dataset.customdatasetquery_set.all()
+
+    if source_tables:
+        columns = []
+        for table in source_tables:
+            columns += [
+                "{}.{}".format(table.table, column)
+                for column in datasets_db.get_columns(
+                    table.database.memorable_name,
+                    schema=table.schema,
+                    table=table.table,
+                )
+            ]
+    elif source_views:
+        columns = datasets_db.get_columns(
+            source_views[0].database.memorable_name,
+            schema=source_views[0].schema,
+            table=source_views[0].view,
+        )
+    elif custom_queries:
+        columns = datasets_db.get_columns(
+            custom_queries[0].database.memorable_name, query=custom_queries[0].query
+        )
+    else:
+        columns = None
+
     context = {
         'model': dataset,
         'has_access': dataset.user_has_access(request.user),
         'data_links': sorted(
             chain(
                 dataset.sourcelink_set.all(),
-                dataset.sourcetable_set.all(),
-                dataset.sourceview_set.all(),
-                dataset.customdatasetquery_set.all(),
+                source_tables,
+                source_views,
+                custom_queries,
             ),
             key=lambda x: x.name,
         ),
+        'fields': columns,
     }
     if dataset.type == dataset.TYPE_MASTER_DATASET:
         return render(request, 'datasets/master_dataset.html', context)

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -1,0 +1,34 @@
+import logging
+
+import psycopg2
+from django.conf import settings
+from psycopg2 import sql
+
+from dataworkspace.apps.core.utils import database_dsn
+
+logger = logging.getLogger('app')
+
+
+def get_columns(database_name, schema=None, table=None, query=None):
+    if table is not None and schema is not None:
+        source = sql.SQL("{}.{}").format(sql.Identifier(schema), sql.Identifier(table))
+    elif query is not None:
+        source = sql.SQL("({}) AS custom_query".format(query.rstrip(";")))
+    else:
+        raise ValueError("Either table or query are required")
+
+    with psycopg2.connect(
+        database_dsn(settings.DATABASES_DATA[database_name])
+    ) as connection:
+        try:
+            return query_columns(connection, source)
+        except Exception:
+            logger.error("Failed to get dataset fields", exc_info=True)
+            return []
+
+
+def query_columns(connection, source):
+    sql = psycopg2.sql.SQL('SELECT * from {} WHERE false').format(source)
+    with connection.cursor() as cursor:
+        cursor.execute(sql)
+        return [c[0] for c in cursor.description]

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -121,6 +121,21 @@
         </div>
     </div>
 
+    {% if user.is_superuser and fields %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Fields</h2>
+            <p class="govuk-body">*Only visible to superusers.</p>
+            <ul class="govuk-list govuk-list--bullet">
+              {% for field in fields %}
+              <li>{{ field  }}</li>
+              {% endfor %}
+            </ul>
+
+        </div>
+    </div>
+    {% endif %}
+
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/dataworkspace/dataworkspace/tests/catalogue/test_views.py
+++ b/dataworkspace/dataworkspace/tests/catalogue/test_views.py
@@ -1,0 +1,116 @@
+import pytest
+import psycopg2
+from django.conf import settings
+from django.urls import reverse
+
+from dataworkspace.apps.core.utils import database_dsn
+from dataworkspace.tests import factories
+
+
+@pytest.fixture
+def dataset_db():
+    database = factories.DatabaseFactory(memorable_name='my_database')
+    with psycopg2.connect(database_dsn(settings.DATABASES_DATA['my_database'])) as conn:
+        conn.cursor().execute(
+            '''
+            CREATE TABLE IF NOT EXISTS dataset_test (
+                id INT,
+                name VARCHAR(255),
+                date DATE
+            );
+
+            CREATE TABLE IF NOT EXISTS dataset_test2 (
+                id INT,
+                name VARCHAR(255)
+            );
+
+            CREATE OR REPLACE VIEW dataset_view AS (SELECT * FROM dataset_test);
+            '''
+        )
+
+    return database
+
+
+def test_master_dataset_fields(client, dataset_db):
+    ds = factories.DataSetFactory.create(published=True)
+    factories.SourceTableFactory(
+        dataset=ds,
+        name='d1',
+        database=dataset_db,
+        schema='public',
+        table='dataset_test',
+    )
+    factories.SourceTableFactory(
+        dataset=ds,
+        name='d2',
+        database=dataset_db,
+        schema='public',
+        table='dataset_test2',
+    )
+
+    response = client.get(
+        reverse(
+            'catalogue:dataset_fullpath',
+            kwargs={'group_slug': ds.grouping.slug, 'set_slug': ds.slug},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["fields"] == [
+        'dataset_test.id',
+        'dataset_test.name',
+        'dataset_test.date',
+        'dataset_test2.id',
+        'dataset_test2.name',
+    ]
+
+
+def test_view_data_cut_fields(client, dataset_db):
+    ds = factories.DataSetFactory.create(published=True)
+    factories.SourceViewFactory(
+        dataset=ds, database=dataset_db, schema='public', view='dataset_view'
+    )
+
+    response = client.get(
+        reverse(
+            'catalogue:dataset_fullpath',
+            kwargs={'group_slug': ds.grouping.slug, 'set_slug': ds.slug},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["fields"] == ['id', 'name', 'date']
+
+
+def test_query_data_cut_fields(client, dataset_db):
+    ds = factories.DataSetFactory.create(published=True)
+    factories.CustomDatasetQueryFactory(
+        dataset=ds,
+        database=dataset_db,
+        query="SELECT id customid, name customname FROM dataset_test",
+    )
+
+    response = client.get(
+        reverse(
+            'catalogue:dataset_fullpath',
+            kwargs={'group_slug': ds.grouping.slug, 'set_slug': ds.slug},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["fields"] == ['customid', 'customname']
+
+
+def test_link_data_cut_doesnt_have_fields(client):
+    ds = factories.DataSetFactory.create(published=True)
+    factories.SourceLinkFactory(dataset=ds)
+
+    response = client.get(
+        reverse(
+            'catalogue:dataset_fullpath',
+            kwargs={'group_slug': ds.grouping.slug, 'set_slug': ds.slug},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["fields"] is None


### PR DESCRIPTION
### Description of change

Adds a preview of the dataset fields to help users make an informed
decision about requesting access.

The field list is derived from the dataset tables, view or custom query
and so should match the columns in a download CSV.

For master datasets containing one or multiple tables the table columns
are prefixed with the table name.

The fields are currently only visible to admin users and the section is
skipped if it failed to retrieve columns from the datasets DB.


### Checklist

Will be completed once we've validated the approach with admin users.

* [X] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
