### PR TITLE
Allow creating a dataset and assigning permissions at the same time

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -149,6 +149,8 @@ class BaseDatasetAdmin(DeletableTimeStampedUserAdmin):
 
         user_content_type_id = ContentType.objects.get_for_model(get_user_model()).pk
 
+        super().save_model(request, obj, form, change)
+
         for user in authorized_users - current_authorized_users:
             DataSetUserPermission.objects.create(dataset=obj, user=user)
             LogEntry.objects.log_action(
@@ -170,8 +172,6 @@ class BaseDatasetAdmin(DeletableTimeStampedUserAdmin):
                 action_flag=CHANGE,
                 change_message=f"Removed dataset {obj} permission",
             )
-
-        super().save_model(request, obj, form, change)
 
         if original_user_access_type != obj.user_access_type:
             LogEntry.objects.log_action(


### PR DESCRIPTION
### Description of change

Django complains if DataSetUserPermission objects are created before
the dataset has been persisted, which only happens when you try to
create a dataset and assign some users to it in the same edit.

This doesn't happen when editing permissions from the users page
since we don't create users in the admin UI.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
