### PR TITLE
(feat) Allow the port of an application to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Link in README when developing locally
+- For each tool at mytool-[sso-id].domain.com, allow mytool-[sso-id]--9000.domain.com to route through to the application.
 
 
 ## 2020-02-14

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -532,7 +532,10 @@ async def async_main():
 
         # fmt: off
         data = \
-            b'' if 'content-length' not in upstream_headers and downstream_request.headers.get('transfer-encoding', '').lower() != 'chunked' else \
+            b'' if (
+                'content-length' not in upstream_headers
+                and downstream_request.headers.get('transfer-encoding', '').lower() != 'chunked'
+            ) else \
             await downstream_request.read() if downstream_request.content.at_eof() else \
             downstream_request.content
         # fmt: on

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -15,12 +15,12 @@ import aiohttp
 from aiohttp import web
 
 import aioredis
+from hawkserver import authenticate_hawk_header
 from multidict import CIMultiDict
 from yarl import URL
 
 from dataworkspace.utils import normalise_environment
 from proxy_session import SESSION_KEY, redis_session_middleware
-from hawkserver import authenticate_hawk_header
 
 
 class UserException(Exception):

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -65,7 +65,7 @@ async def async_main():
 
     csp_common = "object-src 'none';"
     if root_domain not in ['dataworkspace.test:8000']:
-        csp_common += "upgrade-insecure-requests;"
+        csp_common += 'upgrade-insecure-requests;'
 
     # "Admin" pages are shown on the root domain, but also when spawning applications on
     # <my-application>.<root_domain>, so we explicitly name the domain instead of using 'self'

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -116,8 +116,10 @@ locals {
   admin_alb_port          = "443"
   admin_api_path          = "/api/v1/databases"
 
-  notebook_container_name   = "jupyterhub-notebook"
-  notebook_container_port   = "8888"
+  notebook_container_name     = "jupyterhub-notebook"
+  notebook_container_port     = "8888"
+  notebook_container_port_dev = "9000"
+
   notebook_container_memory = 8192
   notebook_container_cpu    = 1024
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -362,6 +362,18 @@ resource "aws_security_group_rule" "admin_service_egress_http_to_notebooks" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "admin_service_egress_http_dev_to_notebooks" {
+  description = "egress-http-dev-to-notebooks"
+
+  security_group_id = "${aws_security_group.admin_service.id}"
+  source_security_group_id = "${aws_security_group.notebooks.id}"
+
+  type        = "egress"
+  from_port   = "${local.notebook_container_port_dev}"
+  to_port     = "${local.notebook_container_port_dev}"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "admin_service_egress_postgres_to_admin_db" {
   description = "egress-postgres-to-admin-db"
 
@@ -423,6 +435,18 @@ resource "aws_security_group_rule" "notebooks_ingress_https_from_admin" {
   type      = "ingress"
   from_port = "${local.notebook_container_port}"
   to_port   = "${local.notebook_container_port}"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "notebooks_ingress_http_dev_from_admin" {
+  description = "ingress-http-dev-from-jupytehub"
+
+  security_group_id = "${aws_security_group.notebooks.id}"
+  source_security_group_id = "${aws_security_group.admin_service.id}"
+
+  type      = "ingress"
+  from_port = "${local.notebook_container_port_dev}"
+  to_port   = "${local.notebook_container_port_dev}"
   protocol  = "tcp"
 }
 


### PR DESCRIPTION
### Description of change

Allow the port of an application to be overridden, and open 9000. This means that, for example, in JupyterLab, a user can start their own webserver on port 9000 and develop on it, opening up

jupyterlab-[sso-id]--9000.domain.com

to view their in-progress application.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
