### PR TITLE
(fix) Avoid database query during page render to try to avoid recent issues of 100% CPU + running out of DB connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-02-26
 
+### Changed
+
+- Remove the permissions check for showing the Visualisations tab to try to reduce the effect of running out database connections.
+
+
 ### Added
 
 - Support for Google Tag Manager to manage analytics

--- a/dataworkspace/dataworkspace/context_processors.py
+++ b/dataworkspace/dataworkspace/context_processors.py
@@ -1,24 +1,16 @@
 from django.conf import settings
-from django.contrib.contenttypes.models import ContentType
-
-from dataworkspace.apps.applications.models import ApplicationInstance
 
 
 def common(request):
-    # Although superusers can alway access the Visualisations page itself,
-    # during early development, we hide the tab itself from the interface
-    # unless the user has been given the explicit permission to develop
-    # visualisations. This is so until the interface is a bit more final, most
-    # superusers still see the application as most users will, which is good
-    # for demos, but can optionally see the WIP interface as needed.
+    # Ready to add a permissions check. Note: after putting an initial permissions
+    # check here, we did occasionally run out of database connections and use
+    # 100% CPU on the server. There was some evidence that an exception here
+    # caused some sort of infinite loop rending the 500 error page, which caused
+    # this function to be called, which then caused another exception...
     #
-    # This I suspect is _not_ cached, and so results in a database query on
-    # every page load. This is slightly unfortunate, but should be acceptable
-    # for an easy query.
-    can_see_visualisations_tab = request.user.user_permissions.filter(
-        codename='develop_visualisations',
-        content_type=ContentType.objects.get_for_model(ApplicationInstance),
-    ).exists()
+    # Not sure of cause/effect, but out of paranoia, decided to remove the
+    # database query.
+    can_see_visualisations_tab = False
 
     return {
         'root_href': f'{request.scheme}://{settings.APPLICATION_ROOT_DOMAIN}/',


### PR DESCRIPTION
### Description of change

Remove the permissions check for showing the Visualisations tab to try to reduce the chance of running out database connections / getting to 100% CPU

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
