### PR TITLE
(build) Retry failed apt-get downloads. S3 seems to fail quite often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-06
+
+### Added
+
+- Retries when fetching dependencies when building the RStudio image. The S3 mirror is surprisingly flaky.
+
+
 ## 2020-02-05
 
 ### Changed

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -35,8 +35,8 @@ RUN \
 	apt-get autoclean -y && \
 	rm -rf /tmp/* && \
 	rm -rf /var/lib/apt/lists/* && \
-	apt-get -o Acquire::Check-Valid-Until=false update && \
-	apt-get -o Acquire::Check-Valid-Until=false install -y --no-install-recommends \
+	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
+	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
 		gdebi-core=0.9.5.7+nmu3 \
 		git=1:2.20.1-2 \
 		procps=2:3.3.15-2 \


### PR DESCRIPTION
### Description of change

Added retries when fetching dependencies when building the RStudio image. The S3 mirror is surprisingly flaky.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
