### PR TITLE
(feat) Separate JupyterLab R and Python directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Separated the JupyterLab Python and R config directories to avoid strange behavior/conflicts when we come to sync them to S3
+- Separated the JupyterLab Python and R data and runtime directories to avoid strange behavior/conflicts when we come to sync them to S3
 
 
 ## 2020-02-17

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -532,6 +532,14 @@
       "value": "/home/jovyan/.jupyterlab_python"
     },
     {
+      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_DATA_DIR",
+      "value": "/home/jovyan/.local/share/jupyterlab_python"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_RUNTIME_DIR",
+      "value": "/home/jovyan/.local/share/jupyterlab_python/runtime"
+    },
+    {
       "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__PORT",
       "value": "8888"
     },
@@ -650,6 +658,14 @@
     {
       "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__ENV__JUPYTER_CONFIG_DIR",
       "value": "/home/jovyan/.jupyterlab_r"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__ENV__JUPYTER_DATA_DIR",
+      "value": "/home/jovyan/.local/share/jupyterlab_r"
+    },
+    {
+      "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__ENV__JUPYTER_RUNTIME_DIR",
+      "value": "/home/jovyan/.local/share/jupyterlab_r/runtime"
     },
     {
       "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__PORT",


### PR DESCRIPTION
### Description of change

A follow-up to c0f6074794c309d0a7e4b4c37891ff872373aca4, separating more
JupyterLab directories between the R and Python instances, to avoid
issues when they are synced to and from S3.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
