### PR TITLE
(feat) Avoid TimeoutError and NetworkError when uploading lots of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Ability to run certain tasks and visualisations on Fargate 1.4.0
+- Task queue with limited concurrency to reduce chance of TimeoutError and NetworkError when uploading large number of files
 
 ## 2020-05-07
 


### PR DESCRIPTION
### Description of change

Attempting to upload large numbers of files at once results in the AWS SDK attempting to initiate at least one connection per file. This means:

- Because the browser limits how many open connections to a server at once there can be, the later files don't actually start uploading soon enough, and they timeout.

- The browser also apparently limits how many connections can be queued: e.g. attempting to upload 2000 files at once in Chrome results in net::ERR_INSUFFICIENT_RESOURCES in the console, and NetworkError exposed to the user

This was reported by a user attempting to upload 500 files at once, so attempting to behave with 2000 files at once I think is reasonable.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
