### PR TITLE
Double queue timeout to 2 minutes for streaming downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Local development domain set to `dataworkspace.test`
-
+- Increase streaming download queue timeout to 2 minutes
 
 ## 2020-02-06
 

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -470,7 +470,7 @@ def streaming_query_response(user_email, database, query, filename):
     put_db_rows_to_queue_job = gevent.spawn(put_db_rows_to_queue)
     put_db_rows_to_queue_job.link_exception(handle_exception)
 
-    response = StreamingHttpResponse(yield_bytes_from_queue(),  content_type='text/csv')
+    response = StreamingHttpResponse(yield_bytes_from_queue(), content_type='text/csv')
     response['Content-Disposition'] = f'attachment; filename="{filename}"'
     return response
 

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -390,7 +390,7 @@ def streaming_query_response(user_email, database, query, filename):
     logger.info('streaming_query_response start: %s %s %s', user_email, database, query)
     cursor_itersize = 1000
     queue_size = 3
-    queue_timeout = 60
+    queue_timeout = 60 * 2
     bytes_queue = gevent.queue.Queue(maxsize=queue_size)
 
     def put_db_rows_to_queue():
@@ -470,7 +470,7 @@ def streaming_query_response(user_email, database, query, filename):
     put_db_rows_to_queue_job = gevent.spawn(put_db_rows_to_queue)
     put_db_rows_to_queue_job.link_exception(handle_exception)
 
-    response = StreamingHttpResponse(yield_bytes_from_queue(), content_type='text/csv')
+    response = StreamingHttpResponse(yield_bytes_from_queue(),  content_type='text/csv')
     response['Content-Disposition'] = f'attachment; filename="{filename}"'
     return response
 


### PR DESCRIPTION
### Description of change
Change streaming download queue timeout to 2 minutes

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
