### PR TITLE
Add approvals page for visualisations

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
+++ b/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
@@ -7,6 +7,7 @@ from dataworkspace.apps.applications.views import (
     visualisation_users_give_access_html_view,
     visualisation_users_with_access_html_view,
     visualisation_catalogue_item_html_view,
+    visualisation_approvals_html_view,
 )
 
 urlpatterns = [
@@ -30,5 +31,10 @@ urlpatterns = [
         '<str:gitlab_project_id>/catalogue-item',
         login_required(visualisation_catalogue_item_html_view),
         name='catalogue-item',
+    ),
+    path(
+        '<str:gitlab_project_id>/approvals',
+        login_required(visualisation_approvals_html_view),
+        name='approvals',
     ),
 ]

--- a/dataworkspace/dataworkspace/forms.py
+++ b/dataworkspace/dataworkspace/forms.py
@@ -1,4 +1,4 @@
-from django.forms import ModelForm, Textarea, TextInput, Select
+from django.forms import ModelForm, Textarea, TextInput, Select, CheckboxInput
 
 
 class GOVUKDesignSystemModelForm(ModelForm):
@@ -19,3 +19,5 @@ class GOVUKDesignSystemModelForm(ModelForm):
                 field.widget.attrs.update({"class": "govuk-textarea"})
             elif isinstance(field.widget, Select):
                 field.widget.attrs.update({"class": "govuk-select"})
+            elif isinstance(field.widget, CheckboxInput):
+                field.widget.attrs.update({"class": "govuk-checkboxes__input"})

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -146,9 +146,14 @@
             </li>
         </ul>
     </li>
-    <li class="nav-item{% if current_menu_item == 'catalogue-item' %} nav-item--current{% endif %}">
+    <li class="nav-item{% if current_menu_item == 'catalogue-item' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
         <a href="{% url 'visualisations:catalogue-item' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'catalogue-item' %} nav-item-link--current{% endif %}">
             Catalogue item
+        </a>
+    </li>
+    <li class="nav-item{% if current_menu_item == 'approvals' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
+        <a href="{% url 'visualisations:approvals' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'approvals' %} nav-item-link--current{% endif %}">
+            Approvals
         </a>
     </li>
 </ul>

--- a/dataworkspace/dataworkspace/templates/partials/govuk_single_checkbox_field.html
+++ b/dataworkspace/dataworkspace/templates/partials/govuk_single_checkbox_field.html
@@ -1,0 +1,18 @@
+<div class="govuk-form-group{% if field.errors %} govuk-form-group--error{% endif %}">
+  <fieldset class="govuk-fieldset" aria-describedby="{{ field.id_for_label }}-hint">
+    {% if field.errors %}
+    <span id="{{ field.id_for_label }}-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error: </span>{{ field.errors.0 }}
+    </span>
+    {% endif %}
+
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        {{ field }}
+        <label class="govuk-label govuk-checkboxes__label" for="{{ field.id_for_label }}" id="{{ field.id_for_label }}-hint">
+          {{ field.label }}
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/dataworkspace/dataworkspace/templates/visualisation_approvals.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_approvals.html
@@ -1,0 +1,68 @@
+{% extends '_visualisation.html' %}
+{% load core_filters %}
+
+{% block head %}
+{{ block.super }}
+{{ form.media }}
+{% endblock %}
+
+{% block page_title %}{% if form.errors %}Error: {% endif %}Catalogue item - {{ block.super }}{% endblock %}
+
+{% block content %}
+{% if form_errors %}
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+    {% for id_for_label, error in form_errors %}
+        <li>
+          <a href="{{ request.path }}#{{ id_for_label }}">{{ error }}</a>
+        </li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-6">
+  <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
+  Approvals
+</h1>
+
+<p class="govuk-body">
+  In order to publish this visualisation, at least two users must approve it.
+</p>
+
+<p class="govuk-body">
+  {% if approvals %}
+  So far, the following {{ approvals | length }} user{{ approvals | pluralize }} {{ approvals | pluralize:'has,have' }} approved it.
+  {% else %}
+  No-one has approved this yet.
+  {% endif %}
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  {% for approval in approvals %}
+    <li>{% if request.user == approval.approver %}You{% else %}{{ approval.approver.get_full_name }}{% endif %} approved this visualisation at {{ approval.created_date }}</li>
+  {% endfor %}
+</ul>
+
+{% if not already_approved %}
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<form method="POST" action="{{ request.path }}" novalidate>
+  {% csrf_token %}
+
+  {{ form.non_field_errors }}
+
+  {{ form.visualisation }}
+  {{ form.approver }}
+
+  {% include "partials/govuk_single_checkbox_field.html" with field=form.approved %}
+
+  <input type="submit" class="govuk-button" value="Approve" />
+ </form>
+{% endif %}
+{% endblock %}

