### PR TITLE
(feat) Fetch and display if the user is a developer on each project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-02-28
+
+### Added
+
+- If the current user has developer or higher privileges on each GitLab project. This is mostly to find out how slow the API requests are going to be in production.
+
+
 ## 2020-02-26
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -214,6 +214,20 @@ def visualisations_html_GET(request):
         for project in projects
     }
 
+    # It looks like the only way to check the current user's access level is
+    # to fetch all the users who have access to the project
+    developer_access_level = 30
+    is_project_developer = {
+        project['id']: has_gitlab_user
+        and True
+        in (
+            project_user['id'] == users[0]['id']
+            and project_user['access_level'] >= developer_access_level
+            for project_user in gitlab_api_v4(f'/projects/{project["id"]}/members/all')
+        )
+        for project in projects
+    }
+
     return render(
         request,
         'visualisations.html',
@@ -222,6 +236,7 @@ def visualisations_html_GET(request):
             'has_gitlab_user': has_gitlab_user,
             'projects': projects,
             'project_branches': project_branches,
+            'is_project_developer': is_project_developer,
         },
         status=200,
     )

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -58,6 +58,11 @@
 
     {% for project in projects %}
         <h2 class="govuk-heading-m">{{ project.name }}</h2>
+
+        {% if is_project_developer|get_key:project.id %}
+        <p class="govuk-body">You have developer privileges on {{ project.name }}.</p>
+        {% endif %}
+
         <dl class="govuk-summary-list">
         {% for branch in project_branches|get_key:project.id %}
             <div class="govuk-summary-list__row">


### PR DESCRIPTION
### Description of change

This is more of a check on the API, as well as seeing how many GitLab
API requests we can do in production per page load before it gets too
slow.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
