### PR TITLE
Upgdrade JupyterLab (Python, R) to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Allow Google Data Studio to fetch from unpublished datasets [they each still have to be individually enabled for Google Data Studio access]
+- Upgrade JupyterLab images to v2.0.0.
+- Fix the custom JupyterLab database-connector plugin to work in v2.0.0.
 
 ## 2020-03-24
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -92,7 +92,7 @@ async def async_main():
             "font-src 'self' data:;"
             "form-action 'self';"
             "frame-ancestors 'self';"
-            "img-src 'self' data:;"
+            "img-src 'self' data: blob:;"
             # Both JupyterLab and RStudio need `unsafe-eval`
             "script-src 'unsafe-inline' 'unsafe-eval' 'self';"
             "style-src 'unsafe-inline' 'self';"

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -42,20 +42,20 @@ RUN \
     apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
     apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
         build-essential=12.6 \
-        git=1:2.20.1-2 \
-        git-man=1:2.20.1-2 \
+        git=1:2.20.1-2+deb10u1 \
+        git-man=1:2.20.1-2+deb10u1 \
         man-db=2.8.5-2 \
         openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
         texlive-generic-extra=2018.20190227-2 \
         texlive-fonts-recommended=2018.20190227-2 \
         wget=1.20.1-1.1 \
-        sudo=1.8.27-1+deb10u1 && \
+        sudo=1.8.27-1+deb10u2 && \
     groupadd -g 4356 jovyan && \
     useradd -u 4357 jovyan -g jovyan -m && \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O miniconda.sh && \
-    echo "e1045ee415162f944b6aebfe560b8fee  miniconda.sh" | md5sum -c && \
+    wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh && \
+    echo "87e77f097f6ebb5127c77662dfc3165e  miniconda.sh" | md5sum -c && \
     mkdir -p "$CONDA_DIR" && \
     bash miniconda.sh -f -b -p "$CONDA_DIR" && \
     rm miniconda.sh && \
@@ -68,7 +68,7 @@ RUN \
     echo 'show_channel_urls: true' >> /opt/conda/.condarc && \
     conda install \
         'bokeh=0.13.0' \
-        'conda=4.5.11' \
+        'conda=4.8.2' \
         'font-ttf-dejavu-sans-mono==2.37' \
         'gensim=3.5.0' \
         'ipympl=0.2.1' \
@@ -92,7 +92,7 @@ RUN \
         'tornado=5.1.1' \
         'xorg-libxext=1.3.3' \
         'xorg-libxrender=0.9.10' && \
-    conda clean -tipsy && \
+    conda clean -tipy && \
     pip install \
         pip==20.0.2 && \
     pip install \

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -75,7 +75,7 @@ RUN \
         'ipython-sql=0.3.9' \
         'ipython=6.5.0' \
         'ipywidgets=7.4.2' \
-        'jupyterlab=0.35.5' \
+        'jupyterlab=1.2.0' \
         'matplotlib=3.0.0' \
         'nltk=3.3.0' \
         'nodejs=11.14.0' \
@@ -122,7 +122,7 @@ RUN \
     jupyter labextension install \
         /jupyterlab_database_access \
         /jupyterlab_template_notebooks/browser \
-        @jupyter-widgets/jupyterlab-manager@0.38 \
+        @jupyter-widgets/jupyterlab-manager@1.1 \
         jupyter-matplotlib@0.3.0 && \
     npm cache clean --force && \
     node /opt/conda/lib/python3.7/site-packages/jupyterlab/staging/yarn.js cache clean && \

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -71,12 +71,12 @@ RUN \
         'conda=4.8.2' \
         'font-ttf-dejavu-sans-mono==2.37' \
         'gensim=3.5.0' \
-        'ipympl=0.2.1' \
+        'ipympl=0.5.6' \
         'ipython-sql=0.3.9' \
         'ipython=6.5.0' \
-        'ipywidgets=7.4.2' \
-        'jupyterlab=1.2.0' \
-        'matplotlib=3.0.0' \
+        'ipywidgets=7.5.1' \
+        'jupyterlab=2.0.0' \
+        'matplotlib=3.2.1' \
         'nltk=3.3.0' \
         'nodejs=11.14.0' \
         'notebook=5.7.8' \
@@ -122,8 +122,7 @@ RUN \
     jupyter labextension install \
         /jupyterlab_database_access \
         /jupyterlab_template_notebooks/browser \
