### PR TITLE
(feat) Wrap dataset identifier schema and table in double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bumped GitLab to latest 12.6
 - Bumped Git and OpenSSL to latest on Alpine 3.10
 - Bumped GitLab to latest 12.7
+- Wrap each of dataset schema and table in double quotes
 
 ## 2020-04-21
 

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -81,7 +81,7 @@
         {% for data_link, _ in data_links_with_link_toggle %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">{{ data_link.name }}</td>
-            <td class="govuk-table__cell">{{ data_link.schema }}.{{ data_link.table }}</td>
+            <td class="govuk-table__cell">"{{ data_link.schema }}"."{{ data_link.table }}"</td>
             <td class="govuk-table__cell">{{ data_link.get_frequency_display }}</td>
             {% if user.is_superuser %}
               <td class="govuk-table__cell">


### PR DESCRIPTION
### Description of change

A lot of the schema names have dots in them, so if used in SQL, they
need to be wrapped in double quotes. I've not seen table names with dots in them, but adding quotes around the table name for consistency/just in case.

The identifier will also (probably) be in the Datasets page in the Visualisation UI, with the double quotes, so doing this for consistency with that page.

<img width="951" alt="Screenshot 2020-04-22 at 09 17 04" src="https://user-images.githubusercontent.com/13877/79957876-27fd2700-847a-11ea-838c-c1a8ab9d2533.png">


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
