### PR TITLE
(fix) Preserve PATH in JupyterLab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The s3sync sidecar container to be Fargate 1.4.0 compatible
 - Added ability to export datacut queries to CSV from admin listing
 - The JupyterLab Python container to be Fargate 1.4.0 compatible
+- The sudoers file in JupyterLab Python to preserve PATH
 
 ## 2020-05-19
 

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -53,6 +53,7 @@ RUN \
         sudo=1.8.27-1+deb10u2 && \
     groupadd -g 4356 jovyan && \
     useradd -u 4357 jovyan -g jovyan -m && \
+    echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
     wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh && \
     echo "87e77f097f6ebb5127c77662dfc3165e  miniconda.sh" | md5sum -c && \


### PR DESCRIPTION
### Description of change

There was a default secure_path in the sudoers file, so overwriting the
entire file.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
