### PR TITLE
(feat) Allow Data Studio access to unpublished data sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-03-26
+
+### Changed
+
+- Allow Google Data Studio to fetch from unpublished datasets [they each still have to be individually enabled for Google Data Studio access]
+
 ## 2020-03-24
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -295,8 +295,7 @@ def can_access_table_by_google_data_studio(user, table_id):
     has_source_table_perms = (
         DataSet.objects.live()
         .filter(
-            Q(published=True)
-            & Q(sourcetable=sourcetable)
+            Q(sourcetable=sourcetable)
             & (
                 Q(user_access_type='REQUIRES_AUTHENTICATION')
                 | Q(datasetuserpermission__user=user)
@@ -422,7 +421,7 @@ def streaming_query_response(user_email, database, query, filename):
             # need to create a separate one to set a timeout on the current
             # connection
             with conn.cursor() as _cur:
-                _cur.execute("SET statement_timeout={0}".format(query_timeout))
+                _cur.execute('SET statement_timeout={0}'.format(query_timeout))
 
             cur.itersize = batch_size
             cur.arraysize = batch_size


### PR DESCRIPTION
### Description of change

They each still have to be individually enabled for Google Data Studio access


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