--- a/dataworkspace/dataworkspace/tests/applications/test_views.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_views.py
@@ -1,8 +1,39 @@
+from contextlib import contextmanager
 from unittest import mock
 
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import Client
 from django.urls import reverse
 
+from dataworkspace.apps.applications.models import (
+    VisualisationApproval,
+    ApplicationInstance,
+)
 from dataworkspace.tests import factories
+from dataworkspace.tests.common import get_http_sso_data
+
+
+@contextmanager
+def _visualisation_ui_gitlab_mocks():
+    with mock.patch(
+        'dataworkspace.apps.applications.views._visualisation_gitlab_project'
+    ) as projects_mock, mock.patch(
+        'dataworkspace.apps.applications.views._visualisation_branches'
+    ) as branches_mock, mock.patch(
+        'dataworkspace.apps.applications.views.gitlab_has_developer_access'
+    ) as access_mock:
+        access_mock.return_value = True
+        projects_mock.return_value = {'id': 1, 'default_branch': 'master'}
+        branches_mock.return_value = [
+            {
+                'name': 'master',
+                'commit': {'committed_date': '2020-04-14T21:25:22.000+00:00'},
+            }
+        ]
+
+        yield projects_mock, branches_mock, access_mock
 
 
 class TestDataVisualisationUICataloguePage:
@@ -16,22 +47,7 @@ class TestDataVisualisationUICataloguePage:
         # Login to admin site
         staff_client.post(reverse('admin:index'), follow=True)
 
