### PR TITLE
(fix) Fix WebSockets in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-14
+
+### Changed
+
+- The CSP header to explicitly allow Websocket requests by named domain: required for Safari since 'self' does not seem to work
+
+
 ## 2020-02-12
 
 ## Added


### PR DESCRIPTION
### Description of change

Changed the CSP header to explicitly allow Websocket requests by named domain: required for Safari since 'self' does not seem to work

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~