### PR TITLE
(feat) Include R package data.table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-08
+
+### Added
+
+- The data.table package in the RStudio docker image
+
+
 ## 2020-01-07
 
 ### Added

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -34,14 +34,15 @@ RUN \
 	apt-get autoclean -y && \
 	rm -rf /tmp/* && \
 	rm -rf /var/lib/apt/lists/* && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends \
+	apt-get -o Acquire::Check-Valid-Until=false update && \
+	apt-get -o Acquire::Check-Valid-Until=false install -y --no-install-recommends \
 		gdebi-core=0.9.5.7+nmu3 \
 		procps=2:3.3.15-2 \
 		r-base=3.6.1-2~bustercran.0 \
 		r-base-dev=3.6.1-2~bustercran.0 \
 		r-cran-base64enc=0.1-3-2 \
 		r-cran-curl=3.3+dfsg-1 \
+		r-cran-data.table=1.12.0+dfsg-1 \
 		r-cran-dbi=1.0.0-2 \
 		r-cran-rpostgresql=0.6-2+dfsg-2 \
 		r-cran-tidyverse=1.2.1-1 \


### PR DESCRIPTION
### Description of change

Adding the R packages data.table to the R Studio image

The mirror isn't regularly updated at the moment, hence the addition of -o Acquire::Check-Valid-Until=false

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
