### PR TITLE
(feat) Show BST times as BST, rather than UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Client-side validation of `short_description` for visualisation catalogue items no longer occurs.
 - The ability to see what Datasets a visualisation has access to
+- Show BST times as BST, rather than UTC
 
 ## 2020-04-22
 

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -135,7 +135,7 @@ WSGI_APPLICATION = 'dataworkspace.wsgi.application'
 AUTH_PASSWORD_VALIDATORS = []
 
 LANGUAGE_CODE = 'en-us'
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/London'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True


### PR DESCRIPTION
### Description of change

Maybe should append BST times with "BST" and UTC times with "UTC" to
make it clear which is being used for each time, but not quite worked
out how to do that.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
