### PR TITLE
(feat) Close connections after celery tasks as attempt to address db connection usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A zero-width space after an underscore in the visualisation datasets page to encourage line breaks in more readable places
 
+### Changed
+
+- Close database connection after each Celery task as attempt to address database connection usage/(leak?)
+
 ## 2020-04-23
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 import gevent
 
 from django.conf import settings
+from django_db_geventpool.utils import close_connection
 
 from dataworkspace.cel import celery_app
 from dataworkspace.apps.applications.models import ApplicationInstance
@@ -32,6 +33,7 @@ def get_spawner(name):
 
 
 @celery_app.task()
+@close_connection
 def spawn(
     name,
     user_email_address,
@@ -52,6 +54,7 @@ def spawn(
 
 
 @celery_app.task()
+@close_connection
 def stop(name, application_instance_id):
     get_spawner(name).stop(application_instance_id)
 

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -12,6 +12,8 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db.models import Q
 
+from django_db_geventpool.utils import close_connection
+
 from dataworkspace.apps.applications.spawner import (
     get_spawner,
     stop,
@@ -270,6 +272,7 @@ def application_instance_max_cpu(application_instance):
 
 
 @celery_app.task()
+@close_connection
 def kill_idle_fargate():
     logger.info('kill_idle_fargate: Start')
 
@@ -315,6 +318,7 @@ def kill_idle_fargate():
 
 
 @celery_app.task()
+@close_connection
 def populate_created_stopped_fargate():
     logger.info('populate_created_stopped_fargate: Start')
 
@@ -407,6 +411,7 @@ def populate_created_stopped_fargate():
 
 
 @celery_app.task()
+@close_connection
 def delete_unused_datasets_users():
     logger.info('delete_unused_datasets_users: Start')
 


### PR DESCRIPTION
### Description of change

It's a bit of a stab in the dark, but adding a few ms to celery tasks should be fairly safe from a UX point of view.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
