### PR TITLE
(feat) Create a new task definition per tool launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Removed user access controls from visualisation templates.
 
+### Changed
+
+- Create a new task defintion per tool launch, to support per-user mount points in EFS
+
 ## 2020-06-09
 
 ### Changed


### PR DESCRIPTION
### Description of change

From the user's point of view, this is a refactor...

... but is a step towards EFS. For home directories. For each user to
have a different mount location in EFS, this has to be specified in the
task defintion. The location can't be specified in the overrides passed
to run_task [this has been confirmed with contact with AWS Support]. So
we create a task definition per launch.

So far, there doesn't seem to be an issue doing this for visualisation
previews, but extending this behaviour to tools, and releasing ahead of
actually moving to EFS, just in case there is some unexpected behaviour
that means we have to re-evaluate/plan the move to EFS.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
