### PR TITLE
Add visualisations to catalogue search results

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -48,11 +48,11 @@ class DatasetSearchForm(forms.Form):
             (DataSetType.REFERENCE.value, 'Reference'),
         ],
         required=False,
-        widget=FilterWidget("Data use", hint_text="Select all that apply."),
+        widget=FilterWidget("Purpose", hint_text="Select all that apply."),
     )
 
     source = forms.ModelMultipleChoiceField(
         queryset=SourceTag.objects.order_by('name').all(),
         required=False,
-        widget=FilterWidget("Data source", hint_text="Select all that apply."),
+        widget=FilterWidget("Source", hint_text="Select all that apply."),
     )

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -45,7 +45,8 @@ class DatasetSearchForm(forms.Form):
         choices=[
             (DataSetType.DATACUT.value, 'Download'),
             (DataSetType.MASTER.value, 'Analyse in tools'),
-            (DataSetType.REFERENCE.value, 'Reference'),
+            (DataSetType.REFERENCE.value, 'Use as reference data'),
+            (DataSetType.VISUALISATION.value, 'View data visualisation'),
         ],
         required=False,
         widget=FilterWidget("Purpose", hint_text="Select all that apply."),

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -2,6 +2,7 @@
 {% load humanize %}
 {% load static %}
 {% load core_filters %}
+{% load core_tags %}
 {% load datasets_tags %}
 
 {% block head %}
@@ -71,6 +72,9 @@
         <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}</a>
       </h2>
       <p class="govuk-body">{{ dataset.short_description }}</p>
+      <p class="govuk-body">
+        <span class="govuk-!-font-weight-bold">Purpose:</span> {{ purpose|get_key:dataset.purpose}}
+      </p>
     </div>
     {% endfor %}
 

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -38,7 +38,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">Welcome to Data Workspace</h1>
     <p class="govuk-body-l">
-      Data Workspace is where DIT staff and partners can access, analyse and securely share data relevant to DIT.
+      Data Workspace is where DIT staff and partners can access, analyse and securely share data and data visualisations relevant to DIT.
     </p>
   </div>
 

--- a/dataworkspace/dataworkspace/tests/api_v1/test_api.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/test_api.py
@@ -13,7 +13,7 @@ class TestApplicationAPI(BaseTestCase):
     def test_start_application_with_invalid_table(self, mock_api_allowed, mock_spawn):
         # Test that any SourceTable objects that don't exist in the db do
         # not break the loading of applications
-        factories.ApplicationTemplateFactory.create()
+        factories.ApplicationTemplateFactory.create(host_basename='testapplication')
         factories.SourceTableFactory.create(
             database=factories.DatabaseFactory.create(memorable_name='my_database'),
             dataset=factories.DataSetFactory.create(

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -212,7 +212,7 @@ class ReferenceDatasetDownloadEventFactory(RelatedObjectEventFactory):
 class ApplicationTemplateFactory(factory.django.DjangoModelFactory):
     name = factory.fuzzy.FuzzyText()
     visible = True
-    host_basename = 'testapplication'
+    host_basename = factory.fuzzy.FuzzyText()
     nice_name = factory.fuzzy.FuzzyText()
     spawner = 'PROCESS'
     spawner_time = int(datetime.timestamp(datetime.now()))
@@ -221,6 +221,14 @@ class ApplicationTemplateFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'applications.ApplicationTemplate'
+
+
+class DataSetApplicationTemplatePermissionFactory(factory.django.DjangoModelFactory):
+    application_template = factory.SubFactory(ApplicationTemplateFactory)
+    dataset = factory.SubFactory(DataSetFactory)
+
+    class Meta:
+        model = 'datasets.DataSetApplicationTemplatePermission'
 
 
 class ApplicationTemplateUserPermissionFactory(factory.django.DjangoModelFactory):
@@ -251,6 +259,7 @@ class VisualisationApprovalFactory(factory.django.DjangoModelFactory):
 class VisualisationCatalogueItemFactory(factory.django.DjangoModelFactory):
     visualisation_template = factory.SubFactory(VisualisationTemplateFactory)
     name = factory.LazyAttribute(lambda o: o.visualisation_template.name)
+    slug = factory.LazyAttribute(lambda o: o.visualisation_template.name.lower())
     published = True
     deleted = False
 


### PR DESCRIPTION
### Description of change

![image](https://user-images.githubusercontent.com/246664/79788225-3810eb80-8340-11ea-81f9-b6565b448f98.png)


### Update Data use and source filter labels


### Update home page text to include data visualisations


### Add "purpose" to the search result descriptions

Adds the filter name label based on the dataset type to each result.

We add the type to the reference datasets by making Django ORM generate a `SELECT ..., 0 as "type"` query.

Django orders model fields before any additional fields like annotations in generated SQL statement which means doing a UNION between a model field in one query and an extra field in another results in different columns getting connected into a single result one (which sometimes leads to a type error and sometimes succeeds with values ending up in the wrong place). To avoid this, we alias model field `type` with `.annotate` in the datasets query, making sure it's added to the end of SELECT field list.

### Add visualisations to catalogue search results

Visualisation follow the same rules as datasets:

* they are filtered by text query
* Access filter only displays visualisations the user has permission to launch (either public ones or the ones the user has an explicit permission for)
* Unpublished visualisations are visible in search results for users with a permission to manage them
* Source filter for visualisations is based on source tag of the connected datasets

### Add tests for visualisation search filters



### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