-        @jupyter-widgets/jupyterlab-manager@1.1 \
-        jupyter-matplotlib@0.3.0 && \
+        @jupyter-widgets/jupyterlab-manager@2.0 && \
     npm cache clean --force && \
     node /opt/conda/lib/python3.7/site-packages/jupyterlab/staging/yarn.js cache clean && \
     echo '[global]' > /etc/pip.conf && \

--- a/jupyterlab-python/jupyterlab_database_access/package.json
+++ b/jupyterlab-python/jupyterlab_database_access/package.json
@@ -1,10 +1,14 @@
 {
   "private": true,
   "name": "jupyterlab_database_access",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Buttons to inject code into the notebook to connect to databases",
   "author": "Department for International Trade",
   "main": "plugin.js",
+  "files": [
+    "plugin.js",
+    "styles.css"
+  ],
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -14,6 +18,10 @@
     "extension": true
   },
   "scripts": {},
-  "dependencies": {},
+  "dependencies": {
+    "@lumino/disposable": "^1.2.0",
+    "@jupyterlab/apputils": "^2.0.0",
+    "@jupyterlab/notebook": "^2.0.0"
+  },
   "devDependencies": {}
 }

--- a/jupyterlab-python/jupyterlab_database_access/plugin.js
+++ b/jupyterlab-python/jupyterlab_database_access/plugin.js
@@ -1,6 +1,6 @@
 import {
   DisposableDelegate
-} from '@phosphor/disposable';
+} from '@lumino/disposable';
 
 import {
   ToolbarButton
@@ -9,6 +9,8 @@ import {
 import {
   NotebookActions
 } from '@jupyterlab/notebook';
+
+require('./styles.css');
 
 export default {
   activate: (app) => {
@@ -32,13 +34,13 @@ class ButtonExtension {
         }
       });
       model.cells.insert(notebook.activeCellIndex, cell);
-      notebook.activeCellIndex--;
+      notebook.activeCellIndex -= 1;
       notebook.widgets[notebook.activeCellIndex].inputHidden = true;
-      NotebookActions.runAndAdvance(notebook, context.session);
+      NotebookActions.runAndAdvance(notebook, context.sessionContext);
       cell.inputHidden = true;
     };
     const button = new ToolbarButton({
-      iconClassName: 'fa fa-database',
+      iconClass: 'fa fa-database data-workspace-access-database-button',
       onClick: onClick,
       tooltip: 'Connect to databases'
     });

--- a/jupyterlab-python/jupyterlab_database_access/styles.css
+++ b/jupyterlab-python/jupyterlab_database_access/styles.css
@@ -1,0 +1,3 @@
+.data-workspace-access-database-button {
+    color: black !important;
+}

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -78,7 +78,7 @@ RUN \
     conda install \
         'conda=4.8.2' \
         'font-ttf-dejavu-sans-mono==2.37' \
-        'jupyterlab=1.2.0' \
+        'jupyterlab=2.0.0' \
         'nodejs=11.14.0' \
         'notebook=5.7.8' \
         'openssl=1.0.2p' \

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -43,8 +43,8 @@ RUN \
     apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
         build-essential=12.6 \
         gfortran=4:8.3.0-1 \
-        git=1:2.20.1-2 \
-        git-man=1:2.20.1-2 \
+        git=1:2.20.1-2+deb10u1 \
+        git-man=1:2.20.1-2+deb10u1 \
         man-db=2.8.5-2 \
         openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
@@ -52,7 +52,7 @@ RUN \
         texlive-fonts-recommended=2018.20190227-2 \
         wget=1.20.1-1.1 \
         r-cran-tidyverse=1.2.1-1 \
-        sudo=1.8.27-1+deb10u1 \
+        sudo=1.8.27-1+deb10u2 \
         ca-certificates && \
     apt-get clean -y && \
         apt-get autoremove -y && \
@@ -62,8 +62,8 @@ RUN \
     groupadd -g 4356 jovyan && \
     useradd -u 4357 jovyan -g jovyan -m && \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
-    wget http://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh -O miniconda.sh && \
-    echo "e1045ee415162f944b6aebfe560b8fee  miniconda.sh" | md5sum -c && \
+    wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh && \
+    echo "87e77f097f6ebb5127c77662dfc3165e  miniconda.sh" | md5sum -c && \
     mkdir -p "$CONDA_DIR" && \
     bash miniconda.sh -f -b -p "$CONDA_DIR" && \
     rm miniconda.sh && \
@@ -76,7 +76,7 @@ RUN \
     echo 'always_yes: true' >> /opt/conda/.condarc && \
     echo 'show_channel_urls: true' >> /opt/conda/.condarc && \
     conda install \
-        'conda=4.5.11' \
+        'conda=4.8.2' \
         'font-ttf-dejavu-sans-mono==2.37' \
         'jupyterlab=0.35.5' \
         'nodejs=11.14.0' \
@@ -100,7 +100,7 @@ RUN \
         'xorg-libxrender=0.9.10' && \
     jupyter kernelspec uninstall python3 -f && \
     rm -r -f /opt/conda/lib/python3.7/site-packages/ipykernel && \
-    conda clean -tipsy && \
+    conda clean -tipy && \
     chown -R jovyan $CONDA_DIR  && \
     pip install \
         pip==20.0.2 && \

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -78,7 +78,7 @@ RUN \
     conda install \
         'conda=4.8.2' \
         'font-ttf-dejavu-sans-mono==2.37' \
-        'jupyterlab=0.35.5' \
+        'jupyterlab=1.2.0' \
         'nodejs=11.14.0' \
         'notebook=5.7.8' \
         'openssl=1.0.2p' \

--- a/jupyterlab-r/jupyterlab_database_access/package.json
+++ b/jupyterlab-r/jupyterlab_database_access/package.json
@@ -1,10 +1,14 @@
 {
   "private": true,
   "name": "jupyterlab_database_access",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Buttons to inject code into the notebook to connect to databases",
   "author": "Department for International Trade",
   "main": "plugin.js",
+  "files": [
+    "plugin.js",
+    "styles.css"
+  ],
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -14,6 +18,10 @@
     "extension": true
   },
   "scripts": {},
-  "dependencies": {},
+  "dependencies": {
+    "@lumino/disposable": "^1.2.0",
+    "@jupyterlab/apputils": "^2.0.0",
+    "@jupyterlab/notebook": "^2.0.0"
+  },
   "devDependencies": {}
 }

