### PR TITLE
Bump cache lock version and auto-expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Enabled support for redirects in Django admin.
 
+### Changed
+
+- Bump redis lock keys for deleting unused dataset users - it got stuck again. Also adds a timeout so that these keys should automatically expire, reducing the chance of them getting stuck.
+
 ## 2020-06-11
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -495,8 +495,9 @@ def delete_unused_datasets_users():
                         # Multiple concurrent GRANT CONNECT on the same database can cause
                         # "tuple concurrently updated" errors
                         with cache.lock(
-                            f'database-grant-connect-{database_name}--v3',
+                            f'database-grant-connect-{database_name}--v4',
                             blocking_timeout=3,
+                            timeout=180,
                         ):
                             cur.execute(
                                 sql.SQL(
@@ -518,8 +519,9 @@ def delete_unused_datasets_users():
 
                         for schema in schemas:
                             with cache.lock(
-                                f'database-grant--{database_name}--{schema}--v3',
+                                f'database-grant--{database_name}--{schema}--v4',
                                 blocking_timeout=3,
+                                timeout=180,
                             ):
                                 for schema_revoke in schema_revokes:
                                     try:


### PR DESCRIPTION
### Description of change
We are regularly seeing errors where we're unable to acquire a lock
quickly enough, which we believe means it has become stuck - perhaps

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
