### PR TITLE
Exclude Metabase embed resources from VPN requirement

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -195,7 +195,11 @@ async def async_main():
         )
 
     def is_metabase_embed_requested(request):
-        return is_metabase_requested(request) and request.url.path.startswith('/embed/')
+        return is_metabase_requested(request) and (
+            request.url.path.startswith('/embed/')
+            or request.url.path.startswith('/api/embed/')
+            or request.url.path.startswith('/app/dist/')
+        )
 
     def is_app_requested(request):
         return (


### PR DESCRIPTION
### Description of change

Since embedded Metabase dashboards are not static HTML pages, apart
from the iframe URL itself we also need to exclude JS and CSS asset
URLs and embed API endpoints from the VPN check.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
