### PR TITLE
Add user access editing to dataset admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-02-14
 
+### Added
+
+- Dataset user permissions can be viewed / modified from the dataset admin page
+
 ### Changed
 
 - The CSP header to explicitly allow Websocket requests by named domain: required for Safari since 'self' does not seem to work

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -14,7 +14,7 @@ class UserProfileFactory(factory.django.DjangoModelFactory):
 
 
 class UserFactory(factory.django.DjangoModelFactory):
-    username = 'test.user@example.com'
+    username = factory.LazyAttribute(lambda _: f'test.user+{uuid.uuid4()}@example.com')
     password = '12345'
 
     class Meta:

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2247,6 +2247,44 @@ class TestSourceLinkAdmin(BaseAdminTestCase):
 
 
 class TestDatasetAdmin(BaseAdminTestCase):
+    def test_edit_dataset_authorized_users(self):
+        dataset = factories.DataSetFactory.create()
+        user1 = factories.UserFactory.create()
+        user2 = factories.UserFactory.create()
+        factories.DataSetUserPermissionFactory.create(dataset=dataset, user=user1)
+
+        self.assertEqual(dataset.user_has_access(user1), True)
+        self.assertEqual(dataset.user_has_access(user2), False)
+
+        response = self._authenticated_post(
+            reverse('admin:datasets_datacutdataset_change', args=(dataset.id,)),
+            {
+                'published': dataset.published,
+                'name': dataset.name,
+                'slug': dataset.slug,
+                'short_description': 'test short description',
+                'description': 'test description',
+                'type': 2,
+                'sourcelink_set-TOTAL_FORMS': '0',
+                'sourcelink_set-INITIAL_FORMS': '0',
+                'sourcelink_set-MIN_NUM_FORMS': '0',
+                'sourcelink_set-MAX_NUM_FORMS': '1000',
+                'sourceview_set-TOTAL_FORMS': '0',
+                'sourceview_set-INITIAL_FORMS': '0',
+                'sourceview_set-MIN_NUM_FORMS': '0',
+                'sourceview_set-MAX_NUM_FORMS': '1000',
+                'customdatasetquery_set-TOTAL_FORMS': '0',
+                'customdatasetquery_set-INITIAL_FORMS': '0',
+                'customdatasetquery_set-MIN_NUM_FORMS': '0',
+                'customdatasetquery_set-MAX_NUM_FORMS': '1000',
+                'authorized_users': user2.id,
+                '_continue': 'Save and continue editing',
+            },
+        )
+        self.assertContains(response, 'was changed successfully')
+        self.assertEqual(dataset.user_has_access(user1), False)
+        self.assertEqual(dataset.user_has_access(user2), True)
+
     def test_delete_external_source_link(self):
         dataset = factories.DataSetFactory.create()
         source_link = factories.SourceLinkFactory(


### PR DESCRIPTION
### Description of change

This allows viewing / modifying users that have access to a dataset
from the dataset admin page, similar to how a list of dataset
permissions for each user can be edited on the user page.

If the permissions are modified, an admin log event is written. The
event is associated with the user object, since that's how we record
permission changes currently.

This only applies to master datasets and data cuts, since reference
data currently doesn't require access requests.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
