### PR TITLE
Update support and feedback links/content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Code snippets to master datasets for users who have access to tools, for getting quickly started working with the data.
+- 'Support and feedback' link to header/footer.
+
+### Changed
+
+- Text on the 'feedback' page to 'Support and feedback' and updated help text.
 
 ## 2020-03-17
 

--- a/dataworkspace/dataworkspace/apps/core/forms.py
+++ b/dataworkspace/dataworkspace/apps/core/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.safestring import mark_safe
 
 
 class SupportForm(forms.Form):
@@ -11,9 +12,21 @@ class SupportForm(forms.Form):
         required=True,
         label='Description',
         widget=forms.Textarea(attrs={'class': 'govuk-textarea'}),
+        #
+        # If you're here because you want to copy the help text (i.e. bullets as form hints), then please don't. If
+        # this needs to be reused, we should probably do something else (e.g. convert it to markdown and add a markdown
+        # filter that can output GOV.UK Design System-aware elements). So this HTML-in-code should either remain an
+        # exception or eventually disappear.
         help_text=(
-            'If you want to provide feedback or a suggestion, describe it here. '
-            'If you were having a problem, explain what you did, what happened and '
-            'what you expected to happen.'
+            mark_safe(
+                """
+<p class="govuk-hint">Please use this form to give us feedback, report a technical issue or request data that is not available on Data Workspace.</p>
+<p class="govuk-hint">If you had a technical issue, briefly explain:</p>
+<ul class="govuk-list govuk-list--bullet govuk-hint">
+  <li>what you did</li>
+  <li>what happened</li>
+  <li>what you expected to happen</li>
+</ul>"""
+            )
         ),
     )

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -106,6 +106,11 @@
             </a>
           </li>
           <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="{% url 'support' %}">
+              Support and feedback
+            </a>
+          </li>
+          <li class="govuk-header__navigation-item">
             <a class="govuk-header__link" href="https://data-services-help.trade.gov.uk/data-workspace">
               Help centre
             </a>
@@ -168,6 +173,11 @@
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="{{ about_url  }}">
                   About
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="{% url 'support' %}">
+                  Support and feedback
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">

--- a/dataworkspace/dataworkspace/templates/core/support.html
+++ b/dataworkspace/dataworkspace/templates/core/support.html
@@ -6,7 +6,7 @@
       <li class="govuk-breadcrumbs__list-item">
         <a class="govuk-breadcrumbs__link" href="{% url 'root' %}">Home</a>
       </li>
-      <li class="govuk-breadcrumbs__list-item">Support
+      <li class="govuk-breadcrumbs__list-item">Support and feedback
       </li>
     </ol>
   </div>
@@ -24,7 +24,8 @@
         </p>
         <a class="govuk-button" href="{% url 'root' %}">Go home</a>
       {% else %}
-        <h1 class="govuk-heading-l">Tell us how we can help</h1>
+        <h1 class="govuk-heading-l">Support and feedback</h1>
+        <p class="govuk-body-l">Tell us how we can help.</p>
         <form method="post" enctype="multipart/form-data">
           {% csrf_token %}
           <fieldset class="govuk-fieldset">

--- a/dataworkspace/dataworkspace/templates/partials/form_field.html
+++ b/dataworkspace/dataworkspace/templates/partials/form_field.html
@@ -4,9 +4,9 @@
     {{ field.label }}
   </label>
   {% if field.help_text %}
-    <span class="govuk-hint">
+    <div class="govuk-hint">
       {{ field.help_text }}
-    </span>
+    </div>
   {% endif %}
   {% for error in field.errors %}
     <span class="govuk-error-message">

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -57,6 +57,7 @@ def test_csp_on_files_endpoint_includes_s3(client):
                 ("Data Workspace", "http://dataworkspace.test:8000/"),
                 ("Home", "http://dataworkspace.test:8000/"),
                 ("About", "/about/"),
+                ("Support and feedback", "/support-and-feedback/"),
                 (
                     "Help centre",
                     "https://data-services-help.trade.gov.uk/data-workspace",
@@ -70,6 +71,7 @@ def test_csp_on_files_endpoint_includes_s3(client):
                 ("Home", "http://dataworkspace.test:8000/"),
                 ("Tools", "/tools/"),
                 ("About", "/about/"),
+                ("Support and feedback", "/support-and-feedback/"),
                 (
                     "Help centre",
                     "https://data-services-help.trade.gov.uk/data-workspace",
@@ -100,6 +102,7 @@ def test_header_links(request_client, expected_links):
             [
                 ('Home', 'http://dataworkspace.test:8000/'),
                 ('About', '/about/'),
+                ("Support and feedback", "/support-and-feedback/"),
                 (
                     'Help centre',
                     'https://data-services-help.trade.gov.uk/data-workspace',
@@ -124,6 +127,7 @@ def test_header_links(request_client, expected_links):
                 ('Home', 'http://dataworkspace.test:8000/'),
                 ("Tools", "/tools/"),
                 ('About', '/about/'),
+                ("Support and feedback", "/support-and-feedback/"),
                 (
                     'Help centre',
                     'https://data-services-help.trade.gov.uk/data-workspace',

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -74,7 +74,9 @@ urlpatterns = [
     ),
     path('files', login_required(file_browser_html_view), name='files'),
     path('healthcheck', healthcheck_view),  # No authentication
-    path('support/', login_required(SupportView.as_view()), name='support'),
+    path(
+        'support-and-feedback/', login_required(SupportView.as_view()), name='support'
+    ),
     path(
         'support/success/<str:ticket_id>',
         login_required(SupportView.as_view()),


### PR DESCRIPTION
### Description of change
Add a link to 'support and feedback' to the heaader/footer, and update
the content on the page to help users understand what the form is for.

Ticket: https://trello.com/c/HYMb3J4Z/908

I know that putting HTML in the Python form is not great, but given this is the sole ask for this kind of formatted text I don't think it's worth going down other routes right now. Open to being challenged on this though.

### Show the thing
<img width="971" alt="Screenshot 2020-03-19 at 10 47 09" src="https://user-images.githubusercontent.com/2920760/77059545-01595580-69cf-11ea-9d30-8ca24d735b20.png">


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
