### PR TITLE
Update download queue timeout to 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - datasets-search feature flag
 
 
+## 2020-01-30
+
+### Changed
+
+- Up queue timeout on streaming downloads to try to mitigate "queue full" errors
+
+
 ## 2020-01-28
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -390,6 +390,7 @@ def streaming_query_response(user_email, database, query, filename):
     logger.info('streaming_query_response start: %s %s %s', user_email, database, query)
     cursor_itersize = 1000
     queue_size = 3
+    queue_timeout = 60
     bytes_queue = gevent.queue.Queue(maxsize=queue_size)
 
     def put_db_rows_to_queue():
@@ -427,12 +428,12 @@ def streaming_query_response(user_email, database, query, filename):
                         csv_writer.writerow(
                             [column_desc[0] for column_desc in cur.description]
                         ),
-                        timeout=10,
+                        timeout=queue_timeout,
                     )
                 bytes_fetched = ''.join(
                     csv_writer.writerow(row) for row in rows
                 ).encode('utf-8')
-                bytes_queue.put(bytes_fetched, timeout=15)
+                bytes_queue.put(bytes_fetched, timeout=queue_timeout)
                 i += len(rows)
                 if not rows:
                     break


### PR DESCRIPTION
### Description of change

Up the gevent queue put timeout to 1 minute to try to curb queue Full errors causing failed downloads.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
