### PR TITLE
Don't overwrite user variable

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -582,7 +582,7 @@ def get_quicksight_dashboard_name_url(dashboard_id, user):
     qs_dashboard_client = session.client('quicksight')
 
     try:
-        user = qs_user_client.register_user(
+        qs_user_client.register_user(
             AwsAccountId=account_id,
             Namespace='default',
             IdentityType='IAM',


### PR DESCRIPTION
### Description of change
This caused the function to fail if it successfully registered a new user, as later parts of the function continued to expect `user` to be a model instance rather than the response from registering a user with QuickSight.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
