### PR TITLE
Remove source created date from data listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The CSP header to explicitly allow Websocket requests by named domain: required for Safari since 'self' does not seem to work
+- Remove source created date from data cut and master dataset detail pages.
 
 
 ## 2020-02-12
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Set expectations for users requesting access to datasets.
 - Fixed passing environment variables to visualisations with database credentials.
+
 
 ## 2020-02-10
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -69,7 +69,6 @@
                 <tr class="govuk-table__row">
                     <th class="govuk-table__header">Link to the data</th>
                     <th class="govuk-table__header">Format</th>
-                    <th class="govuk-table__header">File added</th>
                     <th class="govuk-table__header">Frequency</th>
                 </tr>
                 </thead>
@@ -88,9 +87,6 @@
                         </td>
                         <td class="govuk-table__cell">
                           {% if link.format %}{{ link.format }}{% else %}CSV{% endif %}
-                        </td>
-                        <td class="govuk-table__cell">
-                            {{ link.created_date| date:"d/m/Y"   }}
                         </td>
                         <td class="govuk-table__cell">
                           {% if link.get_frequency_display %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -68,7 +68,6 @@
         <tr class="govuk-table__row">
           <th class="govuk-table__header">Name</th>
           <th class="govuk-table__header">Identifier</th>
-          <th class="govuk-table__header">Dataset added</th>
           <th class="govuk-table__header">Update frequency</th>
           {% if user.is_superuser and data_links %}
             <th class="govuk-table__header">Tools*</th>
@@ -81,7 +80,6 @@
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">{{ table.name }}</td>
             <td class="govuk-table__cell">{{ table.schema }}.{{ table.table }}</td>
-            <td class="govuk-table__cell">{{ table.created_date| date:"d/m/Y" }}</td>
             <td class="govuk-table__cell">{{ table.get_frequency_display }}</td>
             {% if user.is_superuser %}
               <td class="govuk-table__cell">


### PR DESCRIPTION
### Description of change

Do not show created date on data sources as users assume it is the date the data was updated when it is actually the date the source was created in django.

#### Before
![Screenshot from 2020-02-14 10-18-31](https://user-images.githubusercontent.com/594496/74522597-68d53e80-4f13-11ea-94a4-399f8b88b030.png)


#### After
![Screenshot from 2020-02-14 10-16-30](https://user-images.githubusercontent.com/594496/74522548-4ba07000-4f13-11ea-96da-4b457e962e9f.png)

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
