### PR TITLE
(feat) Ability to run tools or visualisations on Fargate 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2010-05-11
+
+### Added
+
+- Ability to run certain tasks and visualisations on Fargate 1.4.0
+
 ## 2020-05-07
+
+### Changed
 
 - Multiuser Supserset to use CSP
 - Fix redirects returned by Superset to maintain HTTPS

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -194,6 +194,8 @@ class FargateSpawner:
             s3_host = options['S3_HOST']
             s3_bucket = options['S3_BUCKET']
 
+            platform_version = options.get('PLATFORM_VERSION', '1.3.0')
+
             database_env = {
                 f'DATABASE_DSN__{database["memorable_name"]}': f'host={database["db_host"]} '
                 f'port={database["db_port"]} sslmode=require dbname={database["db_name"]} '
@@ -282,6 +284,7 @@ class FargateSpawner:
                         cmd,
                         {**s3_env, **database_env, **schema_env, **env},
                         s3_sync,
+                        platform_version,
                     )
                 except ClientError:
                     gevent.sleep(3)
@@ -586,6 +589,7 @@ def _fargate_task_run(
     command_and_args,
     env,
     s3_sync,
+    platform_version,
 ):
     client = boto3.client('ecs')
 
@@ -627,4 +631,5 @@ def _fargate_task_run(
                 'subnets': subnets,
             }
         },
+        platformVersion=platform_version,
     )

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -140,6 +140,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
     }
 
     actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
       "ecr:BatchGetImage",
       "ecr:GetDownloadUrlForLayer"
     ]

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -648,6 +648,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_gitlab_runner" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_notebooks" {
+  description = "ingress-https-from-notebooks"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.notebooks.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 


### PR DESCRIPTION
### Description of change

Not actually enabling for anything for now, since there are issues with
volume permissions and sudo. Specifically shared volumes between
containers end up owned by root, and also sudo fails, which means not
even starting the container as root and changing ownership will work. We
might be able to run as root, but will treat that as a last resort.

So, currently adding in the ability to switch between platform versions
in order to be able to switch to, and rollback from, any change without
a deployment.

For tools or visualisations on 1.4.0, this will:

- Bump the amount of space in user's home directories from 4GB to
  (20GB - docker image size)

- Eventually allow EFS mounts, so maybe could bump it even more, and
  move away from S3 for home directories

Note that not specifying the platform defaults to LATEST
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs.html#ECS.Client.run_task,
but LATEST actually means 1.3.0
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html

The traffic to ECR when starting a tool/visualisation, as per
https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/
now comes from the Task ENI, as opposed to the semi-magic "Fargate ENI".
So we need to

- allow ingress at the IP level to the ECR VPC endpoint from notebooks

- make the IAM policy associated with the VPC endpoint allow access that
  was previously didn't go through it.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
