### PR TITLE
(feat) Edit visualisation datasets access

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -327,11 +327,29 @@ def source_tables_for_user(user):
         **{'dataset__published': True} if not user.is_superuser else {},
     )
     source_tables = [
-        {'database': x.database, 'schema': x.schema, 'table': x.table}
+        {
+            'database': x.database,
+            'schema': x.schema,
+            'table': x.table,
+            'dataset': {
+                'id': x.dataset.id,
+                'name': x.dataset.name,
+                'user_access_type': x.dataset.user_access_type,
+            },
+        }
         for x in req_authentication_tables.union(req_authorization_tables)
     ]
     reference_dataset_tables = [
-        {'database': x.external_database, 'schema': 'public', 'table': x.table_name}
+        {
+            'database': x.external_database,
+            'schema': 'public',
+            'table': x.table_name,
+            'dataset': {
+                'id': x.uuid,
+                'name': x.name,
+                'user_access_type': 'REQUIRES_AUTHENTICATION',
+            },
+        }
         for x in ReferenceDataset.objects.live()
         .filter(deleted=False, **{'published': True} if not user.is_superuser else {})
         .exclude(external_database=None)
@@ -353,7 +371,11 @@ def source_tables_for_app(application_template):
             'database': x.database,
             'schema': x.schema,
             'table': x.table,
-            'dataset': {'id': x.dataset.id, 'name': x.dataset.name},
+            'dataset': {
+                'id': x.dataset.id,
+                'name': x.dataset.name,
+                'user_access_type': x.dataset.user_access_type,
+            },
         }
         for x in req_authentication_tables.union(req_authorization_tables)
     ]
@@ -362,7 +384,11 @@ def source_tables_for_app(application_template):
             'database': x.external_database,
             'schema': 'public',
             'table': x.table_name,
-            'dataset': {'id': x.uuid, 'name': x.name},
+            'dataset': {
+                'id': x.uuid,
+                'name': x.name,
+                'user_access_type': 'REQUIRES_AUTHENTICATION',
+            },
         }
         for x in ReferenceDataset.objects.live()
         .filter(published=True, deleted=False)

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -84,9 +84,25 @@
         display: block;
         font-weight: normal;
     }
