### PR TITLE
Add publishing page to data vis UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Close database connection after each Celery task as attempt to address database connection usage/(leak?)
 - Smaller chance of parallel starts of the same application surfacing an error
 - Updated the text on the data vis ui approvals page to be more explicit around the requirements.
+- Publishing page for data vis UI.
 
 ## 2020-04-23
 

--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -431,6 +431,7 @@ class VisualisationTemplateAdmin(admin.ModelAdmin):
             None,
             {
                 'fields': [
+                    'visible',
                     'host_basename',
                     'nice_name',
                     'spawner',

--- a/dataworkspace/dataworkspace/apps/applications/models.py
+++ b/dataworkspace/dataworkspace/apps/applications/models.py
@@ -19,7 +19,14 @@ class ApplicationTemplate(TimeStampedModel):
         help_text='Used in URLs: only lowercase letters allowed',
         unique=False,
     )
-    visible = models.BooleanField(default=True, null=False)
+    visible = models.BooleanField(
+        default=True,
+        null=False,
+        help_text=(
+            "For tools, whether this appears on the Tools page. "
+            "For visualisations, whether it's accessible at its production URL."
+        ),
+    )
 
     # We expect lots of visualisations with fixed hosts, so we use a undex to ensure
     # that lookups from hostname to application templates are fast...
@@ -104,7 +111,6 @@ class VisualisationTemplate(ApplicationTemplate):
     def save(
         self, force_insert=False, force_update=False, using=None, update_fields=None
     ):
-        self.visible = False
         self.application_type = 'VISUALISATION'
 
         super(VisualisationTemplate, self).save(

--- a/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
+++ b/dataworkspace/dataworkspace/apps/applications/urls_visualisations.py
@@ -9,6 +9,7 @@ from dataworkspace.apps.applications.views import (
     visualisation_catalogue_item_html_view,
     visualisation_approvals_html_view,
     visualisation_datasets_html_view,
+    visualisation_publish_html_view,
 )
 
 urlpatterns = [
@@ -42,5 +43,10 @@ urlpatterns = [
         '<str:gitlab_project_id>/datasets',
         login_required(visualisation_datasets_html_view),
         name='datasets',
+    ),
+    path(
+        '<str:gitlab_project_id>/publish',
+        login_required(visualisation_publish_html_view),
+        name='publish',
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -183,16 +183,18 @@ def application_api_is_allowed(request, public_host):
             and request.user.has_perm('applications.start_all_applications')
         )
 
-    def is_visualisation_and_requires_authentication():
+    def is_published_visualisation_and_requires_authentication():
         return (
             not is_preview
+            and application_template.visible is True
             and application_template.application_type == 'VISUALISATION'
             and application_template.user_access_type == 'REQUIRES_AUTHENTICATION'
         )
 
-    def is_visualisation_and_requires_authorisation_and_has_authorisation():
+    def is_published_visualisation_and_requires_authorisation_and_has_authorisation():
         return (
             not is_preview
+            and application_template.visible is True
             and application_template.application_type == 'VISUALISATION'
             and application_template.user_access_type == 'REQUIRES_AUTHORIZATION'
             and request.user.applicationtemplateuserpermission_set.filter(
@@ -211,8 +213,8 @@ def application_api_is_allowed(request, public_host):
 
     return (
         is_tool_and_correct_user_and_allowed_to_start()
-        or is_visualisation_and_requires_authentication()
-        or is_visualisation_and_requires_authorisation_and_has_authorisation()
+        or is_published_visualisation_and_requires_authentication()
+        or is_published_visualisation_and_requires_authorisation_and_has_authorisation()
         or is_visualisation_preview_and_has_gitlab_developer()
     )
 

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -195,3 +195,7 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
       top: 15px;  /* The original GDS value */
   }
 }
+
+.app-\!-fill-width {
+    width: 100%
+}

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -165,5 +165,10 @@
             Approvals
         </a>
     </li>
+    <li class="nav-item{% if current_menu_item == 'publish' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
+        <a href="{% url 'visualisations:publish' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'publish' %} nav-item-link--current{% endif %}">
+            Publish
+        </a>
+    </li>
 </ul>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/visualisation_publish.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_publish.html
@@ -1,0 +1,99 @@
+{% extends '_visualisation.html' %}
+{% load core_filters %}
+
+{% block head %}
+{{ block.super }}
+{{ form.media }}
+{% endblock %}
+
+{% block page_title %}{% if form.errors %}Error: {% endif %}Catalogue item - {{ block.super }}{% endblock %}
+
+{% block content %}
+{% if errors %}
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+    {% for error_url, error_text in errors %}
+        <li>
+          <a href="{{ error_url }}">{{ error_text }}</a>
+        </li>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}
+
+<h1 class="govuk-heading-l govuk-!-margin-bottom-6">
+  <span class="govuk-caption-l">{{ gitlab_project.name }}</span>
+  Publish
+</h1>
+
+<p class="govuk-body">
+  In order to publish this visualisation, at least two users must have <a class="govuk-link" href="{% url 'visualisations:approvals' gitlab_project.id %}">approved</a> it.
+</p>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body" id="visualisation-explanation">
+      {% if visualisation_published %}
+      Unpublish this visualisation to stop users from accessing it at the
+      <a class="govuk-link" style="white-space: nowrap;" href="{{ visualisation_link }}">production domain</a>.
+      {% else %}
+      Publish this visualisation to make the latest release available for users at the
+      <a class="govuk-link" style="white-space: nowrap;" href="{{ visualisation_link }}">production domain</a>.
+      {% endif %}
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <form method="POST" action="{{ request.path }}">
+      {% csrf_token %}
+      <button type="submit" class="govuk-button app-!-fill-width{% if not visualisation_published and not approved %} govuk-button--disabled{% endif %}" name="action" value="{% if visualisation_published %}unpublish-visualisation{% else %}publish-visualisation{% endif %}" aria-labelledby="visualisation-explanation">
+        {% if visualisation_published %}
+          Unpublish visualisation
+        {% else %}
+          Publish visualisation
+        {% endif %}
+      </button>
+    </form>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body" id="catalogue-explanation">
+      {% if catalogue_published %}
+      Unpublish the
+      <a class="govuk-link" href="{% url 'visualisations:catalogue-item' gitlab_project.id %}">catalogue item</a>
+      to stop users from being able to discover the visualisation on
+      <a class="govuk-link" href="{% url 'root' %}">Data Workspace</a>.
+      {% else %}
+      Publish the
+      <a class="govuk-link" href="{% url 'visualisations:catalogue-item' gitlab_project.id %}">catalogue item</a>
+      to let users discover this visualisation on
+      <a class="govuk-link" href="{% url 'root' %}">Data Workspace</a>.
+      {% endif %}
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <form method="POST" action="{{ request.path }}">
+      {% csrf_token %}
+
+      <button type="submit" class="govuk-button app-!-fill-width{% if not approved or not visualisation_published or not catalogue_complete %} govuk-button--disabled{% endif %}" name="action" value="{% if catalogue_published %}unpublish-catalogue{% else %}publish-catalogue{% endif %}" aria-labelledby="catalogue-explanation">
+        {% if catalogue_published %}
+          Unpublish catalogue item
+        {% else %}
+          Publish catalogue item
+        {% endif %}
+      </button>
+    </form>
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
### Description of change
Adds a page to the Data Vis UI that allows a data vis creator to
publish/unpublish both the production visualisation URL, and the
catalogue item. These respectively control whether the visualisation
can accessed at its prod URL, and whether other users can discover the
visualisation exists at all in the Data Workspace catalogue.

Ticket: https://trello.com/c/FJLZZZAP/980

### Show it
![screencapture-dataworkspace-test-8000-visualisations-6-publish-2020-04-24-13_04_30](https://user-images.githubusercontent.com/2920760/80210736-296e5100-862c-11ea-850a-ad8ccea6aa2d.png)
![screencapture-dataworkspace-test-8000-visualisations-6-publish-2020-04-24-13_04_35](https://user-images.githubusercontent.com/2920760/80210739-2a06e780-862c-11ea-9bc5-3f812f748eaa.png)


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
