### PR TITLE
(feat) Use visualisation topic rather than a group to search visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Squashed migrations to later support removal of `host_pattern`
 - Remove unused `host_pattern`
 - Reduce usage of application "name" so there is less to setup per visualisation
+- Search GitLab for visualisations using topic rather than group, to remove admin involvement
 
 ### Added
 

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -209,15 +209,21 @@ def visualisations_html_GET(request):
     )
 
     def get_projects(gitlab_user):
-        gitlab_projects = gitlab_api_v4(
+        gitlab_projects_including_non_visualisation = gitlab_api_v4(
             'GET',
-            f'groups/{settings.GITLAB_VISUALISATIONS_GROUP}/projects',
+            f'projects',
             params=(
                 ('archived', 'false'),
                 ('min_access_level', DEVELOPER_ACCESS_LEVEL),
                 ('sudo', gitlab_user['id']),
+                ('per_page', '100'),
             ),
         )
+        gitlab_projects = [
+            gitlab_project
+            for gitlab_project in gitlab_projects_including_non_visualisation
+            if 'visualisation' in [tag.lower() for tag in gitlab_project['tag_list']]
+        ]
         application_templates = {
             application_template.gitlab_project_id: application_template
             for application_template in ApplicationTemplate.objects.filter(


### PR DESCRIPTION
### Description of change



This removes the requirement for an admin to move projects into the
visualisations group, since users can add topics to their own projects.

I realise that the endpoint is paginated, and the query does not follow
the pagination. However, it already wasn't, so this change doesn't go
backwards in this respect. In fact, mitigating the issue for now by
bumping the page size from the default 20 to 100. Following the
pagination is left until later.

It does seem that there isn't a way to query for projects with a
specific topic: this has to be done as a manual filter of the results.
However, since we can use min_access_level for the current user, I think
this is still acceptable.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
