### PR TITLE
(feat) More grant locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove of string normalisation from pre-commit config
 
+## 2020-04-18
+
+### Changed
+
+- More locking to avoid "tuple concurrently updated" errors when GRANTing database privileges
+
 ## 2020-04-17
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -471,13 +471,14 @@ def delete_unused_datasets_users():
                                 )
                             )
 
-                        cur.execute(
-                            sql.SQL(
-                                'REVOKE ALL PRIVILEGES ON DATABASE {} FROM {};'
-                            ).format(
-                                sql.Identifier(database_name), sql.Identifier(usename)
+                            cur.execute(
+                                sql.SQL(
+                                    'REVOKE ALL PRIVILEGES ON DATABASE {} FROM {};'
+                                ).format(
+                                    sql.Identifier(database_name),
+                                    sql.Identifier(usename),
+                                )
                             )
-                        )
 
                         for schema in schemas:
                             for schema_revoke in schema_revokes:

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -481,24 +481,27 @@ def delete_unused_datasets_users():
                             )
 
                         for schema in schemas:
-                            for schema_revoke in schema_revokes:
-                                try:
-                                    cur.execute(
-                                        sql.SQL(schema_revoke).format(
-                                            sql.Identifier(schema),
-                                            sql.Identifier(usename),
+                            with cache.lock(
+                                f'database-grant--{database_name}--{schema}'
+                            ):
+                                for schema_revoke in schema_revokes:
+                                    try:
+                                        cur.execute(
+                                            sql.SQL(schema_revoke).format(
+                                                sql.Identifier(schema),
+                                                sql.Identifier(usename),
+                                            )
                                         )
-                                    )
-                                except Exception:
-                                    # This is likely to happen for private schemas where the current user
-                                    # does not have revoke privileges. We carry on in a best effort
-                                    # to remove the user
-                                    logger.info(
-                                        'delete_unused_datasets_users: Unable to %s %s %s',
-                                        schema_revoke,
-                                        schema,
-                                        usename,
-                                    )
+                                    except Exception:
+                                        # This is likely to happen for private schemas where the current user
+                                        # does not have revoke privileges. We carry on in a best effort
+                                        # to remove the user
+                                        logger.info(
+                                            'delete_unused_datasets_users: Unable to %s %s %s',
+                                            schema_revoke,
+                                            schema,
+                                            usename,
+                                        )
 
                         logger.info(
                             'delete_unused_datasets_users: dropping user %s', usename


### PR DESCRIPTION
### Description of change

Recent changes seem to have fixed "tuple concurrently updated" when GRANTing on the database, but the error now occurs later in the granting process.

At the moment, these permissions are created synchronously on starting an application, so the locking would slow down this request. However, treating that as better than erroring. Ideally they would be created as part of the subsequent background task that runs when starting an application, but leaving that until later.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
