### PR TITLE
Add eligibility criteria to data vis UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - A zero-width space after an underscore in the visualisation datasets page to encourage line breaks in more readable places
 - Eligibility criteria to visualisation catalogue items.
+- Eligibility criteria to data vis UI catalogue page.
 
 ### Changed
 

--- a/dataworkspace/dataworkspace/templates/partials/bullet_list_split_array_widget.html
+++ b/dataworkspace/dataworkspace/templates/partials/bullet_list_split_array_widget.html
@@ -1,0 +1,16 @@
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend">
+      {{ widget.label }}
+    </legend>
+
+    <ul class="govuk-list govuk-list--bullet">
+      {% for widget in widget.subwidgets %}
+        <li>
+          <label class="govuk-visually-hidden" for="{{ widget.attrs.id }}">{{ widget.label }}</label>
+          {% include widget.template_name %}
+        </li>
+      {% endfor %}
+    </ul>
+  </fieldset>
+</div>

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -50,6 +50,8 @@
   {% include "partials/govuk_basic_form_field.html" with field=form.personal_data %}
   {% include "partials/govuk_basic_form_field.html" with field=form.restrictions_on_usage %}
 
+  {{ form.eligibility_criteria }}
+
   <input type="submit" class="govuk-button" value="Save" />
 </form>
 {% endblock %}


### PR DESCRIPTION
### Description of change
Let data vis creators edit the eligibility criteria for their
visualisation. This is whole-heartedly an MVP design.

Ticket: https://trello.com/c/BehUXL2e/1011

### Show it
![screencapture-dataworkspace-test-8000-visualisations-6-catalogue-item-2020-04-25-10_08_09](https://user-images.githubusercontent.com/2920760/80275925-b244c580-86dc-11ea-87dc-bae9c287f79b.png)

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
