### PR TITLE
Add tools page for non-tool-authorised users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-02
+
+## Added
+
+- A tools page for users who don't have access to tools, telling them what it is and how to get access.
+
 ## 2020-04-01
 
 ## Changed

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -110,9 +110,14 @@ def tools_html_GET(request):
         app = application_template.host_exact
         return f'{request.scheme}://{app}-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/'
 
+    has_any_tool_perms = request.user.has_perm(
+        "applications.start_all_applications"
+    ) or request.user.has_perm("applications.access_appstream")
+    view_file = 'tools.html' if has_any_tool_perms else 'tools-unauthorised.html'
+
     return render(
         request,
-        'tools.html',
+        view_file,
         {
             'applications': [
                 {

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -83,14 +83,12 @@
               Home
             </a>
           </li>
-          {% if perms.applications.start_all_applications or perms.applications.access_appstream %}
           {% url 'applications:tools' as tools_url %}
           <li class="govuk-header__navigation-item{% if request.get_full_path == tools_url %} govuk-header__navigation-item--active{% endif %}">
             <a class="govuk-header__link" href="{{ tools_url }}">
               Tools
             </a>
           </li>
-          {% endif %}
           {% if can_see_visualisations_tab %}
           {% url 'visualisations:root' as visualisations_root_url %}
           <li class="govuk-header__navigation-item{% if request.get_full_path == visualisations_root_url %} govuk-header__navigation-item--active{% endif %}">
@@ -146,13 +144,11 @@
                   Home
                 </a>
               </li>
-              {% if perms.applications.start_all_applications or perms.applications.access_appstream %}
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="{{ tools_url  }}">
                   Tools
                 </a>
               </li>
-              {% endif %}
               {% if can_see_visualisations_tab %}
               <li class="govuk-footer__inline-list-item">
                 <a class="govuk-footer__link" href="{{ visualisations_root_url  }}">

--- a/dataworkspace/dataworkspace/templates/tools-unauthorised.html
+++ b/dataworkspace/dataworkspace/templates/tools-unauthorised.html
@@ -1,0 +1,50 @@
+{% extends 'tools.html' %}
+{% load static %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Tools</h1>
+
+            <p class="govuk-body">Data Workspace offers access to a range of analysis tools that you can use with datasets in the catalogue.</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>JupyterLab</li>
+                <li>RStudio</li>
+                <li>pgAdmin</li>
+                <li>SPSS/Stata</li>
+            </ul>
+
+            <p class="govuk-body">
+                These are powerful and versatile tools aimed at analysts and data scientists.
+                They require some familiarity with coding languages such as Python, R or SQL.
+                <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/tools-and-how-access-them/">Find out more</a>
+                about the tools and how to start using them in the Help Centre.
+            </p>
+
+            <p class="govuk-body">
+                Users will need to have SC clearance and complete the
+                <a class="govuk-link" href="https://app.ihasco.co.uk/lgjg02">GDPR Essentials</a> and
+                <a class="govuk-link" href="https://civilservicelearning.civilservice.gov.uk/responsible-information">Responsible for Information</a>
+                online training in order to access tools. Click the button below to request access to a specific tool.
+            </p>
+
+            <p class="govuk-body">We will follow up with you within 5 working days to confirm your eligibility and grant access.</p>
+
+            <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <div class="govuk-warning-text__text">
+                    <strong>
+                      <span class="govuk-warning-text__assistive">Warning</span>
+                      You currently do not have permission to access tools.
+                    </strong>
+                </div>
+            </div>
+
+            <p class="govuk-body">
+              <a class="govuk-button" href="{% url 'support' %}">Request access</a>
+              <a class="govuk-link govuk-!-margin-left-3" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/tools-and-how-access-them/">Learn more</a>
+            </p>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
### Description of change
We want to allow non-tool users to understand what tools are for, so
that they can self-assess whether it's something that might be useful
for them and also have a clear path to requesting access.

Ticket: https://trello.com/b/NHmVWCYp/data-workspace

### Show it
<img width="974" alt="Screenshot 2020-04-02 at 16 54 27" src="https://user-images.githubusercontent.com/2920760/78270367-a5301e80-7502-11ea-9451-60813a56db27.png">


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
