### PR TITLE
(feat) Override the server header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Enabled support for redirects in Django admin.
 
+### Changed
+
+- The value of the server header to not reveal it's nginx
+
 ## 2020-06-11
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
 		linux-headers=4.19.36-r0 && \
 	apk add --no-cache \
 		nginx=1.16.1-r2 \
+		nginx-mod-http-headers-more=1.16.1-r2 \
 		openssl=1.1.1g-r0 \
 		parallel=20190522-r0 \
 		py3-psycopg2=2.7.7-r1 \

--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -1,3 +1,4 @@
+load_module /usr/lib/nginx/modules/ngx_http_headers_more_filter_module.so;
 error_log /dev/stderr notice;
 pid /home/django/nginx.pid;
 
@@ -15,7 +16,7 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    server_tokens off;
+    more_set_headers "Server: data-workspace";
 
     client_max_body_size 0;
     proxy_http_version 1.1;


### PR DESCRIPTION
### Description of change

 The `server_tokens off;` turned off the nginx version from the server header, but it was still sent as `nginx`, and it comes up in ITHCs that we shouldn't be exposing the underlying server in headers.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
