### PR TITLE
(fix) Allow removal of users with privileges on schemas without tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated text on "user unauthorised to use tools" page to remove the requirement for them to have SC.
 - Fewer exceptions polling Fargate for task stopped time
+- Fewer exceptions when removing database users: specifically when users had privileges on schemas without tables
 
 ### Added
 

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -384,9 +384,9 @@ def delete_unused_datasets_users():
             logger.info('delete_unused_datasets_users: finding schemas')
             cur.execute(
                 """
-                SELECT DISTINCT schemaname FROM pg_tables
-                WHERE schemaname != 'pg_catalog' and schemaname != 'information_schema'
-                ORDER BY schemaname;
+                SELECT nspname FROM pg_catalog.pg_namespace WHERE
+                nspname != 'pg_catalog' AND nspname != 'information_schema'
+                ORDER BY nspname
             """
             )
             schemas = [result[0] for result in cur.fetchall()]


### PR DESCRIPTION
### Description of change

They weren't able to be dropped since the users privileges on the
schemas were not removed.

This should reduce some of the exceptions that make it to Sentry, since
each time a user couldn't be dropped, an exception was sent to Sentry.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
