### PR TITLE
Update Django to address CVE-2020-7471

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery==4.3.0
 celery-redbeat==0.13.0
 gunicorn[gevent]==19.9.0
 psycogreen==1.0.1
-django==2.2.8
+django==2.2.10
 django-better-admin-arrayfield==1.0.5
 django-ckeditor==5.8.0
 django-db-geventpool==3.1.0


### PR DESCRIPTION
I don't think we're using StringAgg directly, but it's possible that
some of the dependencies are.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
