### PR TITLE
Add visualisation catalogue detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Theia IDE as a hidden tool for testing
 - A message on the conditions that need to be met before sharing a visualisation
 - The ablity to remove visualisation view access
+- Catalogue detail page for visualisations
 
 ## 2020-04-08
 

--- a/dataworkspace/dataworkspace/apps/applications/models.py
+++ b/dataworkspace/dataworkspace/apps/applications/models.py
@@ -78,6 +78,12 @@ class ApplicationTemplate(TimeStampedModel):
     def __str__(self):
         return self.nice_name
 
+    def user_has_access(self, user):
+        return (
+            self.user_access_type == 'REQUIRES_AUTHENTICATION'
+            or self.applicationtemplateuserpermission_set.filter(user=user).exists()
+        )
+
 
 class ToolTemplate(ApplicationTemplate):
     class Meta:

--- a/dataworkspace/dataworkspace/apps/datasets/constants.py
+++ b/dataworkspace/dataworkspace/apps/datasets/constants.py
@@ -10,3 +10,4 @@ class DataSetType(enum.Enum):
     REFERENCE = 0
     MASTER = 1
     DATACUT = 2
+    VISUALISATION = 3

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -24,6 +24,7 @@ def dataset_type_to_manage_unpublished_permission_codename(dataset_type: int):
         DataSetType.REFERENCE.value: 'datasets.manage_unpublished_reference_datasets',
         DataSetType.MASTER.value: 'datasets.manage_unpublished_master_datasets',
         DataSetType.DATACUT.value: 'datasets.manage_unpublished_datacut_datasets',
+        DataSetType.VISUALISATION.value: 'datasets.manage_unpublished_visualisations',
     }[dataset_type]
 
 

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -28,7 +28,7 @@
 
 {% block content %}
   {% if not model.published %}
-    {% include 'partials/unpublished_banner.html' %}
+    {% include 'partials/unpublished_banner.html' with type='dataset' %}
   {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -29,7 +29,7 @@
 
 {% block content %}
   {% if not model.published %}
-    {% include 'partials/unpublished_banner.html' with model=object %}
+    {% include 'partials/unpublished_banner.html' with type='dataset' %}
   {% endif %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -5,7 +5,7 @@
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
 {% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "datacut"})</script>
+<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "visualisation"})</script>
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -29,7 +29,7 @@
 
 {% block content %}
     {% if not model.published %}
