### PR TITLE
(feat) The ability to remove access from a visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Theia IDE as a hidden tool for testing
 - A message on the conditions that need to be met before sharing a visualisation
+- The ablity to remove visualisation view access
 
 ## 2020-04-08
 

--- a/dataworkspace/dataworkspace/templates/visualisation_users_with_access.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_users_with_access.html
@@ -21,6 +21,15 @@
         <dt class="govuk-summary-list__key">
             {{ user.get_full_name }} <span class="visualisation-user-email">{{ user.email }}</span>
         </dt>
+        <dd class="govuk-summary-list__actions">
+            <form method="POST" action="{{ request.path }}">
+                {% csrf_token %}
+                <input type="hidden" name="user-id" value="{{ user.id }}">
+                <button class="govuk-button govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-!-padding-top-1 govuk-!-padding-bottom-1 govuk-!-padding-left-2 govuk-!-padding-right-2" data-module="govuk-button" type="submit" data-prevent-double-click="true">
+                    Remove access<span class="govuk-visually-hidden"> for {{ user.get_full_name }}</span>
+                </button>
+            </form>
+        </dd>
     </div>
     {% endfor %}
 </dl>


### PR DESCRIPTION
### Description of change

Not sure what would be good text for the success message. All options seem clunky to me

<img width="803" alt="Screenshot 2020-04-09 at 10 22 38" src="https://user-images.githubusercontent.com/13877/79195279-e2ab7a80-7e25-11ea-965c-d131e87f41fd.png">


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
