### PR TITLE
(feat) Datasets showing master and reference data an application has …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Client-side validation of `short_description` for visualisation catalogue items no longer occurs.
+- The ability to see what Datasets a visualisation has access to
 
 ## 2020-04-22
 

--- a/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
+++ b/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
@@ -8,6 +8,7 @@ from dataworkspace.apps.applications.views import (
     visualisation_users_with_access_html_view,
     visualisation_catalogue_item_html_view,
     visualisation_approvals_html_view,
+    visualisation_datasets_html_view,
 )
 
 urlpatterns = [
@@ -36,5 +37,10 @@ urlpatterns = [
         '<str:gitlab_project_id>/approvals',
         login_required(visualisation_approvals_html_view),
         name='approvals',
+    ),
+    path(
+        '<str:gitlab_project_id>/datasets',
+        login_required(visualisation_datasets_html_view),
+        name='datasets',
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -349,11 +349,21 @@ def source_tables_for_app(application_template):
         dataset__datasetapplicationtemplatepermission__application_template=application_template,
     )
     source_tables = [
-        {'database': x.database, 'schema': x.schema, 'table': x.table}
+        {
+            'database': x.database,
+            'schema': x.schema,
+            'table': x.table,
+            'dataset': {'id': x.dataset.id, 'name': x.dataset.name},
+        }
         for x in req_authentication_tables.union(req_authorization_tables)
     ]
     reference_dataset_tables = [
-        {'database': x.external_database, 'schema': 'public', 'table': x.table_name}
+        {
+            'database': x.external_database,
+            'schema': 'public',
+            'table': x.table_name,
+            'dataset': {'id': x.uuid, 'name': x.name},
+        }
         for x in ReferenceDataset.objects.live()
         .filter(published=True, deleted=False)
         .exclude(external_database=None)

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -84,6 +84,10 @@
         display: block;
         font-weight: normal;
     }
+    .visualisation-dataset-schema-table {
+        display: block;
+        font-weight: normal;
+    }
     .list-item-with-prefix::before {
         content: "—";
         font-weight: normal;
@@ -128,7 +132,7 @@
             {% endfor %}
         </ul>
     </li>
-    <li class="nav-item{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item--current{% endif %}">
+    <li class="nav-item{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
         <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item-link--current{% endif %}">
             Users
         </a>
@@ -145,6 +149,11 @@
                 </a>
             </li>
         </ul>
+    </li>
+    <li class="nav-item{% if current_menu_item == 'datasets' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
+        <a href="{% url 'visualisations:datasets' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'datasets' %} nav-item-link--current{% endif %}">
+            Datasets
+        </a>
     </li>
     <li class="nav-item{% if current_menu_item == 'catalogue-item' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
         <a href="{% url 'visualisations:catalogue-item' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'catalogue-item' %} nav-item-link--current{% endif %}">

--- a/dataworkspace/dataworkspace/templates/visualisation_datasets.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_datasets.html
@@ -1,0 +1,37 @@
+{% extends '_visualisation.html' %}
+
+{% block page_title %}Datasets - {{ block.super }}{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-l govuk-!-margin-bottom-6">
+    <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
+    Datasets
+</h1>
+
+{% if not datasets %}
+<p class="govuk-body">This visualisation does not have access to any datasets.
+{% endif %}
+
+{% if datasets %}
+<p class="govuk-body">This visualisation has SQL access to the following datasets. The tables of each dataset are listed in the format "schema"."table".</p>
+
+<dl class="govuk-summary-list">
+    {% for dataset, tables in datasets %}
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+            {{ dataset.name }}
+
+            {% for table in tables %}
+            <span class="visualisation-dataset-schema-table">"{{ table.schema }}"."{{ table.table }}"</span>
+            {% endfor %}
+        </dt>
+
+        <dd class="govuk-summary-list__actions">
+            <a href="{% url 'datasets:dataset_detail' dataset.id %}" class="govuk-link govuk-link--no-visited-state">View catalogue item<span class="govuk-visually-hidden"> for {{ dataset.name }}</span></a>
+        </dd>
+    </div>
+    {% endfor %}
+</dl>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
### Description of change

It is expected that in a later version there will be at least one more action per dataset: all master datasets the user has access to will be listed with a button to give the visualisation access to it.

It was considered to lay out the datasets in a table, but not used since table and schema names can be quite long.

<img width="898" alt="Screenshot 2020-04-23 at 15 15 46" src="https://user-images.githubusercontent.com/13877/80109443-67f50480-8575-11ea-9ec3-7769407c9a1b.png">

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
~* [ ] Has the README been updated (if needed)?~
