### PR TITLE
(feat) Handle long branch names a bit better, style-wise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Changed
 
 - Some of the fixed-length sleeps in the integration tests to polling the healthcheck endpoint until it returns non-error response.
+- Styles in the visualisation page to better display long branch names
 
 ## 2020-03-30
 

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -40,6 +40,11 @@
         padding-left: 10px;
         border-left: 4px solid #1d70b8;
     }
+    .subnav-item {
+        /* Only makes a difference for long branch names that wrap to the next line */
+        text-indent: -19px;
+        padding-left: 19px;
+    }
     .nav-item-link:link,
     .subnav-item-link:link {
         text-decoration: none;


### PR DESCRIPTION
### Description of change
From:

<img width="276" alt="Screenshot 2020-04-01 at 15 25 25" src="https://user-images.githubusercontent.com/13877/78149784-4dc07e80-742e-11ea-8153-fa9a333abc6c.png">

to:

<img width="274" alt="Screenshot 2020-04-01 at 15 37 52" src="https://user-images.githubusercontent.com/13877/78150159-d0493e00-742e-11ea-8437-62da23e2f96e.png">


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
