### PR TITLE
(tests) Make integration tests faster and a touch less flakey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-01
+
+## Changed
+
+- Some of the fixed-length sleeps in the integration tests to polling the healthcheck endpoint until it returns non-error response.
+
 ## 2020-03-30
 
 ### Added


### PR DESCRIPTION
### Description of change

Done by converting the fixed-length sleeps to polling the healthcheck endpoint until it returns a success response.

There are still some sleeps waiting for tools/visualisations to load, but leaving them until later.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
