### PR TITLE
Display data fields for all users in a details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2019-12-18
+
+### Added
+
+- Display a list of data fields on the dataset page
+
 
 ## 2019-12-17
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -121,21 +121,22 @@
         </div>
     </div>
 
-    {% if user.is_superuser and fields %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Fields</h2>
-            <p class="govuk-body">*Only visible to superusers.</p>
-            <ul class="govuk-list govuk-list--bullet">
-              {% for field in fields %}
-              <li>{{ field  }}</li>
-              {% endfor %}
-            </ul>
-
-        </div>
-    </div>
+    {% if fields %}
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Data fields
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ul class="govuk-list govuk-list--bullet">
+          {% for field in fields %}
+          <li>{{ field  }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </details>
     {% endif %}
-
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -107,19 +107,21 @@
     </div>
   </div>
 
-  {% if user.is_superuser and fields %}
-  <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Fields</h2>
-          <p class="govuk-body">*Only visible to superusers.</p>
-          <ul class="govuk-list govuk-list--bullet">
-            {% for field in fields %}
-            <li>{{ field  }}</li>
-            {% endfor %}
-          </ul>
-
-      </div>
-  </div>
+  {% if fields %}
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Data fields
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <ul class="govuk-list govuk-list--bullet">
+        {% for field in fields %}
+        <li>{{ field  }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </details>
   {% endif %}
 
   <div class="govuk-grid-row">


### PR DESCRIPTION
### Description of change
<img width="647" alt="image" src="https://user-images.githubusercontent.com/246664/71079096-7cb62b80-2182-11ea-8623-44e79f47e062.png">

After testing data fields queries with existing datasets we can
enable it for all users.

Since the list of fields can be quite long and we're not sure all
users are interested in it we're displaying it as a details component
that can be expanded.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
