### PR TITLE
Allow peer ip to work with no proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bumped Git and OpenSSL to latest on Alpine 3.10
 - Bumped GitLab to latest 12.7
 - Wrap each of dataset schema and table in double quotes
+- Fix `get_peer_ip` for local development when there are no proxies.
 
 ## 2020-04-21
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -201,11 +201,14 @@ async def async_main():
         )
 
     def get_peer_ip(request):
-        peer_ip = (
-            request.headers['x-forwarded-for']
-            .split(',')[-x_forwarded_for_trusted_hops]
-            .strip()
-        )
+        if x_forwarded_for_trusted_hops > 0 or request.headers.get('x-forwarded-for'):
+            peer_ip = (
+                request.headers['x-forwarded-for']
+                .split(',')[-x_forwarded_for_trusted_hops]
+                .strip()
+            )
+        else:
+            peer_ip = request.transport.get_extra_info("peername")[0]
 
         is_private = True
         try:


### PR DESCRIPTION
### Description of change
If running data workspace entirely locally, there are no
`x-forwarded-for` entries, so `get_peer_ip` dies when trying to retrieve
that header.

If there are no expected proxies, and no x-forwarded-for entries, we
should just directly use the peer ip from the request. If either
x-forwarded-for is set, or we expect there to be some proxies, then we
keep the current behaviour.

### Checklist

~* [ ] Have tests been added to cover any changes?~
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
~* [ ] Has the README been updated (if needed)?~
