### PR TITLE
Update the number of rows shown in  preview panel for a ref dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fix the "Skip to main content" link: it would always link to the home page
+- Update the number of rows shown in the preview panel on a reference dataset to 1000
 
 ## 2020-03-23
 

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -282,9 +282,7 @@ FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 
 SEARCH_RESULTS_DATASETS_PER_PAGE = 7
 
-REFERENCE_DATASET_PREVIEW_NUM_OF_ROWS = int(
-    env.get('REFERENCE_DATASET_PREVIEW_NUM_OF_ROWS', 100)
-)
+REFERENCE_DATASET_PREVIEW_NUM_OF_ROWS = 1000
 
 # We explicitly allow some environments to not have a connection to GitLab
 GITLAB_URL = env.get('GITLAB_URL')


### PR DESCRIPTION
### Description of change
This change updates the preview panel on ref datasets to show 1000 rows. 
This is because the feedback we have had from users is that they don't understand the panel is a preview and expect to see the full dataset. Setting the value to 1000 will be greater than any current ref dataset so will in turn end up showing the full dataset. 



### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
