### PR TITLE
Fix method attribution for APM

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/utils.py
+++ b/dataworkspace/dataworkspace/apps/accounts/utils.py
@@ -1,4 +1,5 @@
 import logging
+from functools import wraps
 
 from django.contrib.auth import (
     SESSION_KEY,
@@ -14,6 +15,7 @@ logger = logging.getLogger('app')
 
 
 def login_required(func):
+    @wraps(func)
     def _login_required(request, *args, **kwargs):
         user = authenticate(request)
         if user is None:


### PR DESCRIPTION
### Description of change
Our main wrapper for almost all views, `_login_required`, wasn't
wrapping the decorated functions in a way that allowed APM to properly
understand what view was being called - so almost all page hits were
being logged as `_login_required`. By setting this as a wrapper, it will
properly log which page has been viewed.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
