### PR TITLE
(feat) Allow downloads from visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Updated `get_filename` for source links to support arbitrary file extensions, rather than imposing `.csv` on everything.
 
+### Added
+
+- The `allow-downloads` value in the `sandbox` attribute for wrapped visualisations
+
 ## 2020-05-28
 
 ### Changed

--- a/dataworkspace/dataworkspace/templates/running.html
+++ b/dataworkspace/dataworkspace/templates/running.html
@@ -134,7 +134,7 @@
   </header>
   {% endif %}
 
-  <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" class="vis">
+  <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="vis">
 </body>
 
 </html>


### PR DESCRIPTION
### Description of change

The `allow-downloads` sandbox attribute is not documented at
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe

But it seems to be a recent addition in Chrome
https://www.chromestatus.com/feature/5706745674465280. The error in
Chrome 83 without this is:

    Download is disallowed. The frame initiating or instantiating the
    download is sandboxed, but the flag ‘allow-downloads’ is not set.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
