### PR TITLE
Clickable links in reference dataset descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove unused "User Provided" application
+- Clickable links in reference dataset description
 
 
 ## 2020-03-04

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -266,11 +266,15 @@ CKEDITOR_CONFIGS = {
                 'JustifyCenter',
                 'JustifyRight',
                 'JustifyBlock',
+                '-',
+                'Link',
+                'Unlink',
             ],
             ['Format'],
             ['Cut', 'Copy', 'Paste', '-', 'Undo', 'Redo'],
         ],
         'format_tags': 'div;p;h1;h2;h3;h4;h5;h6',
+        'linkShowAdvancedTab': False,
     }
 }
 


### PR DESCRIPTION
### Description of change
This adds the ability to add clickable links to reference dataset descriptions

- Updating the description

<img width="432" alt="Screenshot 2020-03-05 at 14 26 32" src="https://user-images.githubusercontent.com/8222658/75990889-7fa4fa80-5eed-11ea-9b02-36ee45a83c93.png">

- Add link menu
<img width="463" alt="Screenshot 2020-03-05 at 14 29 04" src="https://user-images.githubusercontent.com/8222658/75991014-b3802000-5eed-11ea-9905-67aa84cbfdbf.png">

- Frontend

<img width="331" alt="Screenshot 2020-03-05 at 14 27 15" src="https://user-images.githubusercontent.com/8222658/75990914-8895cc00-5eed-11ea-9acf-95a03fb1c8a7.png">


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
