### PR TITLE
(refactor) Use RStudio CMD from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Allow the GitLab pipeline to take 30 minutes before cancelling it
+- Use the RStudio CMD from the Dockerfile to make local development on the container more like production by default
 
 ## 2020-04-15
 

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -192,10 +192,6 @@
       "value": "120"
     },
     {
-      "name": "APPLICATION_TEMPLATES__2__SPAWNER_OPTIONS__CMD__1",
-      "value": "/rstudio-start.sh"
-    },
-    {
       "name": "APPLICATION_TEMPLATES__2__SPAWNER_OPTIONS__CLUSTER_NAME",
       "value": "${fargate_spawner__task_custer_name}"
     },

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -111,4 +111,4 @@ RUN \
 
 USER rstudio
 
-CMD ["/usr/lib/rstudio-server/bin/rserver"]
+CMD ["/rstudio-start.sh"]


### PR DESCRIPTION
### Description of change

It's a bit of a gotcha that it doesn't already: firing up the docker image using its default CMD locally wouldn't have run the same thing as in production

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
