### PR TITLE
(fix) Allow visualisations, without s3sync, to have environment variables for database credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Set expectations for users requesting access to datasets.
+- Fixed passing environment variables to visualisations with database credentials.
 
 ## 2020-02-10
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -513,16 +513,19 @@ def _fargate_task_run(
                     'name': container_name,
                 }
             ]
-            + [
-                {
-                    'name': 's3sync',
-                    'environment': [
-                        {'name': name, 'value': value} for name, value in env.items()
-                    ],
-                }
-            ]
-            if s3_sync
-            else [],
+            + (
+                [
+                    {
+                        'name': 's3sync',
+                        'environment': [
+                            {'name': name, 'value': value}
+                            for name, value in env.items()
+                        ],
+                    }
+                ]
+                if s3_sync
+                else []
+            ),
         },
         launchType='FARGATE',
         networkConfiguration={


### PR DESCRIPTION
### Description of change

Allow visualisations, without s3sync, to have environment variables for database credentials

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
