### PR TITLE
Un-review SQL queries if changed after review

### DIFF
--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -412,6 +412,17 @@ class CustomDatasetQueryInlineForm(forms.ModelForm):
                 }
             )
 
+        if (
+            self.instance.reviewed is True
+            and self.cleaned_data['dataset'].published is False
+        ):
+            if set(self.changed_data) - {"reviewed"}:
+                self.cleaned_data['reviewed'] = False
+
+                # We need to also update the instance directly, as well, because the `reviewed` field will not otherwise
+                # be updated for users who have `reviewed` as a read-only field (i.e. "Subject Matter Experts").
+                self.instance.reviewed = False
+
 
 class SourceViewForm(forms.ModelForm):
     model = SourceView

--- a/dataworkspace/dataworkspace/tests/test_security.py
+++ b/dataworkspace/dataworkspace/tests/test_security.py
@@ -25,7 +25,7 @@ def test_baseline_content_security_policy(client):
 
 
 def test_edit_reference_dataset_admin_pages_allow_inline_scripts_for_ckeditor_support(
-    staff_client
+    staff_client,
 ):
     dataset = factories.ReferenceDatasetFactory.create()
 


### PR DESCRIPTION
### Description of change
Make sure that if SME users change SQL queries after they've been reviewed by a superuser, they need to be reviewed again.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
