### PR TITLE
Add spinner to 'tool loading' page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-12
+
+## Added
+
+- A loading spinner on the 'tool spawning' page.
+
+
 ## 2020-02-11
 
 ### Changed

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -156,9 +156,9 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
 .loading-spinner {
   border: 12px solid #ffffff;
   border-radius: 50%;
-  border-top-color: #1d70b8;
-  width: 80px;
-  height: 80px;
+  border-top-color: #00703c;
+  width: 90px;
+  height: 90px;
   -webkit-animation: spin 2s linear infinite;
   animation: spin 2s linear infinite;
   margin: 0 auto;

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -147,3 +147,27 @@
   display: inline;
   padding-left: 4px;
 }
+
+/* Loading spinner CSS
+
+Lifted from an issue on the GOV.UK Design System repo (https://github.com/alphagov/govuk-design-system-backlog/issues/28).
+
+Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issuecomment-489061680*/
+.loading-spinner {
+  border: 12px solid #ffffff;
+  border-radius: 50%;
+  border-top-color: #1d70b8;
+  width: 80px;
+  height: 80px;
+  -webkit-animation: spin 2s linear infinite;
+  animation: spin 2s linear infinite;
+  margin: 0 auto;
+}
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -67,6 +67,7 @@
     <h1 class="govuk-panel__title govuk-!-font-size-47 govuk-!-padding-bottom-3">
       {{ application_nice_name }} is loading...
     </h1>
+    <div class="govuk-!-margin-bottom-3 loading-spinner"></div>
     <h2 class="govuk-panel__body govuk-!-font-size-36 govuk-!-margin-bottom-1">
       This will take 2 minutes approximately<br />
     </h2>

--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -67,7 +67,7 @@
     <h1 class="govuk-panel__title govuk-!-font-size-47 govuk-!-padding-bottom-3">
       {{ application_nice_name }} is loading...
     </h1>
-    <div class="govuk-!-margin-bottom-3 loading-spinner"></div>
+    <div class="govuk-!-margin-bottom-7 loading-spinner"></div>
     <h2 class="govuk-panel__body govuk-!-font-size-36 govuk-!-margin-bottom-1">
       This will take 2 minutes approximately<br />
     </h2>


### PR DESCRIPTION
### Description of change

We find that users have low levels of confidence that their tool is
loading properly when everything on the page is static. By adding a
dynamic spinner we hope to increase confidence that 'work is being
done'.

This solution is lifted from conversation on the GOV.UK Design System
repo: https://github.com/alphagov/govuk-design-system-backlog/issues/28

Ticket: https://trello.com/c/ODpRBsdj/828

## Show the thing
It looks a bit jarring in the gif, but it moves smoothly in reality...

![spinner-green](https://user-images.githubusercontent.com/2920760/74515168-f0b44c00-4f05-11ea-8a5e-ca23064ec092.gif)



### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
