### PR TITLE
(feat) Nicer apt-get update from Theia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix Theia missing menu on new builds by locking dependencies
 - Default to Python 3 in Theia
+- Fewer errors when running apt-get update in Theia
 
 ## 2020-05-01
 

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -35,7 +35,9 @@ RUN \
 		python3-pip \
 		sudo && \
 	curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs && \
+    rm /etc/apt/sources.list.d/nodesource.list && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN \
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 2 && \


### PR DESCRIPTION
### Description of change

Running `sudo apt-get update` from Theia showed errors since it was trying to contact deb.nodesource.com.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
