### PR TITLE
(feat) Sync .ssh directory from tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-22
+
+### Changed
+
+- What directories are synced from tools to include .ssh, to better support the upcoming GitLab integration.
+
+
 ## 2020-01-20
 
 ### Changed

--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -19,4 +19,4 @@ mobius3 \
     --log-level INFO \
     --credentials-source ecs-container-endpoint \
     --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)bigdata/.*)' \
-    --exclude-local '^(?!.*/\.git($|(/.+)))((.*/\..*)|(.*(/|^)bigdata/.*))'
+    --exclude-local '^(?!.*/\.ssh($|(/.+)))(?!.*/\.git($|(/.+)))((.*/\..*)|(.*(/|^)bigdata/.*))'


### PR DESCRIPTION
### Description of change

For the upcoming connection via SSH from tools to gitlab, this will be
via a public/private key pair. It would be expected that you wouldn't
have to regenerate this every time a tool starts.

Note that for now, mobius3 does not store the mode of files, so there is
likely work needed there: otherwise SSH will complain about the private
key being too open.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
