### PR TITLE
(feat) Remove unused security group rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-15
+
+### Changed
+
+- Redis and RDS security groups: they do not need explicit access to Cloudwatch
+
+
 ## 2020-01-14
 
 ### Added

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -388,18 +388,6 @@ resource "aws_security_group" "admin_db" {
   }
 }
 
-resource "aws_security_group_rule" "admin_sdb_egress_https_to_cloudwatch" {
-  description = "egress-https-to-cloudwatch"
-
-  security_group_id = "${aws_security_group.admin_db.id}"
-  source_security_group_id = "${aws_security_group.cloudwatch.id}"
-
-  type        = "egress"
-  from_port   = "443"
-  to_port     = "443"
-  protocol    = "tcp"
-}
-
 resource "aws_security_group_rule" "admin_db_ingress_postgres_from_admin_service" {
   description = "ingress-postgres-from-admin-service"
 
@@ -850,18 +838,6 @@ resource "aws_security_group" "gitlab_redis" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_security_group_rule" "gitlab_redis_egress_https_to_cloudwatch" {
-  description = "egress-https-to-cloudwatch"
-
-  security_group_id = "${aws_security_group.gitlab_redis.id}"
-  source_security_group_id = "${aws_security_group.cloudwatch.id}"
-
-  type        = "egress"
-  from_port   = "443"
-  to_port     = "443"
-  protocol    = "tcp"
 }
 
 resource "aws_security_group_rule" "admin_gitlab_ingress_from_gitlab_service" {


### PR DESCRIPTION
### Description of change

The connections from Redis and RDS to Cloudwatch are apparently not
controllable through our security groups, so no need for these.

### Checklist

~* [ ] Have tests been added to cover any changes? ~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
