### PR TITLE
(feat) Visualisations are wrapped in full height iframe by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-19
+
+### Changed
+
+- New visualisations are wrapped in an iframe by default
+
 ## 2020-05-14
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -714,6 +714,7 @@ def _application_template(gitlab_project):
                     application_type='VISUALISATION',
                     user_access_type='REQUIRES_AUTHORIZATION',
                     gitlab_project_id=gitlab_project['id'],
+                    wrap='FULL_HEIGHT_IFRAME',
                     visible=False,
                 )
                 VisualisationCatalogueItem.objects.create(


### PR DESCRIPTION
### Description of change

AFAIK no issues have been reported by the visualisations manually set to be wrapped in an iframe

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
