### PR TITLE
(feat) Tweak location of Menu button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove the permissions check for showing the Visualisations tab to try to reduce the effect of running out database connections.
+- The location of the Menu button in the main navigation on mobile to make up for the lack of the GOV UK logo + crown which the GDS styles assume.
 
 
 ### Added

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -171,3 +171,21 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* The GDS styles assume the presence of the GOV UK logo + crown, which we
+   don't have, so without these tweaks the white Menu button on mobile is too
+   low: too close to the border of the black top bar.
+
+   As with most (but not all) styles in GDS, this position is "mobile-first",
+   with @media min-width to apply styles on larger screen only. This makes it
+   slightly awkward to override a style on only one width of screen: the value
+   of the style on the larger sizes must be copied and pasted after the
+   override in @media min-width blocks. */
+.govuk-header__menu-button {
+  top: 12px;  /* The original value is 20px */
+}
+@media (min-width: 40.0625em) {
+  .govuk-header__menu-button {
+      top: 15px;  /* The original GDS value */
+  }
+}


### PR DESCRIPTION
### Description of change

Changing the position of the Menu button in the menu on mobile from

<img width="498" alt="Screenshot 2020-02-28 at 07 55 26" src="https://user-images.githubusercontent.com/13877/75522563-31ca5700-5a02-11ea-96ac-8ee65f23422a.png">

to

<img width="498" alt="Screenshot 2020-02-28 at 08 15 43" src="https://user-images.githubusercontent.com/13877/75522764-a30a0a00-5a02-11ea-8af8-70311314e57a.png">

(I'm going to be doing a series of front end changes, and this keeps catching my eye...)
### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
