### PR TITLE
(feat) Tweak launch button widths for better alignment

### DIFF
--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -9,7 +9,7 @@
         .tool-launch-button {
             vertical-align: middle;
             display: inline-block;
-            min-width: 11em;
+            min-width: 12.8em;
         }
         .tool-stop-button {
             vertical-align: middle;


### PR DESCRIPTION
### Description of change

It was/is a slight hack anyway, but at least now it's a hack that gives
slightly neater output.

New version:

<img width="990" alt="Screenshot 2020-02-20 at 14 29 43" src="https://user-images.githubusercontent.com/13877/74944471-01752e00-53ee-11ea-9d29-bb300a36d0d2.png">

Old version:

<img width="994" alt="Screenshot 2020-02-20 at 14 34 38" src="https://user-images.githubusercontent.com/13877/74944573-29649180-53ee-11ea-9ef4-24a8a922d8e7.png">


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~*[ ] Has the README been updated (if needed)?~
