### PR TITLE
Auth checkbox on data vis UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Automatically lowercase emails in data vis UI catalogue page before searching db.
 
+## 2020-04-27
+
+### Added
+
+- User access type checkbox to data vis UI catalogue page.
+
 ## 2020-04-26
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -26,6 +26,7 @@ from dataworkspace.apps.api_v1.views import (
 from dataworkspace.apps.applications.forms import (
     VisualisationsUICatalogueItemForm,
     VisualisationApprovalForm,
+    VisualisationsUITemplate,
 )
 from dataworkspace.apps.applications.gitlab import (
     DEVELOPER_ACCESS_LEVEL,
@@ -766,8 +767,12 @@ def _get_visualisation_catalogue_item_for_gitlab_project(gitlab_project):
 
 
 def visualisation_catalogue_item_html_GET(request, gitlab_project):
-    form = VisualisationsUICatalogueItemForm(
-        instance=_get_visualisation_catalogue_item_for_gitlab_project(gitlab_project)
+    catalogue_item = _get_visualisation_catalogue_item_for_gitlab_project(
+        gitlab_project
+    )
+    form = VisualisationsUICatalogueItemForm(instance=catalogue_item)
+    template_form = VisualisationsUITemplate(
+        instance=catalogue_item.visualisation_template
     )
 
     # We don't want client-side validation on this field, so we remove it - but only for the GET request.
@@ -779,23 +784,30 @@ def visualisation_catalogue_item_html_GET(request, gitlab_project):
         gitlab_project,
         _visualisation_branches(gitlab_project),
         current_menu_item='catalogue-item',
-        template_specific_context={'form': form},
+        template_specific_context={'form': form, 'template_form': template_form},
     )
 
 
 def visualisation_catalogue_item_html_POST(request, gitlab_project):
-    form = VisualisationsUICatalogueItemForm(
-        request.POST,
-        instance=_get_visualisation_catalogue_item_for_gitlab_project(gitlab_project),
+    catalogue_item = _get_visualisation_catalogue_item_for_gitlab_project(
+        gitlab_project
     )
-    if form.is_valid():
-        form.save()
+    form = VisualisationsUICatalogueItemForm(request.POST, instance=catalogue_item)
+    template_form = VisualisationsUITemplate(
+        request.POST, instance=catalogue_item.visualisation_template
+    )
+    if form.is_valid() and template_form.is_valid():
+        with transaction.atomic():
+            form.save()
+            template_form.save()
         return redirect(
             'visualisations:catalogue-item', gitlab_project_id=gitlab_project['id']
         )
 
     form_errors = [
         (field.id_for_label, field.errors[0]) for field in form if field.errors
+    ] + [
+        (field.id_for_label, field.errors[0]) for field in template_form if field.errors
     ]
 
     return _render_visualisation(
@@ -804,7 +816,11 @@ def visualisation_catalogue_item_html_POST(request, gitlab_project):
         gitlab_project,
         _visualisation_branches(gitlab_project),
         current_menu_item='catalogue-item',
-        template_specific_context={"form": form, "form_errors": form_errors},
+        template_specific_context={
+            "form": form,
+            "template_form": template_form,
+            "form_errors": form_errors,
+        },
         status=400 if form_errors else 200,
     )
 

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -347,6 +347,7 @@ def visualisation_branch_html_GET(request, gitlab_project, branch_name):
         request,
         'visualisation_branch.html',
         gitlab_project,
+        application_template,
         branches,
         current_menu_item='branches',
         template_specific_context={
@@ -428,6 +429,7 @@ def visualisation_users_with_access_html_GET(request, gitlab_project):
         request,
         'visualisation_users_with_access.html',
         gitlab_project,
+        application_template,
         branches,
         current_menu_item='users-with-access',
         template_specific_context={
@@ -508,6 +510,7 @@ def visualisation_users_give_access_html_GET(request, gitlab_project, token_data
         request,
         'visualisation_users_give_access.html',
         gitlab_project,
+        application_template,
         branches,
         current_menu_item='users-give-access',
         template_specific_context={
@@ -528,6 +531,7 @@ def visualisation_users_give_access_html_POST(request, gitlab_project, token_dat
             request,
             'visualisation_users_give_access.html',
             gitlab_project,
+            application_template,
             branches,
             current_menu_item='users-give-access',
             template_specific_context={
@@ -712,6 +716,7 @@ def _render_visualisation(
     request,
     template,
     gitlab_project,
+    application_template,
     branches,
     current_menu_item,
     template_specific_context,
@@ -725,6 +730,8 @@ def _render_visualisation(
         template,
         {
             'gitlab_project': gitlab_project,
+            'show_users_section': application_template.user_access_type
+            == 'REQUIRES_AUTHORIZATION',
             'branches': branches,
             'current_menu_item': current_menu_item,
             **template_specific_context,
@@ -782,6 +789,7 @@ def visualisation_catalogue_item_html_GET(request, gitlab_project):
         request,
         'visualisation_catalogue_item.html',
         gitlab_project,
+        catalogue_item.visualisation_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='catalogue-item',
         template_specific_context={'form': form, 'template_form': template_form},
@@ -814,6 +822,7 @@ def visualisation_catalogue_item_html_POST(request, gitlab_project):
         request,
         'visualisation_catalogue_item.html',
         gitlab_project,
+        catalogue_item.visualisation_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='catalogue-item',
         template_specific_context={
@@ -864,6 +873,7 @@ def visualisation_approvals_html_GET(request, gitlab_project):
         request,
         'visualisation_approvals.html',
         gitlab_project,
+        application_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='approvals',
         template_specific_context={
@@ -903,6 +913,7 @@ def visualisation_approvals_html_POST(request, gitlab_project):
         request,
         'visualisation_approvals.html',
         gitlab_project,
+        application_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='approvals',
         template_specific_context={"form": form, "form_errors": form_errors},
@@ -936,6 +947,7 @@ def visualisation_datasets_html_GET(request, gitlab_project):
         request,
         'visualisation_datasets.html',
         gitlab_project,
+        application_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='datasets',
         template_specific_context={'datasets': datasets},
@@ -1179,6 +1191,7 @@ def _render_visualisation_publish_html(
         request,
         'visualisation_publish.html',
         gitlab_project,
+        application_template,
         _visualisation_branches(gitlab_project),
         current_menu_item='publish',
         template_specific_context={

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -196,4 +196,7 @@
   <script nonce="{{ request.csp_nonce }}">
     window.GOVUKFrontend.initAll();
   </script>
+
+  {% block footer_scripts %}
+  {% endblock %}
 </body>

--- a/dataworkspace/dataworkspace/templates/_visualisation.html
+++ b/dataworkspace/dataworkspace/templates/_visualisation.html
@@ -148,6 +148,7 @@
             {% endfor %}
         </ul>
     </li>
+    {% if show_users_section %}
     <li class="nav-item{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
         <a href="{% url 'visualisations:users-give-access' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'users-give-access' or current_menu_item == 'users-with-access' %} nav-item-link--current{% endif %}">
             Users
@@ -166,6 +167,7 @@
             </li>
         </ul>
     </li>
+    {% endif %}
     <li class="nav-item{% if current_menu_item == 'datasets' %} nav-item--current{% endif %} govuk-!-margin-bottom-6">
         <a href="{% url 'visualisations:datasets' gitlab_project.id %}" class="govuk-link govuk-link--no-visited-state nav-item-link{% if current_menu_item == 'datasets' %} nav-item-link--current{% endif %}">
             Datasets

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -49,6 +49,7 @@
   {% include "partials/govuk_basic_form_field.html" with field=form.retention_policy %}
   {% include "partials/govuk_basic_form_field.html" with field=form.personal_data %}
   {% include "partials/govuk_basic_form_field.html" with field=form.restrictions_on_usage %}
+  {% include "partials/govuk_single_checkbox_field.html" with field=template_form.user_access_type %}
 
   {{ form.eligibility_criteria }}
 

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -61,7 +61,7 @@
 
 {% block footer_scripts %}
   {{ block.super }}
-  
+
   <script nonce="{{ request.csp_nonce }}">
     var user_access_type = document.getElementById('{{ template_form.user_access_type.id_for_label }}');
     var eligibility_criteria = document.getElementById('js-eligibility-criteria-wrapper');

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -51,8 +51,31 @@
   {% include "partials/govuk_basic_form_field.html" with field=form.restrictions_on_usage %}
   {% include "partials/govuk_single_checkbox_field.html" with field=template_form.user_access_type %}
 
-  {{ form.eligibility_criteria }}
+  <div id="js-eligibility-criteria-wrapper">
+    {{ form.eligibility_criteria }}
+  </div>
 
   <input type="submit" class="govuk-button" value="Save" />
 </form>
+{% endblock %}
+
+{% block footer_scripts %}
+  {{ block.super }}
+  
+  <script nonce="{{ request.csp_nonce }}">
+    var user_access_type = document.getElementById('{{ template_form.user_access_type.id_for_label }}');
+    var eligibility_criteria = document.getElementById('js-eligibility-criteria-wrapper');
+
+    user_access_type.addEventListener('change', function (e) {
+       if (e.target.checked) {
+          eligibility_criteria.classList.remove('govuk-visually-hidden');
+       }  else {
+          eligibility_criteria.classList.add('govuk-visually-hidden');
+       }
+    });
+
+    if (user_access_type.checked === false) {
+        eligibility_criteria.classList.add('govuk-visually-hidden');
+    }
+  </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/applications/test_views.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_views.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from unittest import mock
 
 import pytest
+from django.contrib.admin.models import LogEntry
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.test import Client
@@ -75,6 +76,7 @@ class TestDataVisualisationUICataloguePage:
     def test_can_set_user_access_type(
         self, staff_client, start_type, post_type, expected_type
     ):
+        log_count = LogEntry.objects.count()
         visualisation = factories.VisualisationCatalogueItemFactory.create(
             short_description="summary",
             published=False,
@@ -98,6 +100,7 @@ class TestDataVisualisationUICataloguePage:
         visualisation.refresh_from_db()
         assert response.status_code == 200
         assert visualisation.visualisation_template.user_access_type == expected_type
+        assert LogEntry.objects.count() == log_count + 1
 
     def test_bad_post_data_no_short_description(self, staff_client):
         visualisation = factories.VisualisationCatalogueItemFactory.create(


### PR DESCRIPTION
### Description of change
Adds a checkbox to the "catalogue item" page in the data vis UI for data vis creators to set whether the vis is available to all logged-in users, or just to a set of explicitly-authorised people.

If it's open for all logged-in users, creators don't need to provide eligibility criteria or manage users with access - so we hide both those sections.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
