### PR TITLE
(feat) Page per visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update the architecture to include GitLab
 
+## 2020-03-21
+
+### Changed
+
+- Page per visualisation
+
 ## 2020-03-20
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/gitlab.py
+++ b/dataworkspace/dataworkspace/apps/applications/gitlab.py
@@ -12,12 +12,17 @@ SUCCESS_PIPELINE_STATUSES = ('success',)
 
 
 def gitlab_api_v4(method, path, params=()):
-    return requests.request(
+    return gitlab_api_v4_with_status(method, path, params)[0]
+
+
+def gitlab_api_v4_with_status(method, path, params=()):
+    response = requests.request(
         method,
         f'{settings.GITLAB_URL}api/v4/{path}',
         params=params,
         headers={'PRIVATE-TOKEN': settings.GITLAB_TOKEN},
-    ).json()
+    )
+    return response.json(), response.status_code
 
 
 def gitlab_api_v4_ecr_pipeline_trigger(

--- a/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
+++ b/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
@@ -1,6 +1,16 @@
 from django.urls import path
 
 from dataworkspace.apps.accounts.utils import login_required
-from dataworkspace.apps.applications.views import visualisations_html_view
+from dataworkspace.apps.applications.views import (
+    visualisations_html_view,
+    visualisation_branch_html_view,
+)
 
-urlpatterns = [path('', login_required(visualisations_html_view), name='root')]
+urlpatterns = [
+    path('', login_required(visualisations_html_view), name='root'),
+    path(
+        '<str:gitlab_project_id>/<str:branch_name>',
+        login_required(visualisation_branch_html_view),
+        name='branch',
+    ),
+]

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -132,7 +132,7 @@
 
     {% block breadcrumbs %}{% endblock %}
 
-    <main class="govuk-main-wrapper" id="main-content" role="main">
+    <main class="govuk-main-wrapper {% block main-wrapper-class %}{% endblock %}" id="main-content" role="main">
       {% for message in messages %}
       <div class="govuk-panel govuk-panel--confirmation govuk-panel--confirmation--left govuk-!-padding-5 govuk-!-margin-bottom-7">
         <h1 class="govuk-panel__title govuk-!-font-size-27">

--- a/dataworkspace/dataworkspace/templates/visualisation_branch.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_branch.html
@@ -1,0 +1,142 @@
+{% extends '_base.html' %}
+{% load static %}
+{% load core_tags %}
+
+{% block page_title %}Visualisations - {{ block.super }}{% endblock %}
+
+{% block head %}
+  {{ block.super }}
+  <style>
+    .branch-icon-small {
+        display: inline-block;
+        height: 16px;
+        width: 16px;
+        position: relative;
+        top: 2px;
+    }
+    .branch-icon-large {
+        display: inline-block;
+        height: 24px;
+        width: 24px;
+        position: relative;
+        top: 2px;
+    }
+    @media (min-width: 40.0625em) {
+        .branch-icon-large {
+            height: 30px;
+            width: 30px;
+        }
+    }
+    .nav {
+        margin-left: 14px;
+    }
+    @media (min-width: 40.0625em) {
+        .nav {
+            margin-left: 0;
+        }
+    }
+    .nav-item--current {
+        margin-left: -14px;
+        padding-left: 10px;
+        border-left: 4px solid #1d70b8;
+    }
+    .nav-item-link:link,
+    .subnav-item-link:link {
+        text-decoration: none;
+    }
+    .nav-item-link--current,
+    .subnav-item-link--current {
+        font-weight: bold;
+    }
+    .underline-on-hover--parent:hover > .underline-on-hover {
+        text-decoration: underline;
+    }
+    .underline-on-hover--parent:active > .underline-on-hover,
+    .underline-on-hover--parent:focus > .underline-on-hover {
+        text-decoration: none;
+    }
+    .commit {
+        background: #f3f2f1;
+        border: 1px solid #b1b4b6;
+    }
+  </style>
+{% endblock %}
+
+{# The two-column layout has a touch too much vertical space #}
+{% block main-wrapper-class %}govuk-!-padding-top-5{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="/">Home</a>
+            </li>
+
+            <li class="govuk-breadcrumbs__list-item">
+               <a class="govuk-breadcrumbs__link" href="{% url 'visualisations:root' %}">Visualisations</a>
+            </li>
+
+            <li class="govuk-breadcrumbs__list-item">
+                {{ gitlab_project.name }}
+            </li>
+
+            <!-- The lack of the name of the specific page under the visualisation name here is
+                 deliberate. It is clear from multiple other elements -->
+        </ol>
+    </div>
+{% endblock %}
+
+{% block inner_content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+        <nav>
+            <ul class="govuk-list nav govuk-!-font-size-18 govuk-!-margin-bottom-8">
+                <li class="nav-item nav-item--current">
+                    <a href="{% url 'visualisations:branch' gitlab_project.id gitlab_project.default_branch %}" class="govuk-link govuk-link--no-visited-state nav-item-link nav-item-link--current underline-on-hover--parent">
+                        <span class="underline-on-hover">Branches</span>
+                    </a>
+                    <ul class="govuk-list subnav govuk-!-font-size-16">
+                        {% for branch in branches %}
+                            <li class="subnab-item">
+                                <a href="{% url 'visualisations:branch' gitlab_project.id branch.name %}" class="govuk-link govuk-link--no-visited-state subnav-item-link {% if current_branch.name == branch.name %}subnav-item-link--current{% endif %} underline-on-hover--parent">
+                                    <svg class="branch-icon-small" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg> <span class="underline-on-hover">{{ branch.name }}</span>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </li>
+            </ul>
+        </nav>
+    </div>
+
+    <div class="govuk-grid-column-three-quarters">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
+            <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
+            <svg class="branch-icon-large" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg> {{ current_branch.name }}
+        </h1>
+
+        <section class="commit govuk-!-padding-5">
+            <h2 class="govuk-heading-m">Latest commit: {{ latest_commit.short_id }}</h2>
+
+            <p class="govuk-body">
+                {{ latest_commit.title }}<br>
+                {{ latest_commit.author_name }} authored on {{ latest_commit_date }}<br>
+            </p>
+
+            <ul class="govuk-list govuk-!-margin-bottom-0 govuk-!-font-size-16">
+                <li>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ latest_commit_link }}">
+                        View<span class="govuk-visually-hidden"> latest</span> commit<span class="govuk-visually-hidden">{{ latest_commit.short_id }}</span> in GitLab
+                    </a>
+                </li>
+                <li class="govuk-!-margin-bottom-0">
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ latest_commit_preview_link }}">
+                        Preview visualisation<span class="govuk-visually-hidden"> at<span class="govuk-visually-hidden"> latest</span> commit {{ latest_commit.short_id }}</span>
+                    </a>
+                </li>
+            </ul>
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -4,31 +4,6 @@
 
 {% block page_title %}Visualisations - {{ block.super }}{% endblock %}
 
