### PR TITLE
(fix) Debian mirror (and bump http library)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Version of packages in RStudio image to latest in current Debian mirror
 - Correct mirrors branch to master
+- Fix Debian mirror missing certain files
 
 ## 2020-03-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Version of packages in RStudio image to latest in current Debian mirror
 - Correct mirrors branch to master
 - Fix Debian mirror missing certain files
+- Bump Lowhaio in mirror jobs to avoid error when re-using connections that have closed
 
 ## 2020-03-19
 

--- a/mirrors-sync/Dockerfile
+++ b/mirrors-sync/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 	pip3 install pip==18.01 && \
 	pip3 install \
 		beautifulsoup4==4.7.1 \
-		lowhaio==0.0.86 \
+		lowhaio==0.0.87 \
 		lowhaio_redirect==0.0.1
 
 COPY mirrors-sync.py /


### PR DESCRIPTION
### Description of change

It was skipping _all_ files that already existed, so the index files weren't being updated.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
