### PR TITLE
(feat) Separate JupyterLab config directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## 2020-02-20
+
+### Changed
+
+- Separated the JupyterLab Python and R config directories to avoid strange behavior/conflicts when we come to sync them to S3
+
+
 ## 2020-02-17
 
 ### Changed

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -528,8 +528,8 @@
       "value": "${fargate_spawner__task_subnet}"
     },
     {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__DUMMY",
-      "value": "value"
+      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_CONFIG_DIR",
+      "value": "/home/jovyan/.jupyterlab_python"
     },
     {
       "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__PORT",
@@ -648,8 +648,8 @@
       "value": "${fargate_spawner__task_subnet}"
     },
     {
-      "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__ENV__DUMMY",
-      "value": "value"
+      "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__ENV__JUPYTER_CONFIG_DIR",
+      "value": "/home/jovyan/.jupyterlab_r"
     },
     {
       "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__PORT",


### PR DESCRIPTION
### Description of change

Separate JupyterLab config directories

Suspect will be syncing them via the home folder, so this should avoid
strange conflicts due to different JupyterLabs running via the same
directory.


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
