### PR TITLE
Loosen up CSP on reference dataset admin page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.utils.encoding import force_text
+from csp.decorators import csp_update
 
 from dataworkspace.apps.datasets.models import (
     SourceLink,
@@ -305,6 +306,18 @@ class ReferenceDatasetAdmin(DeletableTimeStampedUserAdmin):
                 f.instance.created_by = request.user
             f.instance.updated_by = request.user
         super().save_formset(request, form, formset, change)
+
+    # We allow inline scripts to run on this page in order to support CKEditor,
+    # which gives rich-text formatting but unfortunately uses inline scripts to
+    # do so - and we don't have a clean way to either hash the inline script on-demand
+    # or inject our request CSP nonce.
+    @csp_update(SCRIPT_SRC="'unsafe-inline'")
+    def add_view(self, request, form_url='', extra_context=None):
+        return super().add_view(request, form_url, extra_context)
+
+    @csp_update(SCRIPT_SRC="'unsafe-inline'")
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        return super().change_view(request, object_id, form_url, extra_context)
 
 
 @admin.register(CustomDatasetQuery)

--- a/dataworkspace/dataworkspace/tests/test_security.py
+++ b/dataworkspace/dataworkspace/tests/test_security.py
@@ -1,6 +1,7 @@
 from django.urls import reverse
 
 from dataworkspace.tests.common import get_response_csp_as_set
+from dataworkspace.tests import factories
 
 
 def test_baseline_content_security_policy(client):
@@ -21,3 +22,26 @@ def test_baseline_content_security_policy(client):
     }
 
     assert policies == expected_policies
+
+
+def test_edit_reference_dataset_admin_pages_allow_inline_scripts_for_ckeditor_support(
+    staff_client
+):
+    dataset = factories.ReferenceDatasetFactory.create()
+
+    # Log into admin
+    staff_client.get(reverse("admin:index"), follow=True)
+
+    urls = [
+        reverse("admin:datasets_referencedataset_add"),
+        reverse('admin:datasets_referencedataset_change', args=(dataset.id,)),
+    ]
+    for url in urls:
+        response = staff_client.get(url, follow=True)
+        script_src = next(
+            filter(
+                lambda policy: policy.strip().startswith('script-src'),
+                response.get('content-security-policy').split(';'),
+            )
+        )
+        assert "'unsafe-inline'" in script_src


### PR DESCRIPTION
We use CKEditor to render rich text fields on the add/change admin pages
for reference datasets. Our latest CSP update was too strict, leading to
the text field no longer working as an inline script injected by CK
Editor is no longer executed by the browser.

This script is dynamically built by the ckeditor javascript and it
doesn't appear possible to update the CSP headers with a hash of the
script contents or pass in our CSP nonce, so we will have to settle with
downgrading the CSP security on this page for the time being.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
