### PR TITLE
(feat) Give more memory and CPU to visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-03
+
+### Changed
+
+- The amount of memory and CPU available to visualisations
+
+
 ## 2020-01-31
 
 ### Changed

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -123,8 +123,8 @@ locals {
 
   user_provided_container_name   = "user-provided"
   user_provided_container_port   = "8888"
-  user_provided_container_memory = 512
-  user_provided_container_cpu    = 256
+  user_provided_container_memory = 8192
+  user_provided_container_cpu    = 1024
 
   logstash_container_name       = "jupyterhub-logstash"
   logstash_alb_port             = "443"


### PR DESCRIPTION
### Description of change

We could have some sort of per-visualisation configuration, but for now,
probably not worth it.

Bumping to the same amount of memory/CPU as the tools, which is 1 CPU,
and the maximum amount of memory for that CPU, 8GB.

I suspect for a lot of visualisations, such as one that has just been
setup for testing, their data will just be loaded into memory. Not
bumping memory higher for now to have a bit of visibilty on the sorts of
amounts that are needed.


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
