### PR TITLE
(fix) Owner of tables created in pgadmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2019-12-23
+
+### Changed
+
+- Tables created in pgAdmin now have the correct owner: the permanent role of the current user. This means they won't prevent the database user from being cleaned up, and means they will be accessible from other tools.
+
+
 ## 2019-12-20
 
 ### Added


### PR DESCRIPTION
pgadmin creates a table and then immediately issues and ALTER TABLE
query setting the owner of the table to the current temporary database
user, rather that the real-world-user's permanent role. Which means the
sequence of events was:

From pgadmin:
  CREATE TABLE
From the existing trigger:
  ALTER TABLE setting the owner of the table to the permanent role
From pgadmin:
  ALTER TABLE resetting the owner back to the temporary user

This commit then ensures that after any ALTER TABLE, and specifically
the ones from pgadmin the role is always set to the correct permanent role.

Potentially there are small race conditions since I don't think these
queries are atomic, but the only issue would be if a user tried to
access a table between these queries they might see an error.
Potentially also if the database went down right between these queries.
However, this would be rare, and wouldn't cause data loss/any sort of
integrity violation.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* ~[ ] Has the README been updated (if needed)?~
