### PR TITLE
Ignore quicksight reader users

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/management/commands/sync_quicksight_user_datasources.py
+++ b/dataworkspace/dataworkspace/apps/applications/management/commands/sync_quicksight_user_datasources.py
@@ -110,6 +110,12 @@ class Command(BaseCommand):
         for quicksight_user in quicksight_user_list:
             user_arn = quicksight_user['Arn']
             user_email = quicksight_user['Email']
+            user_role = quicksight_user['Role']
+
+            if user_role != 'AUTHOR' and user_role != 'ADMIN':
+                self.stdout.write(f"Skipping {user_email} with role {user_role}.")
+                continue
+
             dw_user = get_user_model().objects.filter(email=user_email).first()
             if not dw_user:
                 self.stdout.write(


### PR DESCRIPTION
### Description of change
When syncing data sources/permissions from Data Workspace to QuickSight,
we only want to do it for authors. Readers and users created to view
embedded dashboards - we don't want to (and QuickSight won't let us)
grant them datasoruce permissions.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
