### PR TITLE
Fix/830 set expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-11
+
+### Changed
+
+- Set expectations for users requesting access to datasets.
+
 ## 2020-02-10
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -267,7 +267,6 @@ def request_access_view(request, dataset_uuid):
 def request_access_success_view(request, dataset_uuid):
     # yes this could cause 400 errors but Todo - replace with session / messages
     ticket = request.GET['ticket']
-    dataset_uuid = request.GET['set']
 
     dataset = find_dataset(dataset_uuid)
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -254,9 +254,7 @@ def request_access_view(request, dataset_uuid):
             )
 
             url = reverse('datasets:request_access_success', args=[dataset_uuid])
-            return HttpResponseRedirect(
-                f'{url}?ticket={ticket_reference}&set={dataset_uuid}'
-            )
+            return HttpResponseRedirect(f'{url}?ticket={ticket_reference}')
 
     return render(
         request,

--- a/dataworkspace/dataworkspace/templates/request_access_success.html
+++ b/dataworkspace/dataworkspace/templates/request_access_success.html
@@ -20,8 +20,12 @@
             <h1 class="govuk-heading-l">Request access</h1>
 
             <p class="govuk-body">
-                Your request has been received. Your reference is: <strong>{{ ticket }}</strong>
-                <br/>
+                Your request has been received. It will normally be completed within 5 working days.
+            </p>
+            <p class="govuk-body">
+                Your reference is: <strong>{{ ticket }}</strong>
+            </p>
+            <p class="govuk-body">
                 You will receive a confirmation email to the address you provided.
             </p>
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -214,3 +214,17 @@ def test_find_datasets_filters_by_source(client):
             'short_description': rds.short_description,
         },
     ]
+
+
+def test_request_access_success_content(client):
+    ds = factories.DataSetFactory.create(published=True, type=1, name='A dataset')
+
+    response = client.get(
+        reverse('datasets:request_access_success', kwargs={"dataset_uuid": ds.id}),
+        {"ticket": "test-ticket-id"},
+    )
+
+    assert (
+        'Your request has been received. It will normally be completed within 5 working days.'
+        in response.content.decode(response.charset)
+    )


### PR DESCRIPTION
### Description of change
Adds a sentence to the confirmation page when submitting a support request to access a dataset.

Note: this message hasn't been added to the general support/"feedback submitted" page - only to the "request access" page.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
