### PR TITLE
(feat) Take GitLab pipeline into account when checking spawner status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Use VPC endpoint for ECR API access (needed for upcoming changes to access the API from the GitLab runner, which does not have internet access)
+- When determining the spawner status, take GitLab pipeline status and time into account, otherwise the spawner is marked as stopped because it takes too long for the task to be created
 
 
 ## 2020-03-14

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -335,7 +335,7 @@ class FargateSpawner:
         spawner_application_id_parsed = json.loads(spawner_application_id)
         cluster_name = spawner_options['CLUSTER_NAME']
 
-        three_minutes_ago = datetime.datetime.now() - datetime.timedelta(seconds=180)
+        three_minutes_ago = datetime.datetime.now() - datetime.timedelta(minutes=3)
         twenty_seconds_ago = datetime.datetime.now() - datetime.timedelta(seconds=20)
 
         # We can't just depend on connectivity to the proxy url, since another

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -165,6 +165,7 @@ class FargateSpawner:
     ):
 
         try:
+            pipeline_id = None
             task_arn = None
             options = json.loads(spawner_options)
 
@@ -316,9 +317,16 @@ class FargateSpawner:
 
             raise Exception('Spawner timed out before finding ip address')
         except Exception:
-            logger.exception('FARGATE %s %s', application_instance_id, spawner_options)
+            logger.exception(
+                'Spawning %s %s %s',
+                pipeline_id,
+                application_instance_id,
+                spawner_options,
+            )
             if task_arn:
                 _fargate_task_stop(cluster_name, task_arn)
+            if pipeline_id:
+                _gitlab_ecr_pipeline_cancel(pipeline_id)
 
     @staticmethod
     def state(spawner_options, created_date, spawner_application_id, proxy_url):

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -96,8 +96,8 @@ class ProcessSpawner:
 
     @staticmethod
     def state(_, created_date, spawner_application_id, proxy_url):
-        ten_seconds_ago = datetime.datetime.now() + datetime.timedelta(seconds=-10)
-        twenty_seconds_ago = datetime.datetime.now() + datetime.timedelta(seconds=-20)
+        ten_seconds_ago = datetime.datetime.now() - datetime.timedelta(seconds=10)
+        twenty_seconds_ago = datetime.datetime.now() - datetime.timedelta(seconds=20)
         spawner_application_id_parsed = json.loads(spawner_application_id)
 
         # We have 10 seconds for the spawner to create the ID. In this case,
@@ -335,8 +335,8 @@ class FargateSpawner:
         spawner_application_id_parsed = json.loads(spawner_application_id)
         cluster_name = spawner_options['CLUSTER_NAME']
 
-        three_minutes_ago = datetime.datetime.now() + datetime.timedelta(seconds=-180)
-        twenty_seconds_ago = datetime.datetime.now() + datetime.timedelta(seconds=-20)
+        three_minutes_ago = datetime.datetime.now() - datetime.timedelta(seconds=180)
+        twenty_seconds_ago = datetime.datetime.now() - datetime.timedelta(seconds=20)
 
         # We can't just depend on connectivity to the proxy url, since another
         # task may now be using is IP address. We must query the ECS API

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -225,7 +225,7 @@ class FargateSpawner:
                     raise Exception('Unable to start pipeline: {}'.format(pipeline))
                 pipeline_id = pipeline['id']
 
-                for _ in range(0, 60 * 5):
+                for _ in range(0, 300):
                     gevent.sleep(3)
                     pipeline = _gitlab_ecr_pipeline_get(pipeline_id)
                     logger.info('Fetched pipeline %s', pipeline)


### PR DESCRIPTION
### Description of change

When determining the spawner status, take GitLab pipeline status and time into account, otherwise the spawner is marked as stopped because it takes too long for the task to be created

### Checklist

*~ [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
