### PR TITLE
(fix) Tools buttons/dropdown alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-09
+
+### Changed
+
+- Neater alignment of buttons and dropdowns on Tools page
+
 ## 2020-06-08
 
 ### Changed

--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -7,12 +7,10 @@
     {{ block.super }}
     <style>
         .tool-launch-button {
-            vertical-align: middle;
             display: inline-block;
             min-width: 12.8em;
         }
         .tool-stop-button {
-            vertical-align: middle;
             display: inline-block;
         }
         @media (min-width: 40.0625em) {


### PR DESCRIPTION
### Description of change

From

<img width="597" alt="Screenshot 2020-06-09 at 10 45 26" src="https://user-images.githubusercontent.com/13877/84132919-5b9e0b80-aa3e-11ea-9695-f6d2b7c72a96.png">

to

<img width="603" alt="Screenshot 2020-06-09 at 10 44 22" src="https://user-images.githubusercontent.com/13877/84132825-3f9a6a00-aa3e-11ea-983a-26255513930c.png">

Screenshots taken from Chrome on Mac OS. The change behaves similarly in Firefox (although the dropdowns to my eye look a more ugly in Firefox, they are equally ugly, but at least better aligned)

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
