### PR TITLE
New header and about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-01-28
+
+### Added
+
+- New header layout for the search UI (only visible with users with a feature flag set)
+- Navigation links in the footer (behind a feature flag)
+- New about page
+
+
 ## 2020-01-27
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -44,6 +44,10 @@ def healthcheck_view(_):
     return HttpResponse('OK')
 
 
+def about_page_view(request):
+    return render(request, 'about.html', {}, status=200)
+
+
 class SupportView(FormView):
     form_class = SupportForm
     template_name = 'core/support.html'

--- a/dataworkspace/dataworkspace/static/search.js
+++ b/dataworkspace/dataworkspace/static/search.js
@@ -89,7 +89,7 @@
       pageUpdated = this.updateResults();
       pageUpdated.done(
         function(){
-          var newPath = window.location.origin + window.location.pathname + "?" + $.param(this.state);
+          var newPath = window.location.origin + this.$form.attr('action') + "?" + $.param(this.state);
           history.pushState(this.state, '', newPath);
         }.bind(this)
       );

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load waffle_tags %}
 <!DOCTYPE html>
 <html lang="en-GB" class="govuk-template">
 
@@ -40,7 +41,41 @@
   </script>
 
   <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
+{% flag "datasets-search" %}
+  <header class="govuk-header" role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+      <div class="govuk-header__logotype">
+        <a href="{{ root_href }}" class="govuk-header__link govuk-header__link--service-name">
+          Data Workspace
+        </a>
+      </div>
+     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav>
+        <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item{% if request.get_full_path == '/' %} govuk-header__navigation-item--active{% endif %}">
+            <a class="govuk-header__link" href="{{ root_href }}">
+              Home
+            </a>
+          </li>
+          {% if perms.applications.start_all_applications or perms.applications.access_appstream %}
+          {% url 'applications:tools' as tools_url %}
+          <li class="govuk-header__navigation-item{% if request.get_full_path == tools_url %} govuk-header__navigation-item--active{% endif %}">
+            <a class="govuk-header__link" href="{{ tools_url }}">
+              Tools
+            </a>
+          </li>
+          {% endif %}
+          {% url 'about' as about_url %}
+          <li class="govuk-header__navigation-item{% if request.get_full_path == about_url %} govuk-header__navigation-item--active{% endif %}">
+            <a class="govuk-header__link" href="{{ about_url }}">
+              About
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+{% else %}
   <header class="govuk-header" role="banner" data-module="header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">
@@ -65,6 +100,7 @@
       </div>
     </div>
   </header>
+{% endflag %}
 
   <div class="govuk-width-container">
     <div class="govuk-phase-banner">
@@ -95,7 +131,27 @@
     <div class="govuk-width-container">
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+            <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
+            {% flag "datasets-search" %}
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="{{ root_href }}">
+                  Home
+                </a>
+              </li>
+              {% if perms.applications.start_all_applications or perms.applications.access_appstream %}
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="{{ tools_url  }}">
+                  Tools
+                </a>
+              </li>
+              {% endif %}
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="{{ about_url  }}">
+                  About
+                </a>
+              </li>
+            {% endflag %}
               <li class="govuk-footer__inline-list-item">
                 <a target="_blank" class="govuk-footer__link" href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/data-workspace-privacy-policy">
                   Privacy Policy

--- a/dataworkspace/dataworkspace/templates/about.html
+++ b/dataworkspace/dataworkspace/templates/about.html
@@ -1,0 +1,86 @@
+{% extends '_base.html' %}
+{% load static %}
+
+{% block page_title %}About - {{ block.super }}{% endblock %}
+
+{% block inner_content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">About</h1>
+    <p class="govuk-body-l">
+      Data Workspace is where DIT staff and those at partner organisations can access, analyse and share data that’s relevant to DIT. It will help you develop insight-driven strategy and policy, and to monitor, evaluate and report on DIT’s work and objectives.
+    </p>
+  </div>
+</div>
+
+<div class="govuk-accordion" data-module="govuk-accordion" id="about-page-accordion">
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="about-page-accordion-heading-1">
+          Datasets
+        </span>
+      </h2>
+    </div>
+    <div id="about-page-accordion-content-1" class="govuk-accordion__section-content" aria-labelledby="about-page-accordion-heading-1">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class='govuk-body'>
+            You can access up-to-date data through a searchable catalogue of <a href="{% url 'datasets:find_datasets' %}">datasets</a>.
+          </p>
+          <p class='govuk-body'>
+            Some datasets can be downloaded by everyone, but for others that contain personal or other sensitive information, you’ll need to request access through their Data Workspace page. We aim to provide access within 5 working days.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="about-page-accordion-heading-2">
+          Data tools
+        </span>
+      </h2>
+    </div>
+    <div id="about-page-accordion-content-2" class="govuk-accordion__section-content" aria-labelledby="about-page-accordion-heading-2">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class='govuk-body'>
+            Analysis tools available on Data Workspace include JupyterLab, RStudio and pgAdmin. These are powerful and versatile tools aimed at analysts and data scientists. They require some familiarity with Python, R or SQL coding languages. You can also access SPPS/STATA which are used by statisticians.
+          </p>
+          <p class='govuk-body'>
+            You can request access to these tools using our <a href="{% url 'support' %}">feedback form</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="about-page-accordion-heading-3">
+          Improving Data Workspace
+        </span>
+      </h2>
+    </div>
+    <div id="about-page-accordion-content-3" class="govuk-accordion__section-content" aria-labelledby="about-page-accordion-heading-3">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class='govuk-body'>Data Workspace is still being developed and we are making improvements including:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>adding new datasets</li>
+            <li>introducing an enhanced user interface to make Data Workspace easier to use</li>
+            <li>sharing data analysis created by other people using our tools and data</li>
+          </ul>
+          <p class="govuk-body">
+            Your feedback will help us to improve our service. You can use the <a href="{% url 'support' %}">feedback form</a> to send us your comments.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -13,7 +13,7 @@
 
 {% block inner_content %}
 
-<form id="live-search-form" action="/datasets/" method="get">
+<form id="live-search-form" action="{% url 'datasets:find_datasets' %}" method="get">
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -6,6 +6,7 @@ from django.urls import path, include
 from dataworkspace.apps.accounts.utils import login_required
 from dataworkspace.apps.catalogue.views import root_view
 from dataworkspace.apps.core.views import (
+    about_page_view,
     public_error_403_html_view,
     public_error_404_html_view,
     public_error_500_html_view,
@@ -29,6 +30,7 @@ admin.site.login = login_required(admin.site.login)
 
 urlpatterns = [
     path('', login_required(root_view), name='root'),
+    path('about/', login_required(about_page_view), name='about'),
     path('error_403', public_error_403_html_view),
     path('error_404', public_error_404_html_view),
     path('error_500', public_error_500_html_view),


### PR DESCRIPTION
### Description of change
![Screen Shot 2020-01-28 at 14 43 31-fullpage](https://user-images.githubusercontent.com/246664/73273908-98c6d700-41dc-11ea-9428-1e7a39c701dd.png)

### Add new header and footer with navigation links

New header layout with Home / Tools / About links, hidden behind the datasets-search feature flag.

Tools link in header and footer is only visible to users that have tools access while the page itself is being redesigned.

### Add about page

Page is public, but is only linked from the header when the search feature flag is active.

### Make live search use the form action path as base URL

If a search page has an alternative URL (e.g. as the home page), we still want any search requests go to the canonical /datatsets/ URL, so live search JS needs to use the form action URL instead of the current page URL as a base path.


### Checklist

* [ ] Have tests been added to cover any changes?
* [X] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
