### PR TITLE
Make sure they really do have access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-
 ## 2020-03-17
 
 ### Changed
 
 - Use VPC endpoint for ECR API access (needed for upcoming changes to access the API from the GitLab runner, which does not have internet access)
 - When determining the spawner status, take GitLab pipeline status and time into account, otherwise the spawner is marked as stopped because it takes too long for the task to be created
+- Fix a bug with "you have access" filter resulting in wrong datasets being included and/or duplicated.
 
 
 ## 2020-03-14

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -109,8 +109,11 @@ def filter_datasets(
         search=search, search_rank=SearchRank(search, search_query)
     )
 
-    if access and datasets.model is not ReferenceDataset:
-        datasets = datasets.filter(datasetuserpermission__isnull=False)
+    if user and access and datasets.model is not ReferenceDataset:
+        access_filter = Q(user_access_type='REQUIRES_AUTHENTICATION') | Q(
+            datasetuserpermission__user=user
+        )
+        datasets = datasets.filter(access_filter)
 
     if query:
         datasets = datasets.filter(search=query)

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -16,6 +16,7 @@ class UserProfileFactory(factory.django.DjangoModelFactory):
 
 class UserFactory(factory.django.DjangoModelFactory):
     username = factory.LazyAttribute(lambda _: f'test.user+{uuid.uuid4()}@example.com')
+    email = factory.LazyAttribute(lambda o: o.username)
     password = '12345'
 
     class Meta:


### PR DESCRIPTION
### Description of change
There was a logic error in the "You have access" filter, which meant
that if _anyone_ had been granted access to the dataset then it would
appear. It was also resulting in each dataset appearing multiple times
in the results. This should fix these problems.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
