### PR TITLE
(fix) Permissions on tables created via CREATE TABLE AS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-02-05
 
+### Changed
+
+- Trigger when a user creates tables in their own schema using CREATE TABLE AS, so they are accessible in other tools
+
 ### Added
 
 - Add admin pages for SourceView and SourceTable

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -160,7 +160,7 @@ def new_private_database_credentials(db_role_and_schema_suffix, source_tables, d
                 BEGIN
                   CREATE EVENT TRIGGER set_table_owner
                   ON ddl_command_end
-                  WHEN tag IN ('ALTER TABLE', 'CREATE TABLE')
+                  WHEN tag IN ('ALTER TABLE', 'CREATE TABLE', 'CREATE TABLE AS')
                   EXECUTE PROCEDURE set_table_owner();
                 EXCEPTION WHEN OTHERS THEN
                   NULL;


### PR DESCRIPTION
### Description of change

Fixed trigger when a user creates tables in their own schema using CREATE TABLE AS, so they are accessible in other tools

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~