### PR TITLE
(feat) Visualisations pages messages and tweaking of what projects to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-02-25
+
+### Changed
+
+- The visualisations page shows a message asking the user to visit GitLab if they haven't already.
+- The visualisations page asks the user to contact support if they have no access to any projects.
+- The visualisations page shows all internal visualisations if the user hasn't yet visited GitLab, or all the visualisations visible projects if they have.
+
+
 ## 2020-02-24
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -185,10 +185,16 @@ def visualisations_html_GET(request):
     if len(users) > 1:
         return HttpResponse(status=500)
 
+    if has_gitlab_user:
+        params = (('sudo', users[0]['id']),)
+    else:
+        params = (('visibility', 'internal'),)
+
     projects = gitlab_api_v4(
         f'groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects',
-        params=(('archived', 'false'),),
+        params=(('archived', 'false'),) + params,
     )
+
     return render(
         request,
         'visualisations.html',

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -152,6 +152,13 @@ def tools_html_POST(request):
     return redirect(redirect_target)
 
 
+def gitlab_api_v4(path):
+    return requests.get(
+        f'{settings.GITLAB_URL}api/v4/{path}',
+        headers={'PRIVATE-TOKEN': settings.GITLAB_TOKEN},
+    ).json()
+
+
 def visualisations_html_view(request):
     if not request.user.has_perm('applications.develop_visualisations'):
         return HttpResponseForbidden()
@@ -163,9 +170,5 @@ def visualisations_html_view(request):
 
 
 def visualisations_html_GET(request):
-    response = requests.get(
-        f'{settings.GITLAB_URL}api/v4/groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects',
-        headers={'PRIVATE-TOKEN': settings.GITLAB_TOKEN},
-    )
-    projects = response.json()
+    projects = gitlab_api_v4(f'groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects')
     return render(request, 'visualisations.html', {'projects': projects}, status=200)

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -185,7 +185,10 @@ def visualisations_html_GET(request):
     if len(users) > 1:
         return HttpResponse(status=500)
 
-    projects = gitlab_api_v4(f'groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects')
+    projects = gitlab_api_v4(
+        f'groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects',
+        params=(('archived', 'false'),),
+    )
     return render(
         request,
         'visualisations.html',

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -26,6 +26,10 @@
     </div>
     {% endif %}
 
+    {% if has_gitlab_user and not projects %}
+        <p class="govuk-body">You do not have access to any visualisations in GitLab. If you think you should have access, please <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Support Team</a>.</p>
+    {% endif %}
+
     {% for project in projects %}
         <h2 class="govuk-heading-m">{{ project.name }}</h2>
         <p class="govuk-body"><a href="{{ project.web_url }}" class="govuk-link">GitLab project</a></p>

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -20,6 +20,12 @@
 {% block inner_content %}
     <h1 class="govuk-heading-l">Visualisations</h1>
 
+    {% if not has_gitlab_user %}
+    <div class="govuk-inset-text">
+        <p class="govuk-body">It looks like GitLab does not have a user record for you. Please visit <a href="{{ gitlab_url }}" class="govuk-link">visit GitLab</a>, which will create one automatically. Then return to this page.</p>
+    </div>
+    {% endif %}
+
     {% for project in projects %}
         <h2 class="govuk-heading-m">{{ project.name }}</h2>
         <p class="govuk-body"><a href="{{ project.web_url }}" class="govuk-link">GitLab project</a></p>


### PR DESCRIPTION
### Description of change

- The visualisations page shows a message asking the user to visit GitLab if they haven't already.
- The visualisations page asks the user to contact support if they have no access to any projects.
- The visualisations page shows all internal visualisations if the user hasn't yet visited GitLab, or all the visualisations visible projects if they have.


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
