### PR TITLE
(fix) IPython sqllite errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The visualisations page shows a message asking the user to visit GitLab if they haven't already.
 - The visualisations page asks the user to contact support if they have no access to any projects.
 - The visualisations page shows all internal visualisations if the user hasn't yet visited GitLab, or all the visualisations visible projects if they have.
+- Where the ipython directory is, from the home directory that is synced using mobius3, to /tmp. This avoids occasional sqllite "attempt to write a readonly database" errors.
 
 
 ## 2020-02-24

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -37,7 +37,7 @@ RUN \
     apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
         build-essential=12.6 \
         git=1:2.20.1-2 \
-        openssh-client=1:7.9p1-10+deb10u1 \
+        openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
         texlive-generic-extra=2018.20190227-2 \
         texlive-fonts-recommended=2018.20190227-2 \
@@ -127,6 +127,11 @@ ENTRYPOINT ["tini", "-g", "--"]
 USER jovyan
 
 WORKDIR /home/jovyan
+
+# The ipython history database does not play well with mobius3, surfacing
+# occasional errors like "attempt to write a readonly database", so we store
+# it where mobius3 does not sync
+ENV IPYTHONDIR=/tmp/ipython
 
 CMD ["/opt/conda/bin/jupyter", \
     "lab", \

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -38,7 +38,7 @@ RUN \
         build-essential=12.6 \
         gfortran=4:8.3.0-1 \
         git=1:2.20.1-2 \
-        openssh-client=1:7.9p1-10+deb10u1 \
+        openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
         texlive-generic-extra=2018.20190227-2 \
         texlive-fonts-recommended=2018.20190227-2 \
@@ -136,6 +136,11 @@ ENTRYPOINT ["tini", "-g", "--"]
 USER jovyan
 
 WORKDIR /home/jovyan
+
+# The ipython history database does not play well with mobius3, surfacing
+# occasional errors like "attempt to write a readonly database", so we store
+# it where mobius3 does not sync
+ENV IPYTHONDIR=/tmp/ipython
 
 CMD ["/opt/conda/bin/jupyter", \
     "lab", \


### PR DESCRIPTION
### Description of change

Moving the ipython config/history directory out from the home directory, to avoid sqllite errors like "attempt to write a readonly database"

Also bumping openssh-client: the build was complaining about attempting
to downgrade.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
