### PR TITLE
(feat) Success alert more similar to error alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Allow the GitLab pipeline to take 30 minutes before cancelling it
 - Use the RStudio CMD from the Dockerfile to make local development on the container more like production by default
+- Success alert more similar to error alert
 
 ## 2020-04-15
 

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -4,6 +4,9 @@
 .govuk-panel--confirmation--left {
   text-align:left;
 }
+.govuk-panel--confirmation:focus {
+  outline: 5px solid #fd0;
+}
 .unknown {
   color: #bfc1c3;
 }

--- a/dataworkspace/dataworkspace/templates/partials/messages.html
+++ b/dataworkspace/dataworkspace/templates/partials/messages.html
@@ -1,5 +1,5 @@
 {% for message in messages %}
-<div class="govuk-panel govuk-panel--confirmation govuk-panel--confirmation--left govuk-!-padding-5 govuk-!-margin-bottom-7">
+<div class="govuk-panel govuk-panel--confirmation govuk-panel--confirmation--left govuk-!-padding-5 govuk-!-margin-bottom-7" role="alert" tabindex="-1" autofocus>
   <h1 class="govuk-panel__title govuk-!-font-size-27">
   {{ message }}
   </h1>


### PR DESCRIPTION
### Description of change

 I realised it was a bit odd when a field in the form is autofocused: the alert is skipped and page scrolls down past it.

So now (all in common with the GDS error alert):

- It has `role="alert"`

- It autofocuses on page start (which means later elements in the page are _not_ autofocused)

- It's _not_ in the keyboard tab order of the page,  i.e. it is only focused on page load, or click from what I can tell. This is a bit odd to me, since it doesn't seem that getting the focus back on the element is possible with just keyboard navigation, but it is consistent with the GDS error alert.

- It has a yellow outline when focused [the yellow==focused is in common with GDS, although depending on element, sometimes the yellow is an outline, and sometimes a background]

There are lots of options + discussion at https://github.com/alphagov/govuk-design-system-backlog/issues/2. So I suspect there could be larger changes to the alert later [deliberately not doing these now].

Potentially clients could have cached the old CSS file for up to a week. Then on the alert they would see the browser's default outline of a focused element: in Chrome on Mac OS this is a light blue outline. Treating this as the least bad of available options... e.g. bumping the file name of the CSS file to cache bust it I realise may be even worse, since during a deployment, requests go between the old and new instances, so potentially a client can see the HTML that contains the
 file name of a CSS file, but then the request for that CSS file goes to an instance without it, the browser gets a 404 for the CSS file, and they will see a horribly broken site.

<img width="1010" alt="Screenshot 2020-04-16 at 08 30 12" src="https://user-images.githubusercontent.com/13877/79427408-8a5ab100-7fbc-11ea-8c17-5c58adf372e9.png">

For comparison, the error alert looks like

<img width="1129" alt="Screenshot 2020-04-16 at 08 39 37" src="https://user-images.githubusercontent.com/13877/79428314-e5d96e80-7fbd-11ea-825b-f31f18b857d0.png">

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
