### PR TITLE
Search results guidance

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -53,7 +53,7 @@ class SupportView(FormView):
     form_class = SupportForm
     template_name = 'core/support.html'
 
-    ZENDESK_TAGS = {'data-request': "data_request"}
+    ZENDESK_TAGS = {"data-request": "data_request"}
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -53,6 +53,8 @@ class SupportView(FormView):
     form_class = SupportForm
     template_name = 'core/support.html'
 
+    ZENDESK_TAGS = {'data-request': "data_request"}
+
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data()
         ctx['ticket_id'] = self.kwargs.get('ticket_id')
@@ -65,8 +67,10 @@ class SupportView(FormView):
 
     def form_valid(self, form):
         cleaned = form.cleaned_data
+
+        tag = self.ZENDESK_TAGS.get(self.request.GET.get('tag'))
         ticket_id = create_support_request(
-            self.request.user, cleaned['email'], cleaned['message']
+            self.request.user, cleaned['email'], cleaned['message'], tag=tag
         )
         return HttpResponseRedirect(
             reverse('support-success', kwargs={'ticket_id': ticket_id})

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -74,6 +74,7 @@
     </div>
     {% endfor %}
 
+    {% if datasets.paginator.count %}
     <nav role="navigation" class="govuk-body">
       Displaying datasets {{ datasets.start_index  }}&ndash;{{ datasets.end_index }} of {{ datasets.paginator.count }}
       <ul class="pagination govuk-list">
@@ -106,6 +107,23 @@
         {% endif %}
       </ul>
     </nav>
+    {% endif %}
+
+    <div {% if datasets.paginator.count %}class="govuk-!-margin-top-9"{% endif %}>
+      <p class="govuk-body">
+        {% if datasets.paginator.count %}
+          If you haven't found what you're looking for, please:
+        {% else %}
+          There are no results for your search, please:
+        {% endif %}
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>check the spelling of your keywords</li>
+        <li>use more general keywords</li>
+        <li>select or deselect different filters</li>
+        <li>request data via our <a href="{% url 'support' %}?tag=data-request">feedback and support form</a></li>
+      </ul>
+    </div>
 
   </div>
 </div>

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -112,7 +112,7 @@
     <div {% if datasets.paginator.count %}class="govuk-!-margin-top-9"{% endif %}>
       <p class="govuk-body">
         {% if datasets.paginator.count %}
-          If you haven't found what you're looking for, please:
+          If you haven’t found what you’re looking for, please:
         {% else %}
           There are no results for your search, please:
         {% endif %}
@@ -121,7 +121,7 @@
         <li>check the spelling of your keywords</li>
         <li>use more general keywords</li>
         <li>select or deselect different filters</li>
-        <li>request data via our <a href="{% url 'support' %}?tag=data-request">feedback and support form</a></li>
+        <li>request data via our <a href="{% url 'support' %}?tag=data-request">support and feedback form</a></li>
       </ul>
     </div>
 

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -36,6 +36,42 @@ class TestSupportView(BaseTestCase):
         )
         mock_create_request.assert_called_once()
 
+    @mock.patch('dataworkspace.apps.core.views.create_support_request')
+    def test_create_tagged_support_request(self, mock_create_request):
+        mock_create_request.return_value = 999
+        response = self._authenticated_post(
+            reverse('support') + '?tag=data-request',
+            data={'email': 'noreply@example.com', 'message': 'A test message'},
+            post_format='multipart',
+        )
+        self.assertContains(
+            response,
+            'Your request has been received. Your reference is: '
+            '<strong>999</strong>.',
+            html=True,
+        )
+        mock_create_request.assert_called_once_with(
+            mock.ANY, 'noreply@example.com', 'A test message', tag='data_request'
+        )
+
+    @mock.patch('dataworkspace.apps.core.views.create_support_request')
+    def test_create_tagged_support_request_unknown_tag(self, mock_create_request):
+        mock_create_request.return_value = 999
+        response = self._authenticated_post(
+            reverse('support') + '?tag=invalid-tag',
+            data={'email': 'noreply@example.com', 'message': 'A test message'},
+            post_format='multipart',
+        )
+        self.assertContains(
+            response,
+            'Your request has been received. Your reference is: '
+            '<strong>999</strong>.',
+            html=True,
+        )
+        mock_create_request.assert_called_once_with(
+            mock.ANY, 'noreply@example.com', 'A test message', tag=None
+        )
+
 
 def test_csp_on_files_endpoint_includes_s3(client):
     response = client.get(reverse('files'))

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -124,7 +124,9 @@ def test_find_datasets_combines_results(client):
         },
     ]
 
-    assert b"If you haven't found what you're looking for" in response.content
+    assert "If you haven’t found what you’re looking for" in response.content.decode(
+        response.charset
+    )
 
 
 def test_find_datasets_filters_by_query(client):

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -88,6 +88,15 @@ def test_request_access_form(client, mocker):
     )
 
 
+def test_find_datasets_with_no_results(client):
+    response = client.get(reverse('datasets:find_datasets'), {"q": "search"})
+
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == []
+
+    assert b"There are no results for your search" in response.content
+
+
 def test_find_datasets_combines_results(client):
     factories.DataSetFactory.create(published=False, name='Unpublished search dataset')
     ds = factories.DataSetFactory.create(published=True, name='A search dataset')
@@ -114,6 +123,8 @@ def test_find_datasets_combines_results(client):
             'short_description': rds.short_description,
         },
     ]
+
+    assert b"If you haven't found what you're looking for" in response.content
 
 
 def test_find_datasets_filters_by_query(client):

--- a/dataworkspace/dataworkspace/zendesk.py
+++ b/dataworkspace/dataworkspace/zendesk.py
@@ -115,7 +115,7 @@ def create_zendesk_ticket(
     return ticket_audit.ticket.id
 
 
-def create_support_request(user, email, message):
+def create_support_request(user, email, message, tag=None):
     client = Zenpy(
         subdomain=settings.ZENDESK_SUBDOMAIN,
         email=settings.ZENDESK_EMAIL,
@@ -126,6 +126,7 @@ def create_support_request(user, email, message):
             subject='Data Workspace Support Request',
             description=message,
             requester=User(email=email, name=user.get_full_name()),
+            tags=[tag] if tag else None,
             custom_fields=[
                 CustomField(
                     id=zendesk_service_field_id, value=zendesk_service_field_value


### PR DESCRIPTION
### Description of change

### Search results
<img width="641" alt="image" src="https://user-images.githubusercontent.com/246664/77106801-97b16980-6a17-11ea-87ed-4593ec125b3a.png">

### No results
<img width="644" alt="image" src="https://user-images.githubusercontent.com/246664/77106833-a5ff8580-6a17-11ea-9097-2a5f0ce4cd76.png">


### Add search guidance to the search results page


### Tag search page zendesk tickets with data_request tag

If a support form is filled following a search results "data request" link the resulting Zendesk ticket is tagged with "data_request".

The tag query parameter is checked against a list of allowed tags.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
