### PR TITLE
Instrument Django-Debug-Toolbar, if installed

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -70,6 +70,15 @@ MIDDLEWARE = [
     'csp.middleware.CSPMiddleware',
 ]
 
+if DEBUG:
+    try:
+        import debug_toolbar  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        INSTALLED_APPS.append('debug_toolbar')
+        MIDDLEWARE.append('debug_toolbar.middleware.DebugToolbarMiddleware')
+
 AUTHENTICATION_BACKENDS = [
     'dataworkspace.apps.accounts.backends.AuthbrokerBackendUsernameIsEmail'
 ]

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -104,6 +104,13 @@ if settings.DEBUG:
 
     urlpatterns += staticfiles_urlpatterns()
 
+    try:
+        import debug_toolbar
+    except ImportError:
+        pass
+    else:
+        urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))
+
 handler403 = public_error_403_html_view
 handler404 = public_error_404_html_view
 handler500 = public_error_500_html_view

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,4 @@ pytest==5.4.1
 pytest-cov==2.8.1
 pytest-mock==2.0.0
 pytest-django==3.8.0
+django-debug-toolbar==2.2


### PR DESCRIPTION
### Description of change
The debug toolbar adds some nice profiling info (e.g. sql queries for
the page, load time, headers/settings, etc) which can be handy in a dev
environment.

We only load the middleware if we're in debug mode and the library is
available, and we only add the library to the dev requirements, so it
should never be available in a production (even dev/staging)
environment.

### Show it (right-hand side)
<img width="1920" alt="Screenshot 2020-04-02 at 17 27 04" src="https://user-images.githubusercontent.com/2920760/78273794-3dc89d80-7507-11ea-9c5a-80d19bab8c8b.png">


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
