### PR TITLE
(feat) Bump Metabase to Fargate 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Bumped to latest Alpine Python
+- Bump Fargate to 1.4.0 for Metabase
 
 ## 2020-05-29
 

--- a/infra/ecs_main_metabase_multiuser.tf
+++ b/infra/ecs_main_metabase_multiuser.tf
@@ -5,8 +5,7 @@ resource "aws_ecs_service" "metabase_multiuser" {
   desired_count   = 2
   launch_type     = "FARGATE"
   deployment_maximum_percent = 200
-  # We need to write to /etc/hosts, which is not writable in 1.4.0
-  platform_version = "1.3.0"
+  platform_version = "1.4.0"
   health_check_grace_period_seconds = "120"
 
   network_configuration {


### PR DESCRIPTION
### Description of change

After contact with AWS Support, /etc/hosts is now writable in Fargate
1.4.0. This means that start.sh can take the value from
/proc/sys/kernel/hostname, write it to /etc/hosts as 127.0.0.1

... which means that Metabase, which during startup attempts to resolve
the value from /proc/sys/kernel/hostname to an IP address, can indeed
startup


### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