-    .visualisation-dataset-schema-table {
-        display: block;
-        font-weight: normal;
+    .visualisation-dataset__item {
+        border-bottom: 1px solid #b1b4b6;
+    }
+    .visualisation-dataset__label {
+        padding-top: 0;
+        padding-bottom: 0;
+        font-weight: bold;
+    }
+    /* The default GDS styles the labels of disable elements as grey using
+       opacity. However, this looks a bit _too_ disabled in the case of
+       selected but disabled items. So we override to only disable the
+       checkbox, which is made of the :before and :after pseudo elements of
+       the label */
+    .govuk-checkboxes__input:disabled + .visualisation-dataset__label {
+        opacity: 1.0;
+    }
+    .govuk-checkboxes__input:disabled + .visualisation-dataset__label:before,
+    .govuk-checkboxes__input:disabled + .visualisation-dataset__label:after {
+        opacity: 0.5;
     }
     .list-item-with-prefix::before {
         content: "—";

--- a/dataworkspace/dataworkspace/templates/visualisation_datasets.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_datasets.html
@@ -4,35 +4,46 @@
 {% block page_title %}Datasets - {{ block.super }}{% endblock %}
 
 {% block content %}
-<h1 class="govuk-heading-l govuk-!-margin-bottom-6">
-    <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
-    Datasets
-</h1>
 
-{% if not datasets %}
-<p class="govuk-body">This visualisation does not have access to any datasets.
-{% endif %}
+<form method="POST" action="{{ request.path }}" novalidate>
+    {% csrf_token %}
 
-{% if datasets %}
-<p class="govuk-body">This visualisation has SQL access to the following datasets. The tables of each dataset are listed in the format "schema"."table".</p>
+    <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l govuk-!-margin-bottom-6">
+            <h1 class="govuk-fieldset__heading">
+                <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
+                Datasets
+            </h1>
+        </legend>
 
-<dl class="govuk-summary-list">
-    {% for dataset, tables in datasets %}
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-            {{ dataset.name }}
+        <p class="govuk-body">You can give this visualisation SQL access to any dataset that you have access to. You cannot remove access from datasets that are available to all Data Workspace users.</p>
 
-            {% for table in tables %}
-            <span class="visualisation-dataset-schema-table">"{{ table.schema|zero_width_space_after:'_' }}"."{{ table.table|zero_width_space_after:'_' }}"</span>
+        <p class="govuk-body">The tables of each dataset are listed in the format "schema"."table".</p>
+
+        <div class="govuk-checkboxes">
+            {% for dataset, tables in datasets %}
+            <div class="govuk-checkboxes__item visualisation-dataset__item govuk-!-margin-top-5 govuk-!-padding-bottom-5 {% if forloop.last %} govuk-!-margin-bottom-5{% endif %}">
+                <input class="govuk-checkboxes__input" id="dataset-{{ dataset.id }}" name="dataset" type="checkbox" value="{{ dataset.id }}" aria-describedby="dataset-{{ dataset.id }}-hint"{% if not dataset.selectable %} disabled{% endif %}{% if dataset.selected %} checked{% endif %}>
+                <label class="govuk-label govuk-checkboxes__label visualisation-dataset__label" for="dataset-{{ dataset.id }}">
+                    {{ dataset.name }}
+                </label>
+                <span id="dataset-{{ dataset.id }}-hint" class="govuk-checkboxes__hint">
+                    <ul class="govuk-list govuk-!-margin-bottom-1">
+                        {% for table in tables %}
+                        <li>
+                            "{{ table.schema|zero_width_space_after:'_' }}"."{{ table.table|zero_width_space_after:'_' }}"
+                        </li>
+                        {% endfor %}
+                    </ul>
+                    <a href="{% url 'datasets:dataset_detail' dataset.id %}" class="govuk-link govuk-link--no-visited-state">View catalogue item<span class="govuk-visually-hidden"> for {{ dataset.name }}</span></a>
+                </span>
+            </div>
             {% endfor %}
-        </dt>
+        </div>
+    </fieldset>
 
-        <dd class="govuk-summary-list__actions">
-            <a href="{% url 'datasets:dataset_detail' dataset.id %}" class="govuk-link govuk-link--no-visited-state">View catalogue item<span class="govuk-visually-hidden"> for {{ dataset.name }}</span></a>
-        </dd>
-    </div>
-    {% endfor %}
-</dl>
-{% endif %}
-
+    <button class="govuk-button" data-module="govuk-button" type="submit" data-prevent-double-click="true">
+        Save datasets access
+    </button>
+</form>
 {% endblock %}

--- a/test/dataset_server.py
+++ b/test/dataset_server.py
@@ -5,6 +5,7 @@ import sys
 
 import aiopg
 from aiohttp import web
+import psycopg2.sql
 
 
 async def async_main():
@@ -15,18 +16,28 @@ async def async_main():
         logger.setLevel(logging.DEBUG)
         logger.addHandler(stdout_handler)
 
-    pool = await aiopg.create_pool(os.environ['DATABASE_DSN__my_database'])
+    async def handle_stop(_):
+        sys.exit()
 
-    async def handle_http(_):
-        async with pool.acquire() as conn:
-            async with conn.cursor() as cur:
-                await cur.execute('SELECT * FROM test_dataset')
-                rows = [row[0] for row in await cur.fetchall()]
+    async def handle_dataset(request):
+        database = request.match_info['database']
+        table = request.match_info['table']
+        dsn = os.environ[f'DATABASE_DSN__{database}']
+        async with aiopg.create_pool(dsn) as pool:
+            async with pool.acquire() as conn:
+                async with conn.cursor() as cur:
+                    await cur.execute(
+                        psycopg2.sql.SQL('SELECT * FROM {}').format(
+                            psycopg2.sql.Identifier(table)
+                        )
+                    )
+                    rows = [row[0] for row in await cur.fetchall()]
 
         return web.json_response({'data': rows}, status=200)
 
     upstream = web.Application()
-    upstream.add_routes([web.get('/http', handle_http)])
+    upstream.add_routes([web.post('/stop', handle_stop)])
+    upstream.add_routes([web.get('/{database}/{table}', handle_dataset)])
     upstream_runner = web.AppRunner(upstream)
     await upstream_runner.setup()
     upstream_site = web.TCPSite(upstream_runner, '0.0.0.0', 8888)

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -500,6 +500,7 @@ class TestApplication(unittest.TestCase):
         table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'
         stdout, stderr, code = await create_private_dataset(
             'my_database',
+            'MASTER',
             dataset_id_test_dataset,
             'test_dataset',
             table_id,
@@ -1087,6 +1088,7 @@ class TestApplication(unittest.TestCase):
         table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'
         stdout, stderr, code = await create_private_dataset(
             'my_database',
+            'DATACUT',
             dataset_id_test_dataset,
             'test_dataset',
             table_id,
@@ -1171,7 +1173,12 @@ class TestApplication(unittest.TestCase):
         dataset_id = '70ce6fdd-1791-4806-bbe0-4cf880a9cc37'
         table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'
         stdout, stderr, code = await create_private_dataset(
-            'my_database', dataset_id, 'test_dataset', table_id, 'test_dataset'
+            'my_database',
+            'MASTER',
+            dataset_id,
+            'test_dataset',
+            table_id,
+            'test_dataset',
         )
         self.assertEqual(stdout, b'')
         self.assertEqual(stderr, b'')
@@ -1386,7 +1393,12 @@ class TestApplication(unittest.TestCase):
         table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'
         url = f'http://dataworkspace.test:8000/api/v1/dataset/{dataset_id}/{table_id}'
         stdout, stderr, code = await create_private_dataset(
-            'my_database', dataset_id, 'test_dataset', table_id, 'test_dataset'
+            'my_database',
+            'MASTER',
+            dataset_id,
+            'test_dataset',
+            table_id,
+            'test_dataset',
         )
         self.assertEqual(stdout, b'')
         self.assertEqual(stderr, b'')
@@ -1969,7 +1981,7 @@ async def create_many_users():
 
 
 async def create_private_dataset(
-    database, dataset_id, dataset_name, table_id, table_name
+    database, dataset_type, dataset_id, dataset_name, table_id, table_name
 ):
     python_code = textwrap.dedent(
         f"""\
@@ -1979,6 +1991,7 @@ async def create_private_dataset(
             SourceTable,
             DatasetReferenceCode,
         )
+        from dataworkspace.apps.datasets.constants import DataSetType
         reference_code, _ = DatasetReferenceCode.objects.get_or_create(code='TEST')
         dataset = DataSet.objects.create(
             name="{dataset_name}",
@@ -1988,6 +2001,7 @@ async def create_private_dataset(
             id="{dataset_id}",
             published=True,
             reference_code=reference_code,
+            type=DataSetType.{dataset_type}.value,
         )
         SourceTable.objects.create(
             id="{table_id}",

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -99,8 +99,9 @@ class TestApplication(unittest.TestCase):
 
         self.assertIn('Test Application is loading...', application_content_2)
 
-        # There are forced sleeps in starting a process
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testapplication-23b40dd9.dataworkspace.test:8000/'
+        )
 
         # The initial connection has to be a GET, since these are redirected
         # to SSO. Unsure initial connection being a non-GET is a feature that
@@ -210,7 +211,10 @@ class TestApplication(unittest.TestCase):
             content = await response.text()
 
         self.assertIn('Test Application is loading...', content)
-        await asyncio.sleep(10)
+
+        await until_non_202(
+            session, 'http://testapplication-23b40dd9.dataworkspace.test:8000/'
+        )
 
         sent_headers = {'from-downstream': 'downstream-header-value'}
         async with session.request(
@@ -330,7 +334,9 @@ class TestApplication(unittest.TestCase):
 
         self.assertIn('testvisualisation is loading...', application_content_1)
 
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testvisualisation.dataworkspace.test:8000/'
+        )
 
         sent_headers = {'from-downstream': 'downstream-header-value'}
         async with session.request(
@@ -436,7 +442,9 @@ class TestApplication(unittest.TestCase):
         self.assertIn('testvisualisation [58d9e87e]', application_content_1)
         self.assertIn('is loading...', application_content_1)
 
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testvisualisation--58d9e87e.dataworkspace.test:8000/'
+        )
 
         sent_headers = {'from-downstream': 'downstream-header-value'}
         async with session.request(
@@ -568,7 +576,9 @@ class TestApplication(unittest.TestCase):
 
         self.assertIn('testvisualisation-a is loading...', application_content_1)
 
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testvisualisation-a.dataworkspace.test:8000/'
+        )
 
         async with session.request(
             'GET',
@@ -653,7 +663,9 @@ class TestApplication(unittest.TestCase):
 
         self.assertIn('testvisualisation-b is loading...', application_content_2)
 
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testvisualisation-b.dataworkspace.test:8000/'
+        )
 
         async with session.request(
             'GET',
@@ -722,8 +734,9 @@ class TestApplication(unittest.TestCase):
 
         self.assertIn('Test Application is loading...', application_content_2)
 
-        # There are forced sleeps in starting a process
-        await asyncio.sleep(10)
+        await until_non_202(
+            session, 'http://testapplication-23b40dd9.dataworkspace.test:8000/'
+        )
 
         # The initial connection has to be a GET, since these are redirected
         # to SSO. Unsure initial connection being a non-GET is a feature that
@@ -1807,6 +1820,16 @@ async def until_succeeds(url):
                 await asyncio.sleep(0.1)
             else:
                 break
+
+
+async def until_non_202(session, url):
+    for _ in range(0, 600):
+        async with session.request('GET', url) as response:
+            if response.status != 202:
+                return
+        await asyncio.sleep(0.1)
+
+    raise Exception()
 
 
 async def flush_database():


### PR DESCRIPTION
### Description of change

<img width="876" alt="Screenshot 2020-04-27 at 16 07 08" src="https://user-images.githubusercontent.com/13877/80388057-537c7900-88a1-11ea-9b30-8e9a5f033303.png">

I did attempt to mirror the Users pages "Give access" and "With access", but it felt really awkward/clunky, as well as being seemingly impossible to come up with some reasonable names for those pages.

Also removed the text that is displayed when there are no datasets: there are always some datasets in the list in production (and also couldn't think of anything that seemed both accurate and concise in this this were to happen).

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
~* [ ] Has the README been updated (if needed)?~
