### PR TITLE
Lock the "delete users" task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Log which lock we fail to obtain when trying to clean up users.
 - Bump redis lock keys - it's possible got stuck on one lock when deleting users. Also adds a timeout so that these keys should automatically expire, reducing the chance of them getting stuck.
+- Lock the 'delete unused users' task so only one instance runs it at a time.
 
 ## 2020-06-17
 

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -1,0 +1,37 @@
+import mock
+import pytest
+import redis
+from django.core.cache import cache
+
+from dataworkspace.apps.applications.utils import delete_unused_datasets_users
+
+
+class TestDeleteUnusedDatasetsUsers:
+    def setup_method(self):
+        print('setup')
+        self.lock = cache.lock("delete_unused_datasets_users", blocking_timeout=0)
+
+    def teardown_method(self):
+        try:
+            self.lock.release()
+        except redis.exceptions.LockError:
+            pass
+
+    @pytest.mark.timeout(2)
+    @mock.patch(
+        'dataworkspace.apps.applications.utils._do_delete_unused_datasets_users'
+    )
+    def test_dies_immediately_if_already_locked(self, do_delete_mock):
+        do_delete_mock.side_effect = Exception(
+            "I will be raised if the lock is available"
+        )
+
+        # Make sure we actually acquire the lock, else the test is flawed
+        assert self.lock.acquire() is True
+        delete_unused_datasets_users()
+        self.lock.release()
+
+        with pytest.raises(Exception) as e:
+            delete_unused_datasets_users()
+
+        assert e.value is do_delete_mock.side_effect

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,6 @@ pytest==5.4.3
 pytest-cov==2.10.0
 pytest-mock==3.1.1
 pytest-django==3.9.0
+pytest-timeout==1.4.1
 django-debug-toolbar==2.2
 requests-mock==1.8.0


### PR DESCRIPTION
### Description of change
We've had some sentry errors about being unable to delete users because
they don't exist that is attributed to multiple instances of this task
running at the same time. By adding a lock around the inner-workings of
the job we can ensure only one instance is running the task at a time,
which should prevent these errors. Any instances that fail to get the
lock can just die silently.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
