### PR TITLE
Exclude local dev domain from CSP HTTP->HTTPS upgrade

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -63,7 +63,9 @@ async def async_main():
     except ValueError:
         root_port = None
 
-    csp_common = "object-src 'none';upgrade-insecure-requests;"
+    csp_common = "object-src 'none';"
+    if root_domain not in ['dataworkspace.test:8000']:
+        csp_common += "upgrade-insecure-requests;"
 
     # "Admin" pages are shown on the root domain, but also when spawning applications on
     # <my-application>.<root_domain>, so we explicitly name the domain instead of using 'self'


### PR DESCRIPTION
Since we don't have a DEBUG flag for the app at the moment the least
disruptive way to stop CSP protocol upgrades in local dev is to check
for the development root_domain.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
