### PR TITLE
(docs) Minor fix to port in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-17
+
+### Changed
+
+- Link in README when developing locally
+
+
 ## 2020-02-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ With the default environment, you will need the below in your `/etc/hosts` file.
 127.0.0.1       dataworkspace.test
 ```
 
-And the application will be visible at http://dataworkspace.test. This is to be able to properly test cookies that are shared with subdomains.
+And the application will be visible at http://dataworkspace.test:8000. This is to be able to properly test cookies that are shared with subdomains.
 
 
 ## Creating migrations / running management commands


### PR DESCRIPTION
### Description of change

Fixed link/port in readme when developing locally to match the default dev configuration

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [x] Has the README been updated (if needed)?
