### PR TITLE
(refactor) Un-generalise public_host -> docker tag for visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove unused "User Provided" application
 - Clickable links in reference dataset description
 - Support more double-hyphens in hosts
+- De-generalise how hosts are converted to Docker tags for visualisations
 
 
 ## 2020-03-04

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -148,10 +148,7 @@ def application_api_PUT(request, public_host):
         )
 
     try:
-        (
-            application_template,
-            public_host_data,
-        ) = application_template_and_data_from_host(public_host)
+        application_template, _ = application_template_and_data_from_host(public_host)
     except ApplicationTemplate.DoesNotExist:
         return JsonResponse(
             {'message': 'Application template does not exist'}, status=400
@@ -207,11 +204,13 @@ def application_api_PUT(request, public_host):
             db_username=creds['db_user'],
         )
 
+    tag = None if application_template.application_type == 'TOOL' else public_host
+
     spawn.delay(
         application_template.spawner,
         request.user.email,
         str(request.user.profile.sso_id),
-        public_host_data,
+        tag,
         application_instance.id,
         application_template.spawner_options,
         credentials,


### PR DESCRIPTION
### Description of change

For visualisations, there are two slightly unnecessary generalisations
to convert the host to a docker tag:

- Application.host_pattern that converted the host into some arbitrary
  dictionary

- Application.spawner_options.CONTAINER_TAG that then converted from
  this dictionary to a docker tag

However for visualisations the only transformation that is ever made was to
convert the exact value of public_host to the docker tag. There isn't a
plan to change this, and even if there were, I suspect will want to do
this from code for all visualisations, so it will be awkward to do this
for all visualisations if it involved their config.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
