### PR TITLE
(feat) Use SSO contact_email as primary email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-06-26
+
+### Changed
+
+- Use SSO contact_email as opposed to email
+
 ## 2020-06-25
 
 ### Changed

--- a/dataworkspace/dataworkspace/tests/common.py
+++ b/dataworkspace/dataworkspace/tests/common.py
@@ -25,6 +25,7 @@ class BaseTestCaseMixin:
 
         self.user_data = {
             'HTTP_SSO_PROFILE_EMAIL': self.user.email,
+            'HTTP_SSO_PROFILE_CONTACT_EMAIL': self.user.email,
             'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
             'HTTP_SSO_PROFILE_USER_ID': 'aae8901a-082f-4f12-8c6c-fdf4aeba2d68',
             'HTTP_SSO_PROFILE_LAST_NAME': 'Bob',
@@ -92,6 +93,7 @@ def get_response_csp_as_set(response):
 def get_http_sso_data(user):
     return {
         'HTTP_SSO_PROFILE_EMAIL': user.email,
+        'HTTP_SSO_PROFILE_CONTACT_EMAIL': user.email,
         'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
         'HTTP_SSO_PROFILE_USER_ID': uuid.uuid4(),
         'HTTP_SSO_PROFILE_LAST_NAME': user.last_name,

--- a/dataworkspace/dataworkspace/tests/conftest.py
+++ b/dataworkspace/dataworkspace/tests/conftest.py
@@ -11,6 +11,7 @@ def staff_user_data(db):
 
     return {
         'HTTP_SSO_PROFILE_EMAIL': user.email,
+        'HTTP_SSO_PROFILE_CONTACT_EMAIL': user.email,
         'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
         'HTTP_SSO_PROFILE_USER_ID': 'aae8901a-082f-4f12-8c6c-fdf4aeba2d68',
         'HTTP_SSO_PROFILE_LAST_NAME': 'Testerson',
@@ -37,6 +38,7 @@ def user_data(db, user):
 
     return {
         'HTTP_SSO_PROFILE_EMAIL': user.email,
+        'HTTP_SSO_PROFILE_CONTACT_EMAIL': user.email,
         'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
         'HTTP_SSO_PROFILE_USER_ID': 'aae8901a-082f-4f12-8c6c-fdf4aeba2d69',
         'HTTP_SSO_PROFILE_LAST_NAME': 'Exampleson',
@@ -65,6 +67,7 @@ def sme_user(db):
 def sme_user_data(db, sme_user):
     return {
         'HTTP_SSO_PROFILE_EMAIL': sme_user.email,
+        'HTTP_SSO_PROFILE_CONTACT_EMAIL': sme_user.email,
         'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
         'HTTP_SSO_PROFILE_USER_ID': 'aae8901a-082f-4f12-8c6c-fdf4aeba2d70',
         'HTTP_SSO_PROFILE_LAST_NAME': 'Sampledóttir',

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -931,6 +931,7 @@ async def async_main():
 
             request['sso_profile_headers'] = (
                 ('sso-profile-email', me_profile['email']),
+                ('sso-profile-contact-email', me_profile['contact_email']),
                 (
                     'sso-profile-related-emails',
                     ','.join(me_profile.get('related_emails', [])),
@@ -1090,6 +1091,10 @@ async def async_main():
             async def handler_with_sso_headers():
                 request['sso_profile_headers'] = (
                     ('sso-profile-email', me_profile['email']),
+                    # The default value of '' should be able to be removed after the cached
+                    # profile in Redis without contact_email has expired, i.e. 60 seconds after
+                    # deployment of this change
+                    ('sso-profile-contact-email', me_profile.get('contact_email', '')),
                     (
                         'sso-profile-related-emails',
                         ','.join(me_profile.get('related_emails', [])),
@@ -1126,6 +1131,7 @@ async def async_main():
             me_profile = {
                 'email': me_profile_full['email'],
                 'related_emails': me_profile_full['related_emails'],
+                'contact_email': me_profile_full['contact_email'],
                 'user_id': me_profile_full['user_id'],
                 'first_name': me_profile_full['first_name'],
                 'last_name': me_profile_full['last_name'],

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -49,6 +49,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -251,6 +252,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -407,6 +409,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -530,6 +533,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -902,6 +906,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1072,6 +1077,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-1': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1242,6 +1248,7 @@ class TestApplication(unittest.TestCase):
             # No token-1
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1280,6 +1287,7 @@ class TestApplication(unittest.TestCase):
             # No token-1
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1412,6 +1420,7 @@ class TestApplication(unittest.TestCase):
             # No token-1
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1628,6 +1637,7 @@ class TestApplication(unittest.TestCase):
             # No token-1
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1725,6 +1735,7 @@ class TestApplication(unittest.TestCase):
             # No token-1
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',
@@ -1767,6 +1778,7 @@ class TestApplication(unittest.TestCase):
         auth_to_me = {
             'Bearer token-2': {
                 'email': 'test@test.com',
+                'contact_email': 'test@test.com',
                 'related_emails': [],
                 'first_name': 'Peter',
                 'last_name': 'Piper',


### PR DESCRIPTION
### Description of change

People tend to be identified by their contact_email in SSO, rather than their email (which sometimes isn't changed because it can break things AFAIK).

This might need to be followed up be a job/management command to run to change the email without users having to visit Data Workspace to do it.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
