### PR TITLE
Remove reference to SC clearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-07
+
+### Changed
+
+- Updated text on "user unauthorised to use tools" page to remove the requirement for them to have SC.
+
 ## 2020-04-06
 
 ### Added

--- a/dataworkspace/dataworkspace/templates/tools-unauthorised.html
+++ b/dataworkspace/dataworkspace/templates/tools-unauthorised.html
@@ -23,7 +23,7 @@
             </p>
 
             <p class="govuk-body">
-                Users will need to have SC clearance and complete the
+                Users will need to complete the
                 <a class="govuk-link" href="https://app.ihasco.co.uk/lgjg02">GDPR Essentials</a> and
                 <a class="govuk-link" href="https://civilservicelearning.civilservice.gov.uk/responsible-information">Responsible for Information</a>
                 online training in order to access tools. Click the button below to request access to a specific tool.


### PR DESCRIPTION
### Description of change
We no longer require users to have SC before we are able to grant tools
access.

Ticket: https://trello.com/c/tN8BtoaD/964

### Checklist

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
