### PR TITLE
(feat) Bump timeout for visualisation build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - New API endpoint listing eventlog entries at `/api/v1/eventlog/events`
 
+### Changed
+
+- The timeout for a visualisation build to complete to 30 minutes
+
 ## 2020-03-27
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -343,7 +343,7 @@ class FargateSpawner:
             cluster_name = spawner_options['CLUSTER_NAME']
 
             now = datetime.datetime.now()
-            fifteen_minutes_ago = now - datetime.timedelta(minutes=15)
+            thirty_minutes_ago = now - datetime.timedelta(minutes=30)
             three_minutes_ago = now - datetime.timedelta(minutes=3)
             twenty_seconds_ago = now - datetime.timedelta(seconds=20)
 
@@ -362,7 +362,7 @@ class FargateSpawner:
                 pipeline_status = pipeline['status']
                 if (
                     pipeline_status in RUNNING_PIPELINE_STATUSES
-                    and created_date > fifteen_minutes_ago
+                    and created_date > thirty_minutes_ago
                 ):
                     return 'RUNNING'
                 if pipeline_status not in SUCCESS_PIPELINE_STATUSES:


### PR DESCRIPTION
### Description of change

Some of them compile lots of R packages. Suspect will still need some nicer way to abort builds, but leaving that until later.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
