### PR TITLE
Explicitly pass updated_date to ReferenceDataset records.update()

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -897,7 +897,7 @@ class ReferenceDataset(DeletableTimestampedUserModel):
             record = self.get_record_model_class().objects.create(**form_data)
         else:
             records = self.get_records().filter(id=internal_id)
-            records.update(**form_data)
+            records.update(**form_data, updated_date=timezone.now())
             record = records.first()
         self.increment_minor_version()
         if sync_externally and self.external_database is not None:


### PR DESCRIPTION
### Description of change

Updating an existing record in a ReferenceDataset does not change the last updated column on the data links table.

This is because when using QuerySet.update(), DateTime fields with auto_now are not updated to the current time and therefore this field needs to be passed explicitly as a keyword argument. See https://code.djangoproject.com/ticket/26239

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
