### PR TITLE
Update source links to support different file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-05-29
+
+### Changed
+
+- Updated `get_filename` for source links to support arbitrary file extensions, rather than imposing `.csv` on everything.
+
 ## 2020-05-28
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1,4 +1,5 @@
 import copy
+import os
 import uuid
 
 from typing import Optional, List
@@ -392,8 +393,8 @@ class ReferenceNumberedDatasetSource(TimeStampedModel):
             )
         return None
 
-    def get_filename(self):
-        filename = '{}.csv'.format(slugify(self.name))
+    def get_filename(self, extension='.csv'):
+        filename = slugify(self.name) + extension
         if self.source_reference is not None:
             return f'{self.source_reference}-{filename}'
         return filename
@@ -544,6 +545,14 @@ class SourceLink(ReferenceNumberedDatasetSource):
 
     def can_show_link_for_user(self, user):
         return True
+
+    def get_filename(self):
+        if self.link_type == self.TYPE_LOCAL:
+            native_extension = os.path.splitext(self.url)[1]
+            extension = native_extension if native_extension else '.csv'
+            return super().get_filename(extension=extension)
+
+        return super().get_filename()
 
 
 class CustomDatasetQuery(ReferenceNumberedDatasetSource):

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dataworkspace.apps.datasets.models import SourceLink
 from dataworkspace.tests import factories
 
 
@@ -92,7 +93,6 @@ def test_dataset_source_reference_code(db, factory):
     (
         factories.SourceTableFactory,
         factories.SourceViewFactory,
-        factories.SourceLinkFactory,
         factories.CustomDatasetQueryFactory,
     ),
 )
@@ -106,3 +106,34 @@ def test_dataset_source_filename(db, factory):
     ds2 = factories.DataSetFactory()
     source2 = factory(dataset=ds2, name='A test source')
     assert source2.get_filename() == 'a-test-source.csv'
+
+
+def test_source_link_filename(db):
+    ds1 = factories.DataSetFactory(
+        reference_code=factories.DatasetReferenceCodeFactory(code='DW')
+    )
+    source1 = factories.SourceLinkFactory(
+        dataset=ds1,
+        name='A test source',
+        url="s3://csv-pipelines/my-data.csv.zip",
+        link_type=SourceLink.TYPE_LOCAL,
+    )
+    assert source1.get_filename() == 'DW00001-a-test-source.zip'
+
+    ds2 = factories.DataSetFactory()
+    source2 = factories.SourceLinkFactory(
+        dataset=ds2,
+        name='A test source',
+        url="s3://csv-pipelines/my-data.csv",
+        link_type=SourceLink.TYPE_LOCAL,
+    )
+    assert source2.get_filename() == 'a-test-source.csv'
+
+    ds3 = factories.DataSetFactory()
+    source3 = factories.SourceLinkFactory(
+        dataset=ds3,
+        name='A test source',
+        url="http://www.google.com/index.html",
+        link_type=SourceLink.TYPE_EXTERNAL,
+    )
+    assert source3.get_filename() == 'a-test-source.csv'


### PR DESCRIPTION
### Description of change
Data flow can now upload .zip files, so we can't just generate .csv
file names any more (or the download will have the wrong extension,
which will confuse some users and programs).

For source links, therefore, we will grab the extension from the URL
(for the given case it'll be an S3 URI) and apply that to the filename.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
