### PR TITLE
Prevent flaky test migrations

### DIFF
--- a/.envs/test.env
+++ b/.envs/test.env
@@ -19,6 +19,14 @@ DATA_DB__my_database__USER=postgres
 DATA_DB__my_database__PASSWORD=postgres
 DATA_DB__my_database__HOST=data-workspace-postgres
 DATA_DB__my_database__PORT=5432
+
+# Set up `my_database` as a mirror of prod so that django/test doesn't consider it an alias and have a 50% chance of using it instead of the default
+# connection. This is a workaround, not a solution, to flaky test migrations. Ideally we'd change the name of the `my_database` DB from `postgres`
+# to `my_database`, but there are other areas of the code that use these settings directly, which doesn't work in the test suite as that prepends
+# `test_` to the DB name - meaning it won't exist. `postgres` DB name exists by default, so it mostly feels like luck that this ever worked in the
+# first place.
+DATA_DB__my_database__TEST__MIRROR=default
+
 DATA_DB__test_external_db__NAME=testdb1
 DATA_DB__test_external_db__USER=postgres
 DATA_DB__test_external_db__PASSWORD=postgres


### PR DESCRIPTION
Our tests seem to fail very frequently due to failed migrations. This
ends up being due to the fact that Django's test suite looks at our
default database config and `my_database` config, considers them
equivalent, and sometimes picks the `my_database` config to run
migrations against. It turns out that they aren't interchangeable in
that way.

By setting `my_database` as a mirror of the `default` database, we can
ensure all migrations are routed to the `default` database. **This is a
workaround, not a solution.** The `mirror` setting is primarily used for
primary/replica instances. In this instance, I believe `my_database` is
- for testing purposes - intended to be a semantically different
  database, so linking them as the same database is not logically
correct. It just so happens that the config we provide for these two
databases, however, is identical: postgres:postgres@data-workspace-postgres/postgres.

It would be better to rename `my_database` to use something other than a
`postgres` database, but there are other parts of the code that start to
fail when attempting to rename the setting `DATA_DB__my_database__NAME`
as they don't take into account running under test conditions.

Associated docs: https://docs.djangoproject.com/en/3.0/topics/testing/advanced/#topics-testing-primaryreplica

Ticket: https://trello.com/c/nN2wRfPK/863

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
