### PR TITLE
(feat) Use Fargate 1.4.0 for tools and visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-05-07
 
+### Changed
+
 - Multiuser Supserset to use CSP
 - Fix redirects returned by Superset to maintain HTTPS
 - Put Superset behind the VPN
+- Use Fargate 1.4.0 for tools and visualisations
 
 ## 2020-05-06
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -627,4 +627,5 @@ def _fargate_task_run(
                 'subnets': subnets,
             }
         },
+        platformVersion='1.4.0',
     )

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -133,6 +133,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
   }
 
   # For Fargate to start tasks
+  # When fully moved over to Fargate 1.4.0, suspect can restrict to more
+  # specific execution roles
   statement {
     principals {
       type = "AWS"
@@ -140,6 +142,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
     }
 
     actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer"
     ]

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -648,6 +648,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_gitlab_runner" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_notebooks" {
+  description = "ingress-https-from-notebooks"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.notebooks.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 


### PR DESCRIPTION
### Description of change

This will

- Bump the amount of space in user's home directories from 4GB to (20GB - docker image size)

- Allow EFS mounts, so maybe could bump it even more

Note that not specifying the platform defaults to LATEST https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task, but LATEST actually means 1.3.0 https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html

The traffic to ECR when starting a tool/visualisation, as per https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/ now comes from the Task ENI, as opposed to the semi-magic "Fargate ENI". So we need to

- allow ingress at the IP level to the ECR VPC endpoint from notebooks

- make the IAM policy associated with the VPC endpoint allow access that was previously didn't go through it.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
