### PR TITLE
Take APM out again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-04-03
 
-### Added
-
-- Instrumentation for Elastic APM
-
-### Changed
+## Changed
 
 - Moved the "no permissions" warning on the datacut page into the top section.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN \
 	apk add --no-cache --virtual .build-deps \
 		build-base=0.5-r1 \
 		git=2.22.2-r0 \
-		python3-dev=3.7.5-r1 \
-		linux-headers=4.19.36-r0 && \
+		python3-dev=3.7.5-r1 && \
 	apk add --no-cache \
 		nginx=1.16.1-r2 \
 		openssl=1.1.1d-r2 \

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -46,7 +46,6 @@ INSTALLED_APPS = [
     'ckeditor',
     'waffle',
     'rest_framework',
-    'elasticapm.contrib.django',
     'dataworkspace.apps.core',
     'dataworkspace.apps.accounts',
     'dataworkspace.apps.catalogue',
@@ -335,15 +334,3 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.CursorPagination',
     'PAGE_SIZE': 100,
 }
-
-ELASTIC_APM_SECRET_TOKEN = env.get("ELASTIC_APM_SECRET_TOKEN")
-ELASTIC_APM = (
-    {
-        'SERVICE_NAME': 'data-workspace',
-        'SECRET_TOKEN': ELASTIC_APM_SECRET_TOKEN,
-        'SERVER_URL': 'https://apm.ci.uktrade.io:8200',
-        'ENVIRONMENT': env.get('ENVIRONMENT', 'development'),
-    }
-    if ELASTIC_APM_SECRET_TOKEN
-    else {}
-)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,3 @@ hawk-server-asyncio==0.0.6
 django-waffle==0.20.0
 django-csp==3.6
 djangorestframework==3.11.0
-elastic-apm==5.5.2
-psutil==5.7.0


### PR DESCRIPTION
Reverts uktrade/data-workspace#582

Looks like APM is no longer available in dev and that the changes by webops have been rolled back out.

They intend to change the port APM is available on in the next few days, so I'll roll this out until that happens and then put this back up for the last time with updated config.