-{% block head %}
-  {{ block.super }}
-  <style>
-    .branch-icon {
-        display: inline-block;
-        height: 18px;
-        width: 18px;
-        position: relative;
-        top: 2px;
-    }
-    .key-link--plain:link,
-    .key-link--plain:visited {
-        text-decoration: none;
-        color: #0b0c0c;
-    }
-    .key-link--plain:hover .underline-on-hover {
-        text-decoration: underline;
-    }
-    .key-link--plain:active .underline-on-hover,
-    .key-link--plain:focus .underline-on-hover {
-        text-decoration: none;
-    }
-  </style>
-{% endblock %}
-
 {% block breadcrumbs %}
     <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
@@ -44,48 +19,49 @@
 {% endblock %}
 
 {% block inner_content %}
-    <h1 class="govuk-heading-l">Visualisations</h1>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Visualisations</h1>
 
-    {% if not has_gitlab_user %}
-    <div class="govuk-inset-text">
-        <p class="govuk-body">It looks like GitLab does not have a user record for you. Please <a href="{{ gitlab_url }}" class="govuk-link">visit GitLab</a>, which will create one automatically. Then return to this page.</p>
-    </div>
-    {% endif %}
-
-    {% if has_gitlab_user and not projects %}
-        <p class="govuk-body">You do not have access to any visualisations in GitLab. If you think you should have access, please <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Support Team</a>.</p>
-    {% endif %}
-
-    {% for project in projects %}
-        <h2 class="govuk-heading-m">{{ project.name }}</h2>
-
-        {% if is_project_developer|get_key:project.id %}
-        <p class="govuk-body">You have developer privileges on {{ project.name }}.</p>
+        {% if not has_gitlab_user %}
+        <div class="govuk-inset-text">
+            <p class="govuk-body">It looks like GitLab does not have a user record for you. Please <a href="{{ gitlab_url }}" class="govuk-link">visit GitLab</a>, which will create one automatically. Then return to this page.</p>
+        </div>
         {% endif %}
 
