### PR TITLE
(fix) Pin Redis to previous working version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-ckeditor==5.8.0
 django-db-geventpool==3.1.0
 django-redis==4.10.0
 zenpy==2.0.17
+redis==3.3.11
 requests==2.22.0
 django-admin-sortable2==0.7.5
 sentry-sdk==0.13.5


### PR DESCRIPTION
### Description of change

To avoid the error

        TypeError("unhashable type: 'Redis'")

### Checklist

~* [ ] Have tests been added to cover any changes?~
~* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?~
~* [ ] Has the README been updated (if needed)?~