-        {% include 'partials/unpublished_banner.html' with type='dataset' %}
+        {% include 'partials/unpublished_banner.html' with type='visualisation' %}
     {% endif %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -38,20 +38,21 @@
                 {{ model.description | safe }}
             </div>
 
-            {% if data_links_with_link_toggle and not has_access %}
+            {% if not has_access %}
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                     <div class="govuk-warning-text__text">
                         <strong>
                             <span class="govuk-warning-text__assistive">Warning</span>
-                            You do not have permission to access these links.
+                            You do not have permission to access this data visualisation.
                         </strong>
                     </div>
                 </div>
+                <!-- TODO: Hook this up with the visualisation-request flow -->
                 {% if model.eligibility_criteria %}
-                  <a class="govuk-button" href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
+                  <a class="govuk-button" href="...">Request access</a>
                 {% else %}
-                  <a class="govuk-button" href="{% url 'datasets:request_access' model.id %}">Request access</a>
+                  <a class="govuk-button" href="...">Request access</a>
                 {% endif %}
             {% endif %}
         </div>
@@ -59,64 +60,32 @@
 
     <div class="govuk-grid-row" style="overflow-x: auto;">
         <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Links</h2>
-              {% if data_links_with_link_toggle and has_access and data_hosted_externally %}
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <div class="govuk-warning-text__text">
-                        <strong>
-                            <span class="govuk-warning-text__assistive">Warning</span>
-                            This data set is hosted by an external source. You'll be forwarded to that source when you select it.
-                        </strong>
-                    </div>
-                </div>
-              {% endif %}
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">Data Visualisations</h2>
         </div>
-
 
         <div class="govuk-grid-column-full">
             <table class="govuk-table">
                 <thead>
                 <tr class="govuk-table__row">
-                    <th class="govuk-table__header">Link to the data</th>
+                    <th class="govuk-table__header">Link to the data visualisation</th>
                     <th class="govuk-table__header">Format</th>
-                    <th class="govuk-table__header">Frequency</th>
+                    <th class="govuk-table__header">Date added</th>
                 </tr>
                 </thead>
                 <tbody>
-
-                {% for data_link, can_show_link in data_links_with_link_toggle %}
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">
-                            {% if has_access and can_show_link %}
-                            <a class="govuk-link" href="{{ data_link.get_absolute_url }}">
-                                {{ data_link.name }}
+                            <a class="govuk-link" href="{{ visualisation_link }}">
+                                {{ model.name }}
                             </a>
-                            {% else %}
-                                {{ data_link.name }}
-                            {% endif %}
                         </td>
                         <td class="govuk-table__cell">
-                          {% if data_link.format %}{{ data_link.format }}{% else %}CSV{% endif %}
+                          Web
                         </td>
                         <td class="govuk-table__cell">
-                          {% if data_link.get_frequency_display %}
-                            {{ data_link.get_frequency_display }}
-                          {% else %}
-                            {{ data_link.frequency }}
-                          {% endif %}
+                          {{ model.published_at }}
                         </td>
                     </tr>
-                {% endfor %}
-
-                {% if not data_links_with_link_toggle %}
-                    <tr class="govuk-table__row">
-                        <td colspan="4" class="govuk-table__cell">
-                            No data available
-                        </td>
-                    </tr>
-                {% endif %}
-
                 </tbody>
             </table>
 
@@ -148,6 +117,14 @@
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Additional Information</h2>
 
             <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Publish date</dt>
+                    <dd class="govuk-summary-list__value">{{ model.published_at }}</dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Updated date</dt>
+                    <dd class="govuk-summary-list__value">{{ model.updated_at }}</dd>
+                </div>
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">Licence</dt>
                     <dd class="govuk-summary-list__value">{{ model.licence|default:"" }}</dd>

--- a/dataworkspace/dataworkspace/templates/partials/unpublished_banner.html
+++ b/dataworkspace/dataworkspace/templates/partials/unpublished_banner.html
@@ -1,10 +1,10 @@
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    You are viewing an unpublished dataset.
+    You are viewing an unpublished {{ type }}.
   </h2>
   <div class="govuk-error-summary__body">
     <p class="govuk-body">
-      This dataset is only visible to superusers.
+      This {{ type }} is only visible to superusers.
       {% if perms.datasets_dataset.change %}
         You can publish it via the <a href="{{ model.get_admin_edit_url }}" class="govuk-breadcrumbs__link">admin page</a>.
       {% endif %}

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -214,6 +214,14 @@ class ApplicationTemplateFactory(factory.django.DjangoModelFactory):
         model = 'applications.ApplicationTemplate'
 
 
+class ApplicationTemplateUserPermissionFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory(UserFactory)
+    application_template = factory.SubFactory(ApplicationTemplateFactory)
+
+    class Meta:
+        model = 'applications.ApplicationTemplateUserPermission'
+
+
 class VisualisationTemplateFactory(ApplicationTemplateFactory):
     application_type = 'VISUALISATION'
 


### PR DESCRIPTION
### Description of change
Adds the catalogue detail page for visualisations.

Ticket: https://trello.com/c/GX0ULwT1/945

### Show it
![screencapture-dataworkspace-test-8000-datasets-28d3ee21-947f-4965-86d8-3c0ab42180db-2020-04-14-17_26_17](https://user-images.githubusercontent.com/2920760/79249403-1feb2900-7e75-11ea-9df2-75d7cc0cc8af.png)


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
