### PR TITLE
(refactor) Reduce usage of application 'name'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## 2020-03-03
+
+### Changed
+
+- Reduce usage of application 'name' in favour of nice_name and id
+
+
 ## 2020-02-28
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -96,19 +96,19 @@ class ApplicationInstanceAdmin(admin.ModelAdmin):
 
 class ApplicationFilter(SimpleListFilter):
     title = 'Filter by application'
-    parameter_name = 'application_template__name'
+    parameter_name = 'application_template__id'
     template = 'admin/application_instance_report_filter.html'
 
     def lookups(self, request, model_admin):
         return tuple(
-            (app.name, app.nice_name)
+            (app.id, app.nice_name)
             for app in ApplicationTemplate.objects.all().order_by('nice_name')
         )
 
     def queryset(self, request, queryset):
         try:
             queryset_filter = {
-                'application_template__name': request.GET['application_template__name']
+                'application_template__id': request.GET['application_template__id']
             }
         except KeyError:
             queryset_filter = {}
@@ -233,7 +233,7 @@ class ApplicationInstanceReportAdmin(admin.ModelAdmin):
         )
 
         try:
-            app_filter = {'name__in': [request.GET['application_template__name']]}
+            app_filter = {'id__in': [request.GET['application_template__id']]}
         except KeyError:
             app_filter = {}
 
@@ -363,7 +363,7 @@ class VisualisationTemplateEditForm(forms.ModelForm):
         widget=FilteredSelectMultiple('master datasets', False),
         queryset=MasterDataset.objects.live()
         .filter(user_access_type='REQUIRES_AUTHORIZATION')
-        .order_by('name'),
+        .order_by('nice_name'),
     )
 
     class Meta:

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -93,7 +93,6 @@ def api_application_dict(application_instance):
         application_instance.state if spawner_state == 'RUNNING' else spawner_state
     )
 
-    template_name = application_instance.application_template.name
     sso_id_hex = hashlib.sha256(
         str(application_instance.owner.profile.sso_id).encode('utf-8')
     ).hexdigest()
@@ -103,7 +102,6 @@ def api_application_dict(application_instance):
         'proxy_url': application_instance.proxy_url,
         'state': api_state,
         'user': sso_id_hex_short,
-        'name': template_name,
     }
 
 


### PR DESCRIPTION
### Description of change
'name' is a strange field whose purpose can be covered by one of:

id: unique and unchanging identifier for the application
nice_name: Human friendly name

(In one case, the name field wasn't being used, so removed it from the dictionary it was in)

In a later PR, will likely remove the name field

Doing this now, because the upcoming visualisations deployment code will
make the app model more complex, so simplyifying things before that.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
