### PR TITLE
(feat) Release to production button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated text on "user unauthorised to use tools" page to remove the requirement for them to have SC.
 
+### Added
+
+- Initial version of button to release a visualisation to production
+
 ## 2020-04-06
 
 ### Added

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -65,6 +65,21 @@
         background: #f3f2f1;
         border: 1px solid #b1b4b6;
     }
+    @media (min-width: 40.0625em) {
+        /* If a browser doesn't support flexbox, the elements will just
+           be stacked, similar to mobile view */
+        .commit-row {
+            display: flex;
+            flex-wrap: wrap;
+        }
+        .commit-left {
+            flex-grow: 1;
+            padding-right: 20px;
+        }
+        .commit-right {
+            text-align: center;
+        }
+    }
   </style>
 {% endblock %}
 

--- a/dataworkspace/dataworkspace/templates/visualisation_branch.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_branch.html
@@ -21,7 +21,33 @@
 {% endif %}
 
 <section class="commit govuk-!-padding-5">
-    <h2 class="govuk-heading-m">Latest commit: {{ latest_commit.short_id }}</h2>
+    <div class="commit-row">
+        <h2 class="commit-left govuk-heading-m">Latest commit: {{ latest_commit.short_id }}</h2>
+        <form method="POST" class="commit-right">
+            {% csrf_token %}
+
+            {% if must_preview_latest_commit_to_release %}
+            <button class="govuk-button govuk-!-margin-bottom-1" data-module="govuk-button" type="submit" disabled="disabled" aria-disabled="true">
+                Release<span class="govuk-visually-hidden"> commit {{ latest_commit.short_id }}</span> to production
+            </button>
+            <p class="govuk-body govuk-!-margin-bottom-3 govuk-!-font-size-14">Preview required before release</p>
+            {% endif %}
+
+            {% if can_release_latest_commit %}
+            <input type="hidden" name="release-commit" value="{{ latest_commit.short_id }}">
+            <button class="govuk-button govuk-!-margin-bottom-3" data-module="govuk-button">
+                Release<span class="govuk-visually-hidden"> commit {{ latest_commit.short_id }}</span> to production
+            </button>
+            {% endif %}
+
+            {% if latest_commit_is_released %}
+            <button class="govuk-button govuk-button--disabled govuk-!-margin-bottom-1" data-module="govuk-button" disabled="disabled" aria-disabled="true">
+                Release<span class="govuk-visually-hidden"> commit {{ latest_commit.short_id }}</span> to production
+            </button>
+            <p class="govuk-body govuk-!-margin-bottom-3 govuk-!-font-size-14">Has been released</p>
+            {% endif %}
+        </form>
+    </div>
 
     <p class="govuk-body">
         {{ latest_commit.title }}<br>

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -45,6 +45,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
 
     actions = [
       "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
     ]
 
     resources = [

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -397,6 +397,8 @@ data "aws_iam_policy_document" "admin_run_tasks" {
   statement {
     actions = [
       "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:PutImage",
     ]
 
     resources = [


### PR DESCRIPTION
### Description of change

Initial version of button. Slightly awkward to have to preview first, but better than me releasing it every time

<img width="1029" alt="Screenshot 2020-04-07 at 09 35 59" src="https://user-images.githubusercontent.com/13877/78648039-5512dc80-78b3-11ea-90c0-d2fe5ea48e0a.png">

<img width="1023" alt="Screenshot 2020-04-07 at 09 36 43" src="https://user-images.githubusercontent.com/13877/78648048-59d79080-78b3-11ea-86cb-84ae9f2457b1.png">



### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
