### PR TITLE
Allow embedding Metabase pages from the root domain

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -117,7 +117,7 @@ async def async_main():
             f"connect-src 'self' wss://{host};"
             "font-src 'self' data:;"
             "form-action 'self';"
-            f"frame-ancestors 'self' {public_host}.{root_domain};"
+            f"frame-ancestors 'self' {root_domain} {public_host}.{root_domain};"
             "img-src 'self' data: blob:;"
             # Both JupyterLab and RStudio need `unsafe-eval`
             "script-src 'unsafe-inline' 'unsafe-eval' 'self';"


### PR DESCRIPTION
### Description of change

In order to embed Metabase dashboards in a Data Workspace page we
need to allow iframes from main Data Workspace domain.

This would only apply to Metabase /embed/ pages, since Metabase has
its own CSP header that disables frame-ancestors on all other pages.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
