### PR TITLE
(feat) JupyterLab Python Fargate 1.4.0 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - The s3sync sidecar container to be Fargate 1.4.0 compatible
 - Added ability to export datacut queries to CSV from admin listing
+- The JupyterLab Python container to be Fargate 1.4.0 compatible
 
 ## 2020-05-19
 

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -388,18 +388,6 @@
       "value": "${fargate_spawner__task_subnet}"
     },
     {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_CONFIG_DIR",
-      "value": "/home/jovyan/.jupyterlab_python"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_DATA_DIR",
-      "value": "/tmp/jupyterlab_python"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ENV__JUPYTER_RUNTIME_DIR",
-      "value": "/tmp/jupyterlab_python/runtime"
-    },
-    {
       "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__PORT",
       "value": "8888"
     },

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -368,34 +368,6 @@
       "value": "120"
     },
     {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__1",
-      "value": "jupyter"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__2",
-      "value": "lab"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__3",
-      "value": "--config=/etc/jupyter/jupyter_notebook_config.py"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__4",
-      "value": "--NotebookApp.token=''"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__5",
-      "value": "--NotebookApp.ip='0.0.0.0'"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__6",
-      "value": "--NotebookApp.allow_remote_access=True"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CMD__7",
-      "value": "--NotebookApp.port=8888"
-    },
-    {
       "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__CLUSTER_NAME",
       "value": "${fargate_spawner__task_custer_name}"
     },

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -132,8 +132,6 @@ COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
 
 ENTRYPOINT ["tini", "-g", "--"]
 
-USER jovyan
-
 WORKDIR /home/jovyan
 
 # The ipython history database does not play well with mobius3, surfacing

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -141,6 +141,11 @@ WORKDIR /home/jovyan
 # it where mobius3 does not sync
 ENV IPYTHONDIR=/tmp/ipython
 
+ENV \
+    JUPYTER_CONFIG_DIR=/home/jovyan/.jupyterlab_python \
+    JUPYTER_DATA_DIR=/tmp/jupyterlab_python \
+    JUPYTER_RUNTIME_DIR=/tmp/jupyterlab_python/runtime
+
 COPY start.sh /
 
 CMD ["/start.sh"]

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -141,10 +141,6 @@ WORKDIR /home/jovyan
 # it where mobius3 does not sync
 ENV IPYTHONDIR=/tmp/ipython
 
-CMD ["/opt/conda/bin/jupyter", \
-    "lab", \
-    "--config=/etc/jupyter/jupyter_notebook_config.py", \
-    "--NotebookApp.token=''", \
-    "--NotebookApp.ip='0.0.0.0'", \
-    "--NotebookApp.allow_remote_access=True", \
-    "--NotebookApp.port=8888"]
+COPY start.sh /
+
+CMD ["/start.sh"]

--- a/jupyterlab-python/start.sh
+++ b/jupyterlab-python/start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+/opt/conda/bin/jupyter \
+	lab \
+	--config=/etc/jupyter/jupyter_notebook_config.py \
+	--NotebookApp.token='' \
+	--NotebookApp.ip='0.0.0.0' \
+	--NotebookApp.allow_remote_access=True \
+	--NotebookApp.port=8888

--- a/jupyterlab-python/start.sh
+++ b/jupyterlab-python/start.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-/opt/conda/bin/jupyter \
+chown -R jovyan:jovyan /home/jovyan
+
+sudo -E -H -u jovyan /opt/conda/bin/jupyter \
 	lab \
 	--config=/etc/jupyter/jupyter_notebook_config.py \
 	--NotebookApp.token='' \


### PR DESCRIPTION
### Description of change

Since the volume shared between containers in Fargate 1.4.0 ends up being owned by root, we have to start JupyterLab as root and change the permission of the home directory, and then start up JupyterLab as a lower privileged user.

The ability to run sudo was very recently added to Fargate 1.4.0 (without even a minor version bump).

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
