### PR TITLE
Fix issue where admins were unable to create new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-16
+
+### Changed
+
+- Fix issue where admins were unable to create new users
+
+
 ## 2020-01-15
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -251,8 +251,12 @@ class AppUserAdmin(UserAdmin):
 
         current_datasets = set(DataSet.objects.filter(datasetuserpermission__user=obj))
         authorized_datasets = set(
-            form.cleaned_data.get('authorized_master_datasets', DataSet.objects.none()).union(
-                form.cleaned_data.get('authorized_data_cut_datasets', DataSet.objects.none())
+            form.cleaned_data.get(
+                'authorized_master_datasets', DataSet.objects.none()
+            ).union(
+                form.cleaned_data.get(
+                    'authorized_data_cut_datasets', DataSet.objects.none()
+                )
             )
         )
 

--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -251,8 +251,8 @@ class AppUserAdmin(UserAdmin):
 
         current_datasets = set(DataSet.objects.filter(datasetuserpermission__user=obj))
         authorized_datasets = set(
-            form.cleaned_data['authorized_master_datasets'].union(
-                form.cleaned_data['authorized_data_cut_datasets']
+            form.cleaned_data.get('authorized_master_datasets', DataSet.objects.none()).union(
+                form.cleaned_data.get('authorized_data_cut_datasets', DataSet.objects.none())
             )
         )
 


### PR DESCRIPTION
### Description of change
Make authorised datasets fields optional to allow for creation of users using the standard form


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
