### PR TITLE
(feat) Make database credentials available in R Studio as environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-16
+
+### Added
+
+- Database credentials to the environment in R Studio, so Shiny apps can be developed that would also access their database credentials from the environment
+
 ## 2020-04-15
 
 ### Changed

--- a/rstudio/rstudio-start.sh
+++ b/rstudio/rstudio-start.sh
@@ -6,8 +6,11 @@ mkdir -p /etc/rstudio/connections
 
 while IFS='=' read -r name value ; do
   if [[ $name == *'DATABASE_DSN__'* ]]; then
-    conn_name=$(echo ${name}    | sed -E 's/DATABASE_DSN__(.*)/\1/')
+    # Make available as environment variable
+    echo "${name}='${!name}'" >> /home/rstudio/.Renviron
 
+    # Make available as connection in the UI
+    conn_name=$(echo ${name}    | sed -E 's/DATABASE_DSN__(.*)/\1/')
     db_user=$(echo ${!name}     | sed -E 's/.*user=([a-z0-9_]+).*/\1/')
     db_password=$(echo ${!name} | sed -E 's/.*password=([a-zA-Z0-9_]+).*/\1/')
     db_port=$(echo ${!name}     | sed -E 's/.*port=([0-9]+).*/\1/')


### PR DESCRIPTION
### Description of change

Shiny apps will access the database using the credentials in the
environment, so making it easier to develop them from RStudio

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~