### PR TITLE
(fix) Ensure to clear previous R environment on RStudio launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-28
+
+### Changed
+
+- Clear the .Renviron file on RStudio launch to avoid using old creds/paths
+
 ## 2020-05-27
 
 ### Changed

--- a/rstudio/rstudio-start.sh
+++ b/rstudio/rstudio-start.sh
@@ -4,6 +4,8 @@ set -e
 
 mkdir -p /etc/rstudio/connections
 
+rm -f /home/rstudio/.Renviron
+
 while IFS='=' read -r name value ; do
   if [[ $name == *'DATABASE_DSN__'* ]]; then
     # Make available as environment variable


### PR DESCRIPTION
### Description of change

It would keep old credentials/paths, and then (for example) attempting
to talk to to S3 would fail.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
