### PR TITLE
(feat) Run Theia on Fargte 1.4.0

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -194,6 +194,8 @@ class FargateSpawner:
             s3_host = options['S3_HOST']
             s3_bucket = options['S3_BUCKET']
 
+            platform_version = options.get('PLATFORM_VERSION', '1.3.0')
+
             database_env = {
                 f'DATABASE_DSN__{database["memorable_name"]}': f'host={database["db_host"]} '
                 f'port={database["db_port"]} sslmode=require dbname={database["db_name"]} '
@@ -282,6 +284,7 @@ class FargateSpawner:
                         cmd,
                         {**s3_env, **database_env, **schema_env, **env},
                         s3_sync,
+                        platform_version,
                     )
                 except ClientError:
                     gevent.sleep(3)
@@ -586,6 +589,7 @@ def _fargate_task_run(
     command_and_args,
     env,
     s3_sync,
+    platform_version,
 ):
     client = boto3.client('ecs')
 
@@ -627,4 +631,5 @@ def _fargate_task_run(
                 'subnets': subnets,
             }
         },
+        platformVersion=platform_version,
     )

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -140,6 +140,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
     }
 
     actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer"
     ]

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -932,6 +932,10 @@
   "value": "${notebooks_bucket}"
 },
 {
+  "name": "APPLICATION_TEMPLATES__10__SPAWNER_OPTIONS__PLATFORM_VERSION",
+  "value": "1.4.0"
+},
+{
   "name": "APPLICATION_TEMPLATES__11__VISIBLE",
   "value": "False"
 },

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -648,6 +648,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_gitlab_runner" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_notebooks" {
+  description = "ingress-https-from-notebooks"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.notebooks.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -68,6 +68,7 @@ RUN \
 RUN \
 	addgroup --system --gid 4356 theia && \
 	adduser --disabled-password --gecos '' --ingroup theia --uid 4357 theia && \
+	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
 	echo "theia ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers
 
 RUN \
@@ -76,16 +77,8 @@ RUN \
 	touch /root/yarn-error.log && \
 	chown theia:theia /root/yarn-error.log
 
-USER theia
-
 ENV \
 	SHELL=/bin/bash
 
-CMD \
-	[ \
-		"yarn", "theia", "start", "/home/theia", \
-		"--plugins=local-dir:/root/plugins", \
-		"--hostname=0.0.0.0", \
-		"--port=8888", \
-		"--cache-folder=/tmp/.yarn-cache" \
-	]
+COPY start.sh /
+CMD ["/start.sh"]

--- a/theia/start.sh
+++ b/theia/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+chown -R theia:theia /home/theia
+
+sudo --user theia \
+  yarn theia start /home/theia \
+  --plugins=local-dir:/root/plugins \
+  --hostname=0.0.0.0  \
+  --port=8888 \
+  --cache-folder=/tmp/.yarn-cache


### PR DESCRIPTION
### Description of change


Just doing this on Theia for now since very few people are using it.

-----

This will:

- Bump the amount of space in user's home directories from 4GB to
  (20GB - docker image size)

- Allow EFS mounts, so maybe could bump it even more

Note that not specifying the platform defaults to LATEST
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task,
but LATEST actually means 1.3.0
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html

The traffic to ECR when starting a tool/visualisation, as per
https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/
now comes from the Task ENI, as opposed to the semi-magic "Fargate ENI".
So we need to

- allow ingress at the IP level to the ECR VPC endpoint from notebooks

- make the IAM policy associated with the VPC endpoint allow access that
  was previously didn't go through it.A

------

Initial tests seemed to show that volumes shared between containers in a
task are now owned by root, which means to write to them, the containers
must be started as root. AWS Support have so far given no explanation.
However, the container chmod the files to another user and then sudo
that user, so the network-facing service will not be run as root.



### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
