### PR TITLE
Use gunicorn for local dev server

### DIFF
--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 
@@ -97,6 +98,11 @@ urlpatterns = [
     ),
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+
+    urlpatterns += staticfiles_urlpatterns()
 
 handler403 = public_error_403_html_view
 handler404 = public_error_404_html_view

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -27,7 +27,7 @@ services:
 
           echo "Starting proxy and django dev server"
           parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \
-              "django-admin runserver 8002" \
+              "gunicorn dataworkspace.wsgi:application -c dataworkspace/gunicorn_config.py --reload" \
               "PROXY_PORT=8000 UPSTREAM_ROOT=http://localhost:8002 python3 -m proxy"
       )
       EOF'


### PR DESCRIPTION
### Description of change

We were using Django test server when running Data Workspace locally,
but it has some differences in how it behaves compared to production,
for example in the way it handles interrupted chunked responses for
data downloads (gunicorn correctly fails the response while Django
doesn't).

To save some time debugging these in the future this switches dev
server to use gunicorn with auto-reload. This should behave the
same way django test server does when python/html or asset files
are changed on disk.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
