### PR TITLE
Fix bug where proxy was checking for incorrect accounts url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-06
+
+### Changed
+
+- Fix issue where proxy was denying access to accounts api endpoint
+
 ## 2020-05-05
 
 ### Changed

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -186,7 +186,7 @@ async def async_main():
             request.url.path.startswith('/api/v1/dataset/')
             or request.url.path.startswith('/api/v1/reference-dataset/')
             or request.url.path.startswith('/api/v1/eventlog/')
-            or request.url.path.startswith('/api/v1/accounts/')
+            or request.url.path.startswith('/api/v1/account/')
             or request.url.path.startswith('/api/v1/application-instance/')
             and request.url.host == root_domain_no_port
         )


### PR DESCRIPTION
### Description of change

Use correct endpoint when checking for hawk auth in the proxy.

This was fixed a while ago but was inadvertently reverted (by me)

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
