### PR TITLE
(fix) Link to GitLab on visualisations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-19
+
+### Changed
+
+- Fix the link to GitLab shown on the visualisations page if the user has not yet visited GitLab
+
 ## 2020-03-18
 
 ### Added


### PR DESCRIPTION
### Description of change

Data Workspace now has GITLAB_URL set as a private domain to allow it to resolve to a private domain, i.e. gitlab.jupyterhub. This won't work from the public internet.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
