### PR TITLE
Actually de-duplicate datasets properly

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -148,9 +148,12 @@ def application_api_PUT(request, public_host):
         )
 
     try:
-        application_template, tag, _, commit_id = application_template_tag_user_commit_from_host(
-            public_host
-        )
+        (
+            application_template,
+            tag,
+            _,
+            commit_id,
+        ) = application_template_tag_user_commit_from_host(public_host)
     except ApplicationTemplate.DoesNotExist:
         return JsonResponse(
             {'message': 'Application template does not exist'}, status=400

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -136,9 +136,12 @@ def get_api_visible_application_instance_by_public_host(public_host):
 
 
 def application_api_is_allowed(request, public_host):
-    application_template, _, host_user, _ = application_template_tag_user_commit_from_host(
-        public_host
-    )
+    (
+        application_template,
+        _,
+        host_user,
+        _,
+    ) = application_template_tag_user_commit_from_host(public_host)
 
     request_sso_id_hex = hashlib.sha256(
         str(request.user.profile.sso_id).encode('utf-8')


### PR DESCRIPTION
### Description of change
I tried to fix this before in
https://github.com/uktrade/data-workspace/pull/530 but hadn't understood
the problem properly.

When a user filters for access as well as use (but not reference
datasets), then we get multiple instances of each dataset returned if
that dataset doesn't require authorisation but has multiple people
specifically authorised to use it.

This fix adds proper querying on public datasets to ensure that only one
instance is returned, and also changes the context passed into templates
to a list of dicts, rather than a list of dataset objects, which is
consistent with what's passed in when "reference" datasets are filtered
for.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
