### PR TITLE
Add more logging around redis cache lock failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-25
+
+### Changed
+
+- Log which lock we fail to obtain when trying to clean up users.
+
 ## 2020-06-17
 
 ### Changed


### PR DESCRIPTION
### Description of change
We are getting regularly errors where our unused-user cleanup task fails
to acquire redis locks in order to drop users. It's hard to investigate
what's going on - knowing which locks are failing _may_ give us more
information and/or narrow things down slightly.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
