### PR TITLE
Automatically grant vis creators the management perm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Ability to unapprove visualisations.
+- Automatic granting of permission for data vis creators to manage unpublished visualisations, which will let them view the catalogue page before publication.
 
 ### Changed
 

--- a/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
@@ -1,0 +1,52 @@
+import mock
+import pytest
+import requests_mock
+from django.contrib.auth import get_user_model
+from django.shortcuts import get_object_or_404
+from django.test import override_settings
+
+from dataworkspace.apps.applications.gitlab import gitlab_has_developer_access
+from dataworkspace.apps.datasets.constants import DataSetType
+from dataworkspace.apps.datasets.utils import (
+    dataset_type_to_manage_unpublished_permission_codename,
+)
+from dataworkspace.tests import factories
+
+
+class TestGitlabHasDeveloperAccess:
+    @override_settings(
+        CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}
+    )
+    @pytest.mark.django_db
+    def test_grants_manage_unpublished_visualisations_permission(self):
+        user = factories.UserFactory.create(
+            username='visualisation.creator@test.com',
+            is_staff=False,
+            is_superuser=False,
+        )
+        visualisation = factories.VisualisationCatalogueItemFactory.create(
+            published=False, visualisation_template__gitlab_project_id=1
+        )
+        perm_codename = dataset_type_to_manage_unpublished_permission_codename(
+            DataSetType.VISUALISATION.value
+        )
+        assert user.has_perm(perm_codename) is False
+
+        with requests_mock.Mocker() as rmock:
+            rmock.get(
+                f'http://127.0.0.1:8007/api/v4/users?extern_uid={user.profile.sso_id}&provider=oauth2_generic',
+                json=[{"id": 1}],
+            )
+            rmock.get(
+                f'http://127.0.0.1:8007/api/v4/projects/1/members/all?user_ids=1',
+                json=[{"id": 1, "access_level": 50}],
+            )
+            has_access = gitlab_has_developer_access(
+                user, visualisation.visualisation_template.gitlab_project_id
+            )
+
+        # Permissions are cached on the instance so we need to re-fetch it entirely - refresh_from_db insufficient.
+        # https://docs.djangoproject.com/en/3.0/topics/auth/default/#permission-caching
+        user = get_object_or_404(get_user_model(), pk=user.id)
+        assert has_access is True
+        assert user.has_perm(perm_codename) is True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,4 @@ pytest-cov==2.8.1
 pytest-mock==3.1.0
 pytest-django==3.8.0
 django-debug-toolbar==2.2
+requests-mock==1.7.0


### PR DESCRIPTION
### Description of change
We have a permission that manages user access to unpublished catalogue
items. This patch automatically gives the permission to visualisation
creators as they browse the visualisation UI,by piggy-backing on
`gitlab_has_developer_access`, which is used to check whether a user has
developer+ access to a given visualisation.

The django-side permissions is global, so they are granted the ability
to see *all* unpublished visualisations. This is fine - and possibly
even preferrable - so that creators can see/crib from other people's
work.

Ticket: https://trello.com/c/0ZvQ3jK4/1012

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
