### PR TITLE
(feat) Avoid copy and paste of common spawner options for visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove unused `host_pattern`
 - Reduce usage of application "name" so there is less to setup per visualisation
 
+### Added
+
+- Common spawner options from the environment to avoid copy+pasting options when creating visualisations
+
 ## 2020-04-14
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -17,6 +17,7 @@ from dataworkspace.apps.applications.models import (
 from dataworkspace.apps.applications.spawner import spawn
 from dataworkspace.apps.applications.utils import (
     api_application_dict,
+    application_options,
     application_api_is_allowed,
     application_template_tag_user_commit_from_host,
     get_api_visible_application_instance_by_public_host,
@@ -191,11 +192,13 @@ def application_api_PUT(request, public_host):
         memory = None
         cpu = None
 
+    spawner_options = json.dumps(application_options(application_template))
+
     application_instance = ApplicationInstance.objects.create(
         owner=request.user,
         application_template=application_template,
         spawner=application_template.spawner,
-        spawner_application_template_options=application_template.spawner_options,
+        spawner_application_template_options=spawner_options,
         spawner_application_instance_id=json.dumps({}),
         public_host=public_host,
         state='SPAWNING',
@@ -220,7 +223,7 @@ def application_api_PUT(request, public_host):
         str(request.user.profile.sso_id),
         tag,
         application_instance.id,
-        application_template.spawner_options,
+        spawner_options,
         credentials,
     )
 

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -106,6 +106,17 @@ def application_template_tag_user_commit_from_host(public_host):
     return (matching[0], tag, user, commit_id)
 
 
+def application_options(application_template):
+    common_spawner_options = settings.APPLICATION_SPAWNER_OPTIONS.get(
+        application_template.spawner, {}
+    ).get(application_template.application_type, {})
+
+    return {
+        **common_spawner_options,
+        **json.loads(application_template.spawner_options),
+    }
+
+
 def api_application_dict(application_instance):
     spawner_state = get_spawner(
         application_instance.application_template.spawner

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -1,6 +1,5 @@
 import datetime
 import hashlib
-import json
 import random
 from urllib.parse import urlsplit
 
@@ -31,6 +30,7 @@ from dataworkspace.apps.applications.models import (
     ApplicationTemplate,
     ApplicationTemplateUserPermission,
 )
+from dataworkspace.apps.applications.utils import application_options
 from dataworkspace.apps.applications.spawner import get_spawner
 from dataworkspace.apps.applications.utils import stop_spawner_and_application
 from dataworkspace.apps.core.views import public_error_500_html_view
@@ -294,7 +294,7 @@ def visualisation_branch_html_GET(request, gitlab_project, branch_name):
         latest_commit['committed_date'], '%Y-%m-%dT%H:%M:%S.%f%z'
     )
     latest_commit_tag_exists = get_spawner(application_template.spawner).tags_for_tag(
-        json.loads(application_template.spawner_options),
+        application_options(application_template),
         f'{application_template.host_basename}--{latest_commit["short_id"]}',
     )
 
@@ -303,8 +303,7 @@ def visualisation_branch_html_GET(request, gitlab_project, branch_name):
         f'{request.scheme}://{host_basename}.{settings.APPLICATION_ROOT_DOMAIN}/'
     )
     tags = get_spawner(application_template.spawner).tags_for_tag(
-        json.loads(application_template.spawner_options),
-        application_template.host_basename,
+        application_options(application_template), application_template.host_basename
     )
     production_commit_id = None
     for tag in tags:
@@ -357,7 +356,7 @@ def visualisation_branch_html_POST(request, gitlab_project, branch_name):
         gitlab_project_id=gitlab_project['id']
     )
     get_spawner(application_template.spawner).retag(
-        json.loads(application_template.spawner_options),
+        application_options(application_template),
         f'{application_template.host_basename}--{release_commit}',
         application_template.host_basename,
     )

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -184,6 +184,7 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 # tests don't have to worry about fixtures / editing the database
 APPLICATION_TEMPLATES = env['APPLICATION_TEMPLATES']
 APPLICATION_ROOT_DOMAIN = env['APPLICATION_ROOT_DOMAIN']
+APPLICATION_SPAWNER_OPTIONS = env.get('APPLICATION_SPAWNER_OPTIONS', {})
 
 # CSP Headers
 CSP_DEFAULT_SRC = [APPLICATION_ROOT_DOMAIN]

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -126,6 +126,7 @@ data "template_file" "admin_container_definitions" {
 
     fargate_spawner__user_provided_task_definition_arn                        = "${aws_ecs_task_definition.user_provided.family}"
     fargate_spawner__user_provided_task_role__policy_document_template_base64 = "${base64encode(data.aws_iam_policy_document.user_provided_access_template.json)}"
+    fargate_spawner__user_provided_ecr_repository__name = "${aws_ecr_repository.user_provided.name}"
 
     zendesk_email = "${var.zendesk_email}"
     zendesk_subdomain = "${var.zendesk_subdomain}"
@@ -233,6 +234,7 @@ data "template_file" "admin_store_db_creds_in_s3_container_definitions" {
 
     fargate_spawner__user_provided_task_definition_arn                        = "${aws_ecs_task_definition.user_provided.family}"
     fargate_spawner__user_provided_task_role__policy_document_template_base64 = "${base64encode(data.aws_iam_policy_document.user_provided_access_template.json)}"
+    fargate_spawner__user_provided_ecr_repository__name = "${aws_ecr_repository.user_provided.name}"
 
     zendesk_email = "${var.zendesk_email}"
     zendesk_subdomain = "${var.zendesk_subdomain}"

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -935,6 +935,66 @@
   "name": "APPLICATION_TEMPLATES__10__SPAWNER_OPTIONS__S3_BUCKET",
   "value": "${notebooks_bucket}"
 },
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__ECR_REPOSITORY_NAME",
+  "value": "${fargate_spawner__user_provided_ecr_repository__name}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__POLICY_NAME",
+  "value": "${notebook_task_role__policy_name}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__CLUSTER_NAME",
+  "value": "${fargate_spawner__task_custer_name}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__DEFINITION_ARN",
+  "value": "${fargate_spawner__user_provided_task_definition_arn}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__CONTAINER_NAME",
+  "value": "user-provided"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__PORT",
+  "value": "8888"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__ASSUME_ROLE_POLICY_DOCUMENT_BASE64",
+  "value": "${notebook_task_role__assume_role_policy_document_base64}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__POLICY_DOCUMENT_TEMPLATE_BASE64",
+  "value": "${fargate_spawner__user_provided_task_role__policy_document_template_base64}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__PERMISSIONS_BOUNDARY_ARN",
+  "value": "${notebook_task_role__permissions_boundary_arn}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__SECURITY_GROUPS__1",
+  "value": "${fargate_spawner__task_security_group}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__SUBNETS__1",
+  "value": "${fargate_spawner__task_subnet}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__S3_SYNC",
+  "value": "False"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__S3_HOST",
+  "value": "s3-eu-west-2.amazonaws.com"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__S3_BUCKET",
+  "value": "${notebooks_bucket}"
+},
+{
+  "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__VISUALISATION__S3_REGION",
+  "value": "eu-west-2"
+},
     {
       "name": "APPLICATION_ROOT_DOMAIN",
       "value": "${root_domain}"


### PR DESCRIPTION
### Description of change

This would also allow the removal of common options in the various tools environment variables, but leaving that until later.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~