### PR TITLE
Add id to source table name shown on admin inline form

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -305,6 +305,9 @@ class SourceTable(BaseSource):
     class Meta:
         db_table = 'app_sourcetable'
 
+    def __str__(self):
+        return f'{self.name} ({self.id})'
+
     def get_google_data_studio_link(self):
         return settings.GOOGLE_DATA_STUDIO_CONNECTOR_PATTERN.replace(
             '<table-id>', str(self.id)


### PR DESCRIPTION
### Description of change
Quick fix so admins can see source table ids (and use them when making api calls)

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
