### PR TITLE
Move "no access" warning into first section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-03
+
+## Changed
+
+- Moved the "no permissions" warning on the datacut page into the top section.
+
 ## 2020-04-02
 
 ## Added

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -37,31 +37,30 @@
             <div class="govuk-body">
                 {{ model.description | safe }}
             </div>
+
+            {% if data_links_with_link_toggle and not has_access %}
+                <div class="govuk-warning-text">
+                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                    <div class="govuk-warning-text__text">
+                        <strong>
+                            <span class="govuk-warning-text__assistive">Warning</span>
+                            You do not have permission to access these links.
+                        </strong>
+                    </div>
+                </div>
+                {% if model.eligibility_criteria %}
+                  <a class="govuk-button" href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
+                {% else %}
+                  <a class="govuk-button" href="{% url 'datasets:request_access' model.id %}">Request access</a>
+                {% endif %}
+            {% endif %}
         </div>
     </div>
 
     <div class="govuk-grid-row" style="overflow-x: auto;">
         <div class="govuk-grid-column-two-thirds">
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Links</h2>
-
-            {% if data_links_with_link_toggle %}
-              {% if not has_access %}
-                  <div class="govuk-warning-text">
-                      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                      <div class="govuk-warning-text__text">
-                          <strong>
-                              <span class="govuk-warning-text__assistive">Warning</span>
-                              You do not have permission to access these links.
-                              <br>
-                              {% if model.eligibility_criteria %}
-                                <a class="govuk-link--no-visited-state" href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
-                              {% else %}
-                                <a class="govuk-link--no-visited-state" href="{% url 'datasets:request_access' model.id %}">Request access</a>
-                              {% endif %}
-                          </strong>
-                      </div>
-                  </div>
-              {% elif data_hosted_externally %}
+              {% if data_links_with_link_toggle and has_access and data_hosted_externally %}
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                     <div class="govuk-warning-text__text">
@@ -72,7 +71,6 @@
                     </div>
                 </div>
               {% endif %}
-            {% endif %}
         </div>
 
 


### PR DESCRIPTION
### Description of change
Bo pointed out recently that the "no access" warning has been dropped
down into the wrong section. This patch moves it back up. It also
addresses a further design point that the link should be styled like an
action button.

### Show it
<img width="1060" alt="Screenshot 2020-04-03 at 11 27 38" src="https://user-images.githubusercontent.com/2920760/78351603-fd1c6300-759e-11ea-80c3-77fedf6e5816.png">

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
