### PR TITLE
(fix) Pass x-forwarded-proto as https to Superset to fix redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2020-05-07
 
 - Multiuser Supserset to use CSP
+- Fix redirects returned by Superset to maintain HTTPS
 
 ## 2020-05-06
 

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -143,7 +143,7 @@ data "template_file" "admin_container_definitions" {
     google_analytics_site_id = "${var.google_analytics_site_id}"
     google_data_studio_connector_pattern = "${var.google_data_studio_connector_pattern}"
 
-    superset_root = "http://${aws_lb.superset_multiuser.dns_name}/"
+    superset_root = "https://${var.superset_internal_domain}/"
   }
 }
 

--- a/infra/ecs_main_superset_multiuser.tf
+++ b/infra/ecs_main_superset_multiuser.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_service" "superset_multiuser" {
   }
 
   depends_on = [
-    "aws_lb_listener.superset_multiuser_80",
+    "aws_lb_listener.superset_multiuser_443",
   ]
 }
 
@@ -141,10 +141,13 @@ resource "aws_lb" "superset_multiuser" {
   subnets            = ["${aws_subnet.private_without_egress.*.id}"]
 }
 
-resource "aws_lb_listener" "superset_multiuser_80" {
+resource "aws_lb_listener" "superset_multiuser_443" {
   load_balancer_arn = "${aws_lb.superset_multiuser.arn}"
-  port              = "80"
-  protocol          = "HTTP"
+  port              = "443"
+  protocol          = "HTTPS"
+
+  ssl_policy      = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  certificate_arn = "${aws_acm_certificate_validation.superset_multiuser_internal.certificate_arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.superset_multiuser_8000.arn}"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -116,6 +116,7 @@ variable gitlab_runner_key {}
 variable superset_multiuser_admin_users {}
 variable superset_multiuser_db_instance_class {}
 variable superset_multiuser_container_image {}
+variable superset_internal_domain {}
 
 locals {
   registry_container_name    = "jupyterhub-registry"

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -158,6 +158,35 @@ resource "aws_route53_record" "gitlab" {
   }
 }
 
+resource "aws_route53_record" "superset_multiuser_internal" {
+  provider = "aws.route53"
+  zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
+  name    = "${var.superset_internal_domain}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.superset_multiuser.dns_name}"
+    zone_id                = "${aws_lb.superset_multiuser.zone_id}"
+    evaluate_target_health = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "superset_multiuser_internal" {
+  domain_name       = "${aws_route53_record.superset_multiuser_internal.name}"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "superset_multiuser_internal" {
+  certificate_arn = "${aws_acm_certificate.superset_multiuser_internal.arn}"
+}
 
 # resource "aws_route53_record" "jupyterhub" {
 #   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -344,8 +344,8 @@ resource "aws_security_group_rule" "admin_service_egress_http_to_superset_lb" {
   source_security_group_id = "${aws_security_group.superset_multiuser_lb.id}"
 
   type        = "egress"
-  from_port   = "80"
-  to_port     = "80"
+  from_port   = "443"
+  to_port     = "443"
   protocol    = "tcp"
 }
 
@@ -1283,8 +1283,8 @@ resource "aws_security_group_rule" "superset_lb_ingress_http_admin_service" {
   source_security_group_id = "${aws_security_group.admin_service.id}"
 
   type        = "ingress"
-  from_port   = "80"
-  to_port     = "80"
+  from_port   = "443"
+  to_port     = "443"
   protocol    = "tcp"
 }
 


### PR DESCRIPTION
### Description of change

Unfortunately, an Application Load Balancer, even an internal Application Load Balancer like the one in front of Superset, with an HTTP listener apparently overrides x-forwarded-proto with `http`, which makes Superset think it's on HTTP rather than HTTPS, and Superset returns redirects to HTTP URLs, which browsers block due to the recently added CSP.

We could use a Network Load Balancer which will pass through the x-forwarded-proto header unchanged, but since target instances are in ECS/Fargate, they have to be added to the target group "by ip". This then results in the fact that from the point of view of the Superset service security group, they are connected to from the internal IP(s) of the network load balancer. These IPs are not fixed, and there is no way to attach a security group to a Network Load Balancer, so we have no apparently way of allowing internal access to the Superset service from its Network Load Balancer without allowing access from everything else in the VPC. We could put the Network Load Balancer in its own subnet, and use NACLs, but that's a lot more quite faffy infrastructure...

... so we make the Application Load Balancer an HTTPS listener, so it overrides x-forwarded-proto with the exact value it had: `https`.


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
