### PR TITLE
(feat) GitLab runner to run visualisation docker builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The lifecycle policy on the GitLab EBS volume to prevent accidental destruction
 
+### Added
+
+- A GitLab runner to run visualisation builds
+
 
 ## 2020-03-09
 

--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -247,7 +247,10 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     ]
 
     resources = [
+      # For docker to pull from ECR
       "arn:aws:s3:::prod-${data.aws_region.aws_region.name}-starport-layer-bucket/*",
+      # For AWS Linux 2 packages
+      "arn:aws:s3:::amazonlinux.*.amazonaws.com/*",
     ]
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -98,10 +98,14 @@ variable gitlab_domain {}
 variable gitlab_bucket {}
 variable gitlab_container_image {}
 variable gitlab_db_instance_class {}
+variable gitlab_runner_visualisations_deployment_project_token {}
 
 variable gitlab_sso_id {}
 variable gitlab_sso_secret {}
 variable gitlab_sso_domain {}
+
+variable gitlab_key {}
+variable gitlab_runner_key {}
 
 locals {
   registry_container_name    = "jupyterhub-registry"


### PR DESCRIPTION
### Description of change

The GitLab runner runs in the same VPC and subnets as the notebooks to avoid it having any direct internet access: they will run essentially untrusted code: the Dockerfiles of visualisations.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