-        with mock.patch(
-            'dataworkspace.apps.applications.views._visualisation_gitlab_project'
-        ) as projects_mock, mock.patch(
-            'dataworkspace.apps.applications.views._visualisation_branches'
-        ) as branches_mock, mock.patch(
-            'dataworkspace.apps.applications.views.gitlab_has_developer_access'
-        ) as access_mock:
-            access_mock.return_value = True
-            projects_mock.return_value = {'id': 1, 'default_branch': 'master'}
-            branches_mock.return_value = [
-                {
-                    'name': 'master',
-                    'commit': {'committed_date': '2020-04-14T21:25:22.000+00:00'},
-                }
-            ]
-
+        with _visualisation_ui_gitlab_mocks():
             response = staff_client.post(
                 reverse(
                     'visualisations:catalogue-item',
@@ -55,22 +71,7 @@ class TestDataVisualisationUICataloguePage:
         # Login to admin site
         staff_client.post(reverse('admin:index'), follow=True)
 
-        with mock.patch(
-            'dataworkspace.apps.applications.views._visualisation_gitlab_project'
-        ) as projects_mock, mock.patch(
-            'dataworkspace.apps.applications.views._visualisation_branches'
-        ) as branches_mock, mock.patch(
-            'dataworkspace.apps.applications.views.gitlab_has_developer_access'
-        ) as access_mock:
-            access_mock.return_value = True
-            projects_mock.return_value = {'id': 1, 'default_branch': 'master'}
-            branches_mock.return_value = [
-                {
-                    'name': 'master',
-                    'commit': {'committed_date': '2020-04-14T21:25:22.000+00:00'},
-                }
-            ]
-
+        with _visualisation_ui_gitlab_mocks():
             response = staff_client.post(
                 reverse(
                     'visualisations:catalogue-item',
@@ -86,3 +87,83 @@ class TestDataVisualisationUICataloguePage:
         assert "The visualisation must have a summary" in response.content.decode(
             response.charset
         )
+
+
+class TestDataVisualisationUIApprovalPage:
+    @pytest.mark.django_db
+    def test_approve_visualisation_successfully(self):
+        develop_visualisations_permission = Permission.objects.get(
+            codename='develop_visualisations',
+            content_type=ContentType.objects.get_for_model(ApplicationInstance),
+        )
+        user = factories.UserFactory.create(
+            username='visualisation.creator@test.com',
+            is_staff=False,
+            is_superuser=False,
+        )
+        user.user_permissions.add(develop_visualisations_permission)
+        visualisation = factories.VisualisationCatalogueItemFactory.create(
+            published=False, visualisation_template__gitlab_project_id=1
+        )
+
+        # Login to admin site
+        client = Client(**get_http_sso_data(user))
+        client.post(reverse('admin:index'), follow=True)
+
+        with _visualisation_ui_gitlab_mocks():
+            response = client.post(
+                reverse(
+                    'visualisations:approvals',
+                    args=(visualisation.visualisation_template.gitlab_project_id,),
+                ),
+                {
+                    "approved": "on",
+                    "approver": user.id,
+                    "visualisation": str(visualisation.visualisation_template.id),
+                },
+                follow=True,
+            )
+
+        assert response.status_code == 200
+        assert len(VisualisationApproval.objects.all()) == 1
+
+    @pytest.mark.django_db
+    def test_bad_post_data_approved_box_not_checked(self):
+        develop_visualisations_permission = Permission.objects.get(
+            codename='develop_visualisations',
+            content_type=ContentType.objects.get_for_model(ApplicationInstance),
+        )
+        user = factories.UserFactory.create(
+            username='visualisation.creator@test.com',
+            is_staff=False,
+            is_superuser=False,
+        )
+        user.user_permissions.add(develop_visualisations_permission)
+        visualisation = factories.VisualisationCatalogueItemFactory.create(
+            published=False, visualisation_template__gitlab_project_id=1
+        )
+
+        # Login to admin site
+        client = Client(**get_http_sso_data(user))
+        client.post(reverse('admin:index'), follow=True)
+
+        with _visualisation_ui_gitlab_mocks():
+            response = client.post(
+                reverse(
+                    'visualisations:approvals',
+                    args=(visualisation.visualisation_template.gitlab_project_id,),
+                ),
+                {
+                    "approver": user.id,
+                    "visualisation": str(visualisation.visualisation_template.id),
+                },
+                follow=True,
+            )
+
+        visualisation.refresh_from_db()
+        assert response.status_code == 400
+        assert (
+            "You must confirm that you have reviewed this visualisation"
+            in response.content.decode(response.charset)
+        )
+        assert len(VisualisationApproval.objects.all()) == 0


### PR DESCRIPTION
### Description of change
Add a page where visualisation users/creators can approve other people's
visualisations (or potentially their own, hence we require two
approvals).

Ticket: https://trello.com/c/zzdmPLu7/979

### Show the thing
![screencapture-dataworkspace-test-8000-visualisations-6-approvals-2020-04-21-16_03_48](https://user-images.githubusercontent.com/2920760/79882030-e329af80-83e9-11ea-9cfe-a85773c9fa4e.png)
![screencapture-dataworkspace-test-8000-visualisations-6-approvals-2020-04-21-16_04_42](https://user-images.githubusercontent.com/2920760/79882035-e45adc80-83e9-11ea-9a5b-7a113c5070b7.png)
![screencapture-dataworkspace-test-8000-visualisations-6-approvals-2020-04-21-16_04_47](https://user-images.githubusercontent.com/2920760/79882038-e4f37300-83e9-11ea-83f3-7cbfbc3b7185.png)


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
~* [ ] Has the README been updated (if needed)?~