### PR TITLE
(feat) GitLab behind VPN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fixed links to branches and commits in visualisations page
+- GitLab load balancer to be in own subnet with NACL
+- Communication from the admin application and GitLab via port 80 on private IP
 
 ## 2020-03-17
 

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -224,7 +224,7 @@ resource "aws_lb" "gitlab" {
   load_balancer_type = "network"
 
   subnet_mapping {
-    subnet_id     = "${aws_subnet.public.*.id[0]}"
+    subnet_id     = "${aws_subnet.public_whitelisted_ingress.*.id[0]}"
     allocation_id = "${aws_eip.gitlab.id}"
   }
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -94,6 +94,9 @@ variable s3sync_container_image {}
 variable google_analytics_site_id {}
 variable google_data_studio_connector_pattern {}
 
+variable gitlab_ip_whitelist {
+  type = "list"
+}
 variable gitlab_domain {}
 variable gitlab_bucket {}
 variable gitlab_container_image {}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -313,6 +313,18 @@ resource "aws_security_group" "admin_service" {
   }
 }
 
+resource "aws_security_group_rule" "admin_service_egress_http_to_gitlab_service" {
+  description = "egress-http-to-gitlab-service"
+
+  security_group_id = "${aws_security_group.admin_service.id}"
+  source_security_group_id = "${aws_security_group.gitlab_service.id}"
+
+  type        = "egress"
+  from_port   = "80"
+  to_port     = "80"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "gitlab_service_egress_https_to_ecr_api" {
   description = "egress-https-to-ecr-api"
 
@@ -869,6 +881,18 @@ resource "aws_security_group_rule" "gitlab_service_ingress_http_from_nlb" {
 
   security_group_id = "${aws_security_group.gitlab_service.id}"
   cidr_blocks = ["${aws_eip.gitlab.private_ip}/32"]
+
+  type        = "ingress"
+  from_port   = "80"
+  to_port     = "80"
+  protocol    = "tcp"
+}
+
+resource "aws_security_group_rule" "gitlab_service_ingress_http_from_admin_service" {
+  description = "ingress-http-from-admin-service"
+
+  security_group_id = "${aws_security_group.gitlab_service.id}"
+  source_security_group_id =  "${aws_security_group.admin_service.id}"
 
   type        = "ingress"
   from_port   = "80"


### PR DESCRIPTION
### Description of change

Also opens up port 80 between the admin application and GitLab for the
API: so the communication doesn't go via the NAT/public internet, and so
we don't have to open up the GitLab load balancer to the address of the
NAT instance.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
