### PR TITLE
(fix) GitLab link in template and remove duplicated word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Fixed the broken link to GitLab from the visualisations page
+- Removed duplicated word in visualisations page
+
+
+## 2020-02-25
+
+### Changed
+
 - The visualisations page shows a message asking the user to visit GitLab if they haven't already.
 - The visualisations page asks the user to contact support if they have no access to any projects.
 - The visualisations page shows all internal visualisations if the user hasn't yet visited GitLab, or all the visualisations visible projects if they have.

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -198,6 +198,10 @@ def visualisations_html_GET(request):
     return render(
         request,
         'visualisations.html',
-        {'has_gitlab_user': has_gitlab_user, 'projects': projects},
+        {
+            'gitlab_url': settings.GITLAB_URL,
+            'has_gitlab_user': has_gitlab_user,
+            'projects': projects,
+        },
         status=200,
     )

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -22,7 +22,7 @@
 
     {% if not has_gitlab_user %}
     <div class="govuk-inset-text">
-        <p class="govuk-body">It looks like GitLab does not have a user record for you. Please visit <a href="{{ gitlab_url }}" class="govuk-link">visit GitLab</a>, which will create one automatically. Then return to this page.</p>
+        <p class="govuk-body">It looks like GitLab does not have a user record for you. Please <a href="{{ gitlab_url }}" class="govuk-link">visit GitLab</a>, which will create one automatically. Then return to this page.</p>
     </div>
     {% endif %}
 


### PR DESCRIPTION
### Description of change

Fix GitLab link in template and remove duplicated word

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
