### PR TITLE
(feat) Support double hyphens in hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove unused "User Provided" application
 - Clickable links in reference dataset description
+- Support more double-hyphens in hosts
 
 
 ## 2020-03-04

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -252,10 +252,11 @@ async def async_main():
         public_host, _, _ = downstream_request.url.host.partition(
             f'.{root_domain_no_port}'
         )
-        public_host, _, port_override_str = public_host.partition('--')
+        public_host, _, public_host_or_port_override = public_host.rpartition('--')
         try:
-            port_override = int(port_override_str)
+            port_override = int(public_host_or_port_override)
         except ValueError:
+            public_host = public_host_or_port_override
             port_override = None
         host_api_url = admin_root + '/api/v1/application/' + public_host
         host_html_path = '/tools/' + public_host


### PR DESCRIPTION
### Description of change

Right now my-app-name--9000.domain.com routes to port 9000 on an
applications. I suspect for previewing applications will want something
like my-app-name--commitid--9000, so we need to use rpartition rather
than partition to find the port number.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
