### PR TITLE
(fix) 'Skip to main content' link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-24
+
+### Changed
+
+- Fix the "Skip to main content" link: it would always link to the home page
+
 ## 2020-03-23
 
 - Fix Google Data Studio link

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -67,7 +67,7 @@
     document.body.className = document.body.className + ' js-enabled';
   </script>
 
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+  <a href="{{ request.path }}#main-content" class="govuk-skip-link">Skip to main content</a>
   <header class="govuk-header" role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logotype">


### PR DESCRIPTION
### Description of change

The base href is set to `/` on the root domain, partially to make links on the spawning and error pages, which are on other domains, work as expected. However, this means that links with just a #fragment will always go to the #fragment on the root path of the root domain, unless prefixed by the path of the current page.

![out](https://user-images.githubusercontent.com/13877/77414054-4c50df80-6db8-11ea-848a-81be13b85fa2.gif)


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