-        <dl class="govuk-summary-list">
-        {% for branch in project_branches|get_key:project.id %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">
-                    <a class="govuk-link govuk-link--no-visited-state key-link--plain" href="{{ project.web_url }}/tree/{{ branch.name }}">
-                        <!-- Icons provided by Font Awesome https://fontawesome.com/license */ -->
-                        <svg class="branch-icon" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg>
-                        <span class="underline-on-hover">{{ branch.name }}</span>
-                    </a>
-                </dt>
-                </a>
-                <dd class="govuk-summary-list__value">
-                    <a class="govuk-link govuk-link--no-visited-state" href="{{ project.web_url }}/commit/{{ branch.commit.id }}">{{ branch.commit.title }} ({{ branch.commit.short_id }})</a>
-                </dd>
-                {% with preview_link=project_branches_preview_links|get_key:project.id|get_key:branch.name %}
-                    {% if preview_link %}
-                    <dd class="govuk-summary-list__actions">
-                        <a class="govuk-link govuk-link--no-visited-state" href="{{ preview_link }}">Preview</a>
-                    </dd>
-                    {% endif %}
-                {% endwith %}
-            </div>
+        {% if has_gitlab_user and not projects %}
+            <p class="govuk-body">You do not have access to any visualisations in GitLab. If you think you should have access, please <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Support Team</a>.</p>
+        {% endif %}
+
+        {% for project in projects %}
+        <section>
+            <h2 class="govuk-heading-m">{{ project.gitlab_project.name }}</h2>
+
+            {% if project.gitlab_project.description %}
+                <p class="govuk-body">{{ project.gitlab_project.description }}</p>
+            {% endif %}
+
+            <ul class="govuk-list">
+                {% if project.manage_link %}
+                <li>
+                    <a class="govuk-link" href="#"><a class="govuk-link govuk-link--no-visited-state" href="{{ project.manage_link }}">Manage<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span></a></a>
+                </li>
+                {% endif %}
+                <li>
+                    <a class="govuk-link govuk-link--no-visited-state" href="{{ project.gitlab_project.web_url }}">View<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span> source in GitLab</a>
+                </li>
+                {% if project.view_link %}
+                <li>
+                    <a class="govuk-link" href="#"><a class="govuk-link govuk-link--no-visited-state" href="{{ project.view_link }}">View<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span> production visualisation</a></a>
+                </li>
+                {% endif %}
+            </ul>
+
+            {% if not forloop.last %}
+                <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+            {% endif %}
+        </section>
         {% endfor %}
-        </dl>
-    {% endfor %}
+    </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
### Description of change

The page to navigate visualisations: (When to show what links, and what to do if they can't be shown, is still being decided. Also would like something more descriptive than "Manage", but can't seem to think of anything that isn't really clunky)


<img width="1151" alt="Screenshot 2020-03-22 at 10 01 13" src="https://user-images.githubusercontent.com/13877/77246955-33afc080-6c24-11ea-88b9-ee672330ff09.png">

The manage visualisation page itself:

<img width="1149" alt="Screenshot 2020-03-22 at 10 01 01" src="https://user-images.githubusercontent.com/13877/77246960-42967300-6c24-11ea-9cff-f0be0a645c0e.png">

The side `nav` at the moment is in the `main` element of the page. To change this, it will need a more hefty change to the base template, so leaving that until later.

The commit ID does have quite a bit of prominence. This is a bit... technical/meaningless, and so it change later, but for now, it's in 3 places (in addition to GitLab)

- In the visualisation management page
- The starting page when starting a preview visualisations by ID
- The URL of the preview visualisation (in the host name)

Not quite sure what's best regarding the prominence of the commit ID. An alternative would be the commit message, time, and author. However, if this is done, I suspect should be both on the application loading screen and the visualisation management page. A small concern is that commit messages can often just be similarly meaningless like "fix bug" (especially for new devs, which essentially are the target of this). Leaving this until later for now.

Another oddity/thing to be sorted is the "Branches" link in the side menu. For now, it goes to the first branch, which is the default branch. Not sure what's best here, but treating it as an "it will do for now" item.

The use of the "branch" icon is deliberate:

- A branch name is always prefixed by the branch icon, to try to make it clearer that it is a branch rather than something else (even if the icon isn't immediately recognised as "branch" for new users, I hope it will be after a bit of use... and ultimately, these pages are for frequent use, so I think we can optimise a bit for that)
- Also, to tie in the UI with elements from GitLab (and GitHub), which uses a similar icon

(I toyed with a commit icon for similar reasons, but for me at least, the commit icon has less meaning than the branch icon, and somehow felt less useful)

(Obviously all can be changed from feedback etc, since so much of the design is just based on my intuition)

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
