### PR TITLE
(feat) Avoid surfacing IntegrityError when starting an application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Close database connection after each Celery task as attempt to address database connection usage/(leak?)
+- Smaller chance of parallel starts of the same application surfacing an error
 
 ## 2020-04-23
 


### PR DESCRIPTION
### Description of change

If two parallel requests are received to start an application, the second of these would error. Instead, we silently "succeed" by returning the response as though the user successfully started to start the application.

This is likely to be more likely as visualisations get more popular, since multiple people can start the same visualisation at the same time.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
