### PR TITLE
(feat) Upload pack files on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-27
+
+### Changed
+
+- Version of mobius3, and its configuration to fix syncing issues with .git directories
+
+
 ## 2020-01-22
 
 ### Changed

--- a/s3sync/Dockerfile
+++ b/s3sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/uktrade/mobius3:v0.0.27
+FROM quay.io/uktrade/mobius3:v0.0.28
 
 COPY start.sh /
 

--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -19,4 +19,5 @@ mobius3 \
     --log-level INFO \
     --credentials-source ecs-container-endpoint \
     --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)bigdata/.*)' \
-    --exclude-local '^(?!.*/\.ssh($|(/.+)))(?!.*/\.git($|(/.+)))((.*/\..*)|(.*(/|^)bigdata/.*))'
+    --exclude-local '^(?!.*/\.ssh($|(/.+)))(?!.*/\.git($|(/.+)))((.*/\..*)|(.*(/|^)bigdata/.*))' \
+    --upload-on-create '^.*/\.git/objects/pack/.+\.((pack)|(m?idx))$'


### PR DESCRIPTION
It looks like no IN_CLOSE_WRITE event is received for .pack or .idx
files. I suspect they are created via

- a separate temporary file, with name like tmp_pack_hBV4Alz, being
  created, modified and, closed;
- a _hard_ link is created to this file, with the final .pack name;
- the original tmp_pack_hBV4Alz name is deleted.

So after a repository is cloned, because there is no IN_CLOSE_WRITE
event, the upload of these files is never queued, and after a few
minutes, the sync notices these files are not in the bucket, and thinks
that these files must have been removed, and then decides to delete them
locally.

This change is somewhat hacky/brittle. If git changes the location of
these files for example, this fix would break.

### Description of change


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
