### PR TITLE
Bump cache lock version and auto-expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Log which lock we fail to obtain when trying to clean up users.
+- Bump redis lock keys - it's possible got stuck on one lock when deleting users. Also adds a timeout so that these keys should automatically expire, reducing the chance of them getting stuck.
 
 ## 2020-06-17
 

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -495,8 +495,8 @@ def delete_unused_datasets_users():
 
                         # Multiple concurrent GRANT CONNECT on the same database can cause
                         # "tuple concurrently updated" errors
-                        lock_name = f'database-grant-connect-{database_name}--v3'
-                        with cache.lock(lock_name, blocking_timeout=3):
+                        lock_name = f'database-grant-connect-{database_name}--v4'
+                        with cache.lock(lock_name, blocking_timeout=3, timeout=180):
                             cur.execute(
                                 sql.SQL(
                                     'REVOKE CONNECT ON DATABASE {} FROM {};'
@@ -516,8 +516,8 @@ def delete_unused_datasets_users():
                             )
 
                         for schema in schemas:
-                            lock_name = f'database-grant--{database_name}--{schema}--v3'
-                            with cache.lock(lock_name, blocking_timeout=3):
+                            lock_name = f'database-grant--{database_name}--{schema}--v4'
+                            with cache.lock(lock_name, blocking_timeout=3, timeout=180):
                                 for schema_revoke in schema_revokes:
                                     try:
                                         cur.execute(

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -102,7 +102,9 @@ def new_private_database_credentials(
         # Multiple concurrent GRANT CONNECT on the same database can cause
         # "tuple concurrently updated" errors
         with cache.lock(
-            f'database-grant-connect-{database_data["NAME"]}--v3', blocking_timeout=3
+            f'database-grant-connect-{database_data["NAME"]}--v4',
+            blocking_timeout=3,
+            timeout=180,
         ):
             with connections[database_obj.memorable_name].cursor() as cur:
                 cur.execute(
@@ -212,8 +214,9 @@ def new_private_database_credentials(
 
         for schema in schemas:
             with cache.lock(
-                f'database-grant--{database_data["NAME"]}--{schema}--v3',
+                f'database-grant--{database_data["NAME"]}--{schema}--v4',
                 blocking_timeout=3,
+                timeout=180,
             ):
                 with connections[database_obj.memorable_name].cursor() as cur:
                     logger.info(
@@ -230,8 +233,9 @@ def new_private_database_credentials(
 
         for schema, table in tables_that_exist:
             with cache.lock(
-                f'database-grant--{database_data["NAME"]}--{schema}--v3',
+                f'database-grant--{database_data["NAME"]}--{schema}--v4',
                 blocking_timeout=3,
+                timeout=180,
             ):
                 with connections[database_obj.memorable_name].cursor() as cur:
                     logger.info(


### PR DESCRIPTION
### Description of change
We are regularly seeing errors where we're unable to acquire a lock
quickly enough, which we believe means it has become stuck. This patch
will give the lock a TTL of 3 minutes, and it will automatically be
available for re-locking after that time, which should reduce any need
for us to bump the lock version.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
