### PR TITLE
(feat) Slightly better handling of concurrent adding of visualisation access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-04-26
+
+### Changed
+
+- Slightly better handling of concurrent giving of visualisation access
+
 ## 2020-04-24
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -538,22 +538,21 @@ def visualisation_users_give_access_html_POST(request, gitlab_project):
 
     content_type_id = ContentType.objects.get_for_model(user).pk
 
-    with transaction.atomic():
-        try:
+    try:
+        with transaction.atomic():
             ApplicationTemplateUserPermission.objects.create(
                 user=user, application_template=application_template
             )
-        except IntegrityError:
-            return error(f'{user.get_full_name()} already has access')
-
-        LogEntry.objects.log_action(
-            user_id=request.user.pk,
-            content_type_id=content_type_id,
-            object_id=user.id,
-            object_repr=force_str(user),
-            action_flag=CHANGE,
-            change_message=f'Added visualisation {application_template} permission',
-        )
+            LogEntry.objects.log_action(
+                user_id=request.user.pk,
+                content_type_id=content_type_id,
+                object_id=user.id,
+                object_repr=force_str(user),
+                action_flag=CHANGE,
+                change_message=f'Added visualisation {application_template} permission',
+            )
+    except IntegrityError:
+        return error(f'{user.get_full_name()} already has access')
 
     messages.success(
         request,


### PR DESCRIPTION
### Description of change
The try/except and transaction were the wrong way round, i.e. if two people added the same user at the exact same time, at the end of the transaction one of them would raise IntegrityError and result in a 500.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
