### PR TITLE
Don't restrict resources for quicksight

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -538,7 +538,7 @@ data "aws_iam_policy_document" "admin_run_tasks" {
 
     resources = [
       # ECS doesn't provide more-specific permission for RegisterTaskDefinition
-      "arn:aws:quicksight::${data.aws_caller_identity.aws_caller_identity.account_id}:*",
+      "*",
     ]
   }
 }


### PR DESCRIPTION
### Description of change
The previous permission was too restrictive - prevented some API calls. For prototyping I think it's OK to open this up  rather than pinning down the exact perm/resource pairing.