### PR TITLE
(fix) Duplicate query string params being received

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -385,7 +385,7 @@ async def async_main():
         )
 
     async def handle_admin(downstream_request, method, path, query):
-        upstream_url = URL(admin_root).with_path(path).with_query(query)
+        upstream_url = URL(admin_root).with_path(path)
         return await handle_http(
             downstream_request,
             method,


### PR DESCRIPTION
### Description of change

Fix duplicate query string parameters being received by the admin application. Usually, this doesn't make a difference. However, on endpoint users `getlist`, which is sensitive to duplicate parameters, and its behaviour breaks

### Checklist

* [ ] Have tests been added to cover any changes?

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
