### PR TITLE
(feat) Ensure application doesn't start if no host_exact for tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Remove now-unnecessary constraint on host_exact,host_pattern
+- Require host_exact to be populated for tools on start
 
 
 ## 2020-03-05

--- a/dataworkspace/dataworkspace/apps/applications/management/commands/ensure_application_template_models.py
+++ b/dataworkspace/dataworkspace/apps/applications/management/commands/ensure_application_template_models.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
                 ApplicationTemplate.objects.create(
                     name=desired_application_template['NAME'],
                     visible=desired_application_template['VISIBLE'] == 'True',
-                    host_exact=desired_application_template.get('HOST_EXACT', ''),
+                    host_exact=desired_application_template['HOST_EXACT'],
                     host_pattern=desired_application_template['HOST_PATTERN'],
                     nice_name=desired_application_template['NICE_NAME'],
                     spawner=desired_application_template['SPAWNER'],
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                     name=desired_application_template['NAME']
                 )
                 template.visible = desired_application_template['VISIBLE'] == 'True'
-                template.host_exact = desired_application_template.get('HOST_EXACT', '')
+                template.host_exact = desired_application_template['HOST_EXACT']
                 template.host_pattern = desired_application_template['HOST_PATTERN']
                 template.nice_name = desired_application_template['NICE_NAME']
                 template.spawner = desired_application_template['SPAWNER']


### PR DESCRIPTION
### Description of change

... since otherwise, routing to tools will break

Suspect will be moving away from tools auto-populated by environment
variables, but for now, they are, so should try to make sure they don't
break.


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
