### PR TITLE
Use full request path when authenticating hawk requests

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -941,7 +941,7 @@ async def async_main():
                 request.method,
                 request.url.host,
                 request.url.port,
-                request.url.path,
+                request.url.path_qs,
                 request.headers['Content-Type'],
                 content,
             )


### PR DESCRIPTION
### Description of change

Use the full path and query string when authenticating hawk requests.

Clients using pagination on the api currently have to remove the query string from the url when creating their hawk sender header. This is because data workspace was using the path only and not the path and query string as is required. In practice this meant that you would have to create a hawk token with one url (without query string) and then make a request to a different url (full url with query string) which is not ideal.

Effectively we've gone from 
```
sender = mohawk.Sender(
    credentials=credentials,
    url=url.split('?')[0],
)
response = requests.get(url, headers={'Authorization': sender.request_header})
```

to

```
sender = mohawk.Sender(
    credentials=credentials,
    url=url,
)
response = requests.get(url, headers={'Authorization': sender.request_header})
```

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
