### PR TITLE
(feat) s3sync is Fargate 1.4.0 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 2020-05-07
 
+### Changed
+
 - Multiuser Supserset to use CSP
 - Fix redirects returned by Superset to maintain HTTPS
 - Put Superset behind the VPN
+- Made s3sync Fargate 1.4.0 compatible
 
 ## 2020-05-06
 

--- a/s3sync/Dockerfile
+++ b/s3sync/Dockerfile
@@ -7,10 +7,9 @@ CMD ["/start.sh"]
 USER root
 
 RUN \
+	apk add sudo && \
 	addgroup -S -g 4356 s3sync && \
 	adduser -S -u 4357 s3sync -G s3sync
-
-USER s3sync
 
 # Must be created to ensure it has the correct user permissions
 RUN mkdir /home/s3sync/data

--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chown -R s3sync:s3sync /home/s3sync/data
+
 # Path-style even though it's deprecated. The bucket names have dots in, and
 # at the time of writing the host-style certs returned by AWS are wildcards
 # and don't support dots in the bucket name
@@ -10,7 +12,7 @@ set -e
 # already on the remote _are_ synced to local
 # Exclude .__mobius3_flush__ files locally, since there is a suspected bug
 # in mobius3 where they can end up being uploaded
-mobius3 \
+sudo -E -u s3sync mobius3 \
     /home/s3sync/data \
     ${S3_BUCKET} \
     https://s3-${S3_REGION}.amazonaws.com/{}/ \


### PR DESCRIPTION
### Description of change
s3sync is a sidecar container running alongside tools: they share a
volume to both write to and read from.

Fargate 1.3.0, seems to preserve the ownership from the containers, the
s3sync user and group. However, in 1.4.0, it seems to now be owned by
root. To write to the volume, there seems to be little alternative than
to start the container as root.

However, we do this for a short a time as possible just to change
permissions on the shared folder, and then run the s3sync proper as the
lower-privilage s3sync user.

AWS Support have been contacted several days ago, but so far have
provided no explanation or alternative. Maybe previously named docker
volumes were used, and now they're bind mounts?

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
