### PR TITLE
Move contact section to bottom of page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fix incorrection change of name -> nice name in Django admin
+- Move the `contact` section to the bottom of the dataset detail view.
 
 
 ## 2020-03-03

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -37,10 +37,6 @@
             <p class="govuk-body">
                 {{ model.description | linebreaksbr }}
             </p>
-
-            <h3 class="govuk-heading-l">Contact</h3>
-            {% include 'partials/contact.html' with model=model.enquiries_contact only %}
-
         </div>
     </div>
 
@@ -186,6 +182,9 @@
                   </dd>
                 </div>
             </dl>
+            {% if model.enquiries_contact %}
+              {% include 'partials/contact.html' with model=model.enquiries_contact as_section=True only %}
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -36,8 +36,6 @@
       <p class="govuk-body">
         {{ model.description | linebreaksbr }}
       </p>
-      <h3 class="govuk-heading-l">Contact</h3>
-      {% include 'partials/contact.html' with model=model.enquiries_contact only %}
     </div>
   </div>
 
@@ -165,6 +163,9 @@
           </dd>
         </div>
       </dl>
+      {% if model.enquiries_contact %}
+        {% include 'partials/contact.html' with model=model.enquiries_contact as_section=True only %}
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -37,10 +37,6 @@
       <div class="govuk-body">
         {{ model.description|safe }}
       </div>
-      {% if model.enquiries_contact %}
-        <h3 class="govuk-heading-m">Contact</h3>
-        {% include 'partials/contact.html' with model=model.enquiries_contact only %}
-      {% endif %}
     </div>
   </div>
 
@@ -219,6 +215,9 @@
           <dd class="govuk-summary-list__value">{{ model.restrictions_on_usage | linebreaksbr }}</dd>
         </div>
       </dl>
+      {% if model.enquiries_contact %}
+        {% include 'partials/contact.html' with model=model.enquiries_contact as_section=True only %}
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/partials/contact.html
+++ b/dataworkspace/dataworkspace/templates/partials/contact.html
@@ -1,7 +1,14 @@
+{% if as_section %}
+<h3 class="govuk-heading-m">Contact</h3>
+<p class="govuk-body">
+  Use this contact to ask questions about this data and how to use it.
+</p>
+{% endif %}
+
 <p class="govuk-body">
     {{ model.first_name }} {{ model.last_name }}
     {% if model.email %}
         <br/>
-        <a href="mailto:{{ model.email }}">{{ model.email }}</a>
+        <a class="govuk-link" href="mailto:{{ model.email }}">{{ model.email }}</a>
     {% endif %}
 </p>


### PR DESCRIPTION
### Description of change
Moves the contact section to the bottom of the dataset detail view. Also adds proper GOV.UK styling to the email address link.

### Show the thing
![Screenshot 2020-03-04 at 15 33 17](https://user-images.githubusercontent.com/2920760/75895424-8cfab000-5e2d-11ea-89ca-38734d6e08aa.png)


### Checklist

~~* [ ] Have tests been added to cover any changes?~~
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~~* [ ] Has the README been updated (if needed)?~~