### PR TITLE
Allow admin task to assume quicksight role

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -608,6 +608,16 @@ data "aws_iam_policy_document" "admin_run_tasks" {
       "*",
     ]
   }
+
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    resources = [
+      "${aws_iam_role.admin_dashboard_embedding.arn}"
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "admin_admin_store_db_creds_in_s3_task" {


### PR DESCRIPTION
### Description of change
The dashboard role gives the admin run task role permission to assume it, but not vice versa, so this patch allows the admin run task role to assume the dashboard role.