### PR TITLE
Add pagination links to search results

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -188,7 +188,7 @@ def filter_datasets(datasets, query, source, use=None):
     search = SearchVector('name', 'short_description')
     search_query = SearchQuery(query)
 
-    datasets = datasets.annotate(
+    datasets = datasets.filter(published=True).annotate(
         search=search, search_rank=SearchRank(search, search_query)
     )
 
@@ -220,7 +220,9 @@ def find_datasets(request):
 
     # Include reference datasets if required
     if not use or "0" in use:
-        reference_datasets = filter_datasets(ReferenceDataset.objects, query, source)
+        reference_datasets = filter_datasets(
+            ReferenceDataset.objects.live(), query, source
+        )
         datasets = datasets.values(
             'id', 'name', 'slug', 'short_description', 'search_rank'
         ).union(

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -51,13 +51,33 @@
     <nav role="navigation" class="govuk-body">
       Displaying datasets {{ datasets.start_index  }}&ndash;{{ datasets.end_index }} of {{ datasets.paginator.count }}
       <ul class="pagination govuk-list">
-          {% if datasets.has_previous %}
-            <li><a href="{% url_replace page=datasets.previous_page_number %}">Previous</a></li>
-          {% endif %}
+        {% if datasets.has_previous %}
+          <li><a href="{% url_replace page=datasets.previous_page_number %}">Previous</a></li>
+        {% endif %}
 
-          {% if datasets.has_next %}
-            <li><a href="{% url_replace page=datasets.next_page_number %}">Next</a></li>
+        {% if datasets.number > 3 %}
+          <li><a href="{% url_replace page=1 %}">{{ 1 }}</a></li>
+          {% if datasets.number > 4 %}<li>&hellip;</li>{% endif %}
+        {% endif %}
+
+        {% if datasets.paginator.num_pages > 1 %}
+        {% for i in datasets.paginator.page_range %}
+          {% if datasets.number == i %}
+            <li class="active">{{ i }}</li>
+          {% elif i >= datasets.number|add:'-2' and i <= datasets.number|add:'2' %}
+            <li><a href="{% url_replace page=i %}">{{ i }}</a></li>
           {% endif %}
+        {% endfor %}
+        {% endif %}
+
+        {% if datasets.paginator.num_pages > datasets.number|add:'2' %}
+          {% if datasets.paginator.num_pages > datasets.number|add:'3' %}<li>&hellip;</li>{% endif %}
+          <li><a href="{% url_replace page=datasets.paginator.num_pages %}">{{ datasets.paginator.num_pages }}</a></li>
+        {% endif %}
+
+        {% if datasets.has_next %}
+          <li><a href="{% url_replace page=datasets.next_page_number %}">Next</a></li>
+        {% endif %}
       </ul>
     </nav>
 

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -37,6 +37,8 @@
     {{ form.source }}
   </div>
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">{{ datasets.paginator.count }} results</p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {% for dataset in datasets %}
     <div class="search-result">
       <h2 class="govuk-heading-m">

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -32,6 +32,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
+    <h2 class="govuk-heading-l">Filters</h2>
     {{ form.use }}
     {{ form.source }}
   </div>

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -144,6 +144,7 @@ def test_old_reference_dataset_url_redirects_to_new_url(client):
 
 @override_flag('datasets-search', active=True)
 def test_find_datasets_combines_results(client):
+    factories.DataSetFactory.create(published=False, name='Unpublished dataset')
     ds = factories.DataSetFactory.create(published=True, name='A dataset')
     rds = factories.ReferenceDatasetFactory.create(
         published=True, name='A reference dataset'


### PR DESCRIPTION
### Description of change

### Search results count
<img width="999" alt="image" src="https://user-images.githubusercontent.com/246664/72267216-975fb100-3617-11ea-8771-efe6727568ab.png">

### Pagination links
![Screenshot_2020-01-13 Search - Data Workspace(1)](https://user-images.githubusercontent.com/246664/72267042-4780ea00-3617-11ea-83ee-847e9851a6a5.png)
![Screenshot_2020-01-13 Search - Data Workspace(2)](https://user-images.githubusercontent.com/246664/72267071-59628d00-3617-11ea-8fa6-a86c5b85a8ab.png)
![Screenshot_2020-01-13 Search - Data Workspace](https://user-images.githubusercontent.com/246664/72267092-61223180-3617-11ea-8048-3a1385d6bdf1.png)
![Screenshot_2020-01-13 Search - Data Workspace(3)](https://user-images.githubusercontent.com/246664/72267110-6a130300-3617-11ea-9c45-70194f81a8ad.png)
![Screenshot_2020-01-13 Search - Data Workspace(4)](https://user-images.githubusercontent.com/246664/72267118-6da68a00-3617-11ea-88a9-a9065a62401a.png)
![Screenshot_2020-01-13 Search - Data Workspace(5)](https://user-images.githubusercontent.com/246664/72267123-7008e400-3617-11ea-9c12-4f02e34e58c7.png)


### Remove unpublished and deleted datasets from search

Datasets that aren't published and deleted reference datasets shouldn't be displayed in the search results.

### Add Filters heading to the search page


### Add results count on top of the search results page


### Add extended pagination links to search results

Displays first, last and current page number surrounded by 2 next/ previous pages.


### Checklist

* [X] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
