### PR TITLE
(feat) Move link to production visualisation to master branch page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-04-01
 
-## Changed
+### Changed
 
 - Some of the fixed-length sleeps in the integration tests to polling the healthcheck endpoint until it returns non-error response.
 - Styles in the visualisation page to better display long branch names
+- A production section in the master branch of a visualisation page
 
 ## 2020-03-30
 

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -244,19 +244,8 @@ def visualisations_html_GET(request):
             )
         return None
 
-    def view_link(gitlab_project):
-        try:
-            host_exact = application_templates[gitlab_project['id']].host_exact
-        except KeyError:
-            return None
-        return f'{request.scheme}://{host_exact}.{settings.APPLICATION_ROOT_DOMAIN}/'
-
     projects = [
-        {
-            'gitlab_project': gitlab_project,
-            'manage_link': manage_link(gitlab_project),
-            'view_link': view_link(gitlab_project),
-        }
+        {'gitlab_project': gitlab_project, 'manage_link': manage_link(gitlab_project)}
         for gitlab_project in gitlab_projects
     ]
 
@@ -306,6 +295,11 @@ def visualisation_branch_html_GET(request, gitlab_project_id, branch_name):
         latest_commit['committed_date'], '%Y-%m-%dT%H:%M:%S.%f%z'
     )
 
+    host_exact = application_template.host_exact
+    production_link = (
+        f'{request.scheme}://{host_exact}.{settings.APPLICATION_ROOT_DOMAIN}/'
+    )
+
     return _render_visualisation(
         request,
         'visualisation_branch.html',
@@ -313,6 +307,7 @@ def visualisation_branch_html_GET(request, gitlab_project_id, branch_name):
         branches,
         current_menu_item='branches',
         template_specific_context={
+            'production_link': production_link,
             'current_branch': current_branch,
             'latest_commit': latest_commit,
             'latest_commit_link': latest_commit_link,

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -60,7 +60,8 @@
     .underline-on-hover--parent:focus > .underline-on-hover {
         text-decoration: none;
     }
-    .commit {
+    .commit,
+    .production {
         background: #f3f2f1;
         border: 1px solid #b1b4b6;
     }

--- a/dataworkspace/dataworkspace/templates/visualisation_branch.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_branch.html
@@ -6,6 +6,18 @@
     <svg class="branch-icon-large" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg> {{ current_branch.name }}
 </h1>
 
+{% if current_branch.name == gitlab_project.default_branch %}
+<section class="production govuk-!-padding-5 govuk-!-margin-bottom-5">
+    <h2 class="govuk-heading-m govuk-heading-production">Production</h2>
+
+    <ul class="govuk-list govuk-!-margin-bottom-0 govuk-!-font-size-16">
+        <li class="govuk-!-margin-bottom-0">
+            <a class="govuk-link" href="#"><a class="govuk-link govuk-link--no-visited-state" href="{{ production_link }}">View<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span> production visualisation</a>
+        </li>
+    </ul>
+</section>
+{% endif %}
+
 <section class="commit govuk-!-padding-5">
     <h2 class="govuk-heading-m">Latest commit: {{ latest_commit.short_id }}</h2>
 

--- a/dataworkspace/dataworkspace/templates/visualisations.html
+++ b/dataworkspace/dataworkspace/templates/visualisations.html
@@ -50,11 +50,6 @@
                 <li>
                     <a class="govuk-link govuk-link--no-visited-state" href="{{ project.gitlab_project.web_url }}">View<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span> source in GitLab</a>
                 </li>
-                {% if project.view_link %}
-                <li>
-                    <a class="govuk-link" href="#"><a class="govuk-link govuk-link--no-visited-state" href="{{ project.view_link }}">View<span class="govuk-visually-hidden"> {{ project.gitlab_project.name }}</span> production visualisation</a></a>
-                </li>
-                {% endif %}
             </ul>
 
             {% if not forloop.last %}


### PR DESCRIPTION
### Description of change

I've already found it a bit annoying having to flit back and forth. It does look a bit bland/empty right now, but more will go in it later.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
