### PR TITLE
(dev) Ability to load up Metabase locally

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -96,7 +96,7 @@ GITLAB_ECR_PROJECT_ID=4
 GITLAB_ECR_PROJECT_TRIGGER_TOKEN=some-token
 
 SUPERSET_ROOT=http://some.domain.test/
-METABASE_ROOT=http://some.domain.test/
+METABASE_ROOT=http://data-workspace-metabase:3000/
 
 QUICKSIGHT_USER_REGION=us-east-1
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight

--- a/.envs/test.env
+++ b/.envs/test.env
@@ -82,7 +82,7 @@ NOTIFY_API_KEY=test-key
 FERNET_EMAIL_TOKEN_KEY=testkey00000000-aaaaaaaaaaaaaaaaaaaaaaaaaaa=
 
 SUPERSET_ROOT=http://some.domain.test/
-METABASE_ROOT=http://some.domain.test/
+METABASE_ROOT=http://data-workspace-metabase:3000/
 
 QUICKSIGHT_USER_REGION=us-east-1
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-14
+
+### Added
+
+- The ability to run Metabase locally
+
 ## 2020-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ With the default environment, you will need the below in your `/etc/hosts` file.
 127.0.0.1       dataworkspace.test
 ```
 
-And the application will be visible at http://dataworkspace.test:8000. This is to be able to properly test cookies that are shared with subdomains.
+And the application will be visible at http://dataworkspace.test:8000. This is to be able to properly test cookies that are shared with subdomains. To run tool and visualisation-related code, you will need subdomains in your `/etc/hosts` file, such as 
+
+```
+127.0.0.1       metabase.dataworkspace.test
+```
 
 
 ## Creating migrations / running management commands

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     links:
       - "data-workspace-postgres"
       - "data-workspace-redis"
+      - "data-workspace-metabase"
 
   data-workspace-postgres:
     build:
@@ -30,6 +31,11 @@ services:
     image: data-workspace-redis
     ports:
       - "6379:6379"
+
+  data-workspace-metabase:
+    image: metabase/metabase
+    ports:
+      - "3000:3000"
 
 volumes:
   db-data:


### PR DESCRIPTION
### Description of change

Not connected to any database other than the ephemeral one it would load
up in its container, but enough to test a bit of code in the proxy.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
