### PR TITLE
Allow for filtering by source tag on dataset admin listing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-07
+
+### Added
+
+- Allow for filtering by source tag on dataset admin listing pages
+
+
 ## 2019-12-27
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -81,10 +81,11 @@ class BaseDatasetAdmin(admin.ModelAdmin):
         'slug',
         'short_description',
         'grouping',
+        'get_source_tags',
         'published',
         'number_of_downloads',
     )
-    list_filter = ('grouping',)
+    list_filter = ('grouping', 'source_tags')
     search_fields = ['name']
     actions = [clone_dataset]
     autocomplete_fields = ['source_tags']
@@ -120,6 +121,11 @@ class BaseDatasetAdmin(admin.ModelAdmin):
                 'data-workspace-admin.css',
             )
         }
+
+    def get_source_tags(self, obj):
+        return ', '.join([x.name for x in obj.source_tags.all()])
+
+    get_source_tags.short_description = 'Source Tags'
 
     @transaction.atomic
     def save_model(self, request, obj, form, change):


### PR DESCRIPTION
### Description of change

Add source column to admin listing and allow for filtering by source tags

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