--- a/jupyterlab-r/jupyterlab_database_access/plugin.js
+++ b/jupyterlab-r/jupyterlab_database_access/plugin.js
@@ -1,6 +1,6 @@
 import {
   DisposableDelegate
-} from '@phosphor/disposable';
+} from '@lumino/disposable';
 
 import {
   ToolbarButton
@@ -9,6 +9,8 @@ import {
 import {
   NotebookActions
 } from '@jupyterlab/notebook';
+
+require('./styles.css');
 
 export default {
   activate: (app) => {
@@ -32,13 +34,13 @@ class ButtonExtension {
         }
       });
       model.cells.insert(notebook.activeCellIndex, cell);
-      notebook.activeCellIndex--;
+      notebook.activeCellIndex -= 1;
       notebook.widgets[notebook.activeCellIndex].inputHidden = true;
-      NotebookActions.runAndAdvance(notebook, context.session);
+      NotebookActions.runAndAdvance(notebook, context.sessionContext);
       cell.inputHidden = true;
     };
     const button = new ToolbarButton({
-      iconClassName: 'fa fa-database',
+      iconClass: 'fa fa-database data-workspace-access-database-button',
       onClick: onClick,
       tooltip: 'Connect to databases'
     });

--- a/jupyterlab-r/jupyterlab_database_access/styles.css
+++ b/jupyterlab-r/jupyterlab_database_access/styles.css
@@ -1,0 +1,3 @@
+.data-workspace-access-database-button {
+    color: black !important;
+}


### PR DESCRIPTION
### Description of change
Upgrade to JupyterLab 2.0.0

Notes:
* We update git/git-man/sudo apt packages as the old ones are no longer available, looks like removed due to vulnerabilities.
* Remove `-s` option from `conda clean` as it's been deprecated. Not replaced it with anything as it's there to clean up source files from the image build, but the new process is `conda build --clean-sources`, which isn't available by default, i.e. requires installing a new package. Doesn't feel necessary to do.
* We allow `blob:` in img-src for CSP as it seems matplotlib now manages these as blobs rather than as `data:`.
* Add custom styling to the database access button for the JupyterLab plugin. As part of the upgrade, icons were reworked and it became transparent due to jupyterlab styling. This style simply overrides it and sets the icon colour to black again. A bit of a hack, but didn't feel worth spending much more time on it.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
