### PR TITLE
Show "external link" warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-03-06
 
+### Added
+
+- A "warning" section for data links that point at externally-hosted sources.
+
 ### Changed
 
 - Remove now-unnecessary constraint on host_exact,host_pattern

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -264,6 +264,10 @@ class DatasetDetailView(DetailView):
                 'has_access': self.object.user_has_access(self.request.user),
                 'data_links_with_link_toggle': data_links_with_link_toggle,
                 'fields': columns,
+                'data_hosted_externally': any(
+                    not source_link.url.startswith('s3://')
+                    for source_link in self.object.sourcelink_set.all()
+                ),
             }
         )
         return ctx

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -41,29 +41,42 @@
     </div>
 
     <div class="govuk-grid-row" style="overflow-x: auto;">
-        <div class="govuk-grid-column-full">
+        <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Links</h2>
 
             {% if data_links_with_link_toggle %}
-                {% if not has_access %}
-                    <div class="govuk-warning-text">
-                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                        <div class="govuk-warning-text__text">
-                            <strong>
-                                <span class="govuk-warning-text__assistive">Warning</span>
-                                You do not have permission to access these links.
-                                <br>
-                                {% if model.eligibility_criteria %}
-                                  <a class="govuk-link--no-visited-state" href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
-                                {% else %}
-                                  <a class="govuk-link--no-visited-state" href="{% url 'datasets:request_access' model.id %}">Request access</a>
-                                {% endif %}
-                            </strong>
-                        </div>
+              {% if not has_access %}
+                  <div class="govuk-warning-text">
+                      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                      <div class="govuk-warning-text__text">
+                          <strong>
+                              <span class="govuk-warning-text__assistive">Warning</span>
+                              You do not have permission to access these links.
+                              <br>
+                              {% if model.eligibility_criteria %}
+                                <a class="govuk-link--no-visited-state" href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
+                              {% else %}
+                                <a class="govuk-link--no-visited-state" href="{% url 'datasets:request_access' model.id %}">Request access</a>
+                              {% endif %}
+                          </strong>
+                      </div>
+                  </div>
+              {% elif data_hosted_externally %}
+                <div class="govuk-warning-text">
+                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <div class="govuk-warning-text__text">
+                        <strong>
+                            <span class="govuk-warning-text__assistive">Warning</span>
+                            This data set is hosted by an external source. You'll be forwarded to that source when you select it.
+                        </strong>
                     </div>
-                {% endif %}
+                </div>
+              {% endif %}
             {% endif %}
+        </div>
 
+
+        <div class="govuk-grid-column-full">
             <table class="govuk-table">
                 <thead>
                 <tr class="govuk-table__row">


### PR DESCRIPTION
### Description of change
Adds some warning text under the "Data links" header when the data link is hosted externally (i.e. not on Data Workspace).

### Show the thing
<img width="1053" alt="Screenshot 2020-03-06 at 12 57 57" src="https://user-images.githubusercontent.com/2920760/76085525-1df69600-5faa-11ea-94d0-d056188a7e7f.png">

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
