### PR TITLE
(feat) Slightly nicer presentation of long schema and table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-24
+
+### Added
+
+- A zero-width space after an underscore in the visualisation datasets page to encourage line breaks in more readable places
+
 ## 2020-04-23
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
+++ b/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
@@ -19,6 +19,12 @@ def get_key(dictionary, field):
 
 
 @register.filter
+def zero_width_space_after(string, sub):
+    zero_width_space = u'\u200B'
+    return string.replace(sub, f'{sub}{zero_width_space}')
+
+
+@register.filter
 def add_class(field, class_attr):
     if 'class' in field.field.widget.attrs:
         field.field.widget.attrs['class'] = '{} {}'.format(

--- a/dataworkspace/dataworkspace/templates/visualisation_datasets.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_datasets.html
@@ -1,4 +1,5 @@
 {% extends '_visualisation.html' %}
+{% load core_tags %}
 
 {% block page_title %}Datasets - {{ block.super }}{% endblock %}
 
@@ -22,7 +23,7 @@
             {{ dataset.name }}
 
             {% for table in tables %}
-            <span class="visualisation-dataset-schema-table">"{{ table.schema }}"."{{ table.table }}"</span>
+            <span class="visualisation-dataset-schema-table">"{{ table.schema|zero_width_space_after:'_' }}"."{{ table.table|zero_width_space_after:'_' }}"</span>
             {% endfor %}
         </dt>
 

--- a/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_gitlab.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 import requests_mock
 from django.contrib.auth import get_user_model

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -368,8 +368,8 @@ class TestApplication(unittest.TestCase):
         gitlab_cleanup = await create_server(
             8007,
             [
-                web.get('/api/v4//users', handle_users),
-                web.get('/api/v4//projects/3/members/all', handle_members),
+                web.get('/api/v4/users', handle_users),
+                web.get('/api/v4/projects/3/members/all', handle_members),
                 web.get('/api/v4/projects/3', handle_project),
                 web.get('/{path:.*}', handle_general_gitlab),
             ],
@@ -502,10 +502,10 @@ class TestApplication(unittest.TestCase):
         gitlab_cleanup = await create_server(
             8007,
             [
-                web.get('/api/v4//users', handle_users),
-                web.get('/api/v4//projects/3/members/all', handle_members),
+                web.get('/api/v4/users', handle_users),
+                web.get('/api/v4/projects/3/members/all', handle_members),
                 web.get('/api/v4/projects/3', handle_project_3),
-                web.get('/api/v4//projects/4/members/all', handle_members),
+                web.get('/api/v4/projects/4/members/all', handle_members),
                 web.get('/api/v4/projects/4', handle_project_4),
                 web.get('/{path:.*}', handle_general_gitlab),
             ],
@@ -1513,11 +1513,11 @@ class TestApplication(unittest.TestCase):
             8007,
             [
                 web.get('/api/v4/groups/visualisations', handle_group),
-                web.get('/api/v4//users', handle_users),
+                web.get('/api/v4/users', handle_users),
                 web.get('/api/v4/projects', handle_projects),
-                web.get('/api/v4//projects/3/members/all', handle_members),
+                web.get('/api/v4/projects/3/members/all', handle_members),
                 web.get('/api/v4/projects/3', handle_project),
-                web.get('/api/v4//projects/3/repository/branches', handle_branches),
+                web.get('/api/v4/projects/3/repository/branches', handle_branches),
                 web.get('/{path:.*}', handle_general_gitlab),
             ],
         )


### PR DESCRIPTION
### Description of change

From

<img width="863" alt="Screenshot 2020-04-24 at 07 00 07" src="https://user-images.githubusercontent.com/13877/80179910-7553d280-85f9-11ea-9787-cc7b8c99f43a.png">

to

<img width="870" alt="Screenshot 2020-04-24 at 07 01 06" src="https://user-images.githubusercontent.com/13877/80179916-784ec300-85f9-11ea-9af9-428bf77c0ee2.png">

Ideally this would be done in CSS, but there doesn't seem to be a CSS-only way of telling the browser that underscores, that are often part of schema and table names, are not parts of words.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
