### PR TITLE
Instrument sentry release tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Launch DNS resolver in a single fixed subnet: will be the same subnet as the upcoming EFS mount target
+- Configure sentry to track releases so it can attribute issues more precisely.
 - Add GTM initial events block to base template for injecting data before GTM startup (fix)
 
 ## 2020-07-19

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -290,7 +290,10 @@ S3_ROLE_PREFIX = env['S3_ROLE_PREFIX']
 YOUR_FILES_ENABLED = env.get('YOUR_FILES_ENABLED', 'False') == 'True'
 
 if env.get('SENTRY_DSN') is not None:
-    sentry_sdk.init(env['SENTRY_DSN'], integrations=[DjangoIntegration()])
+    sentry_kwargs = {"integrations": [DjangoIntegration()]}
+    if env.get('CONTAINER_TAG'):
+        sentry_kwargs['release'] = env.get('CONTAINER_TAG')
+    sentry_sdk.init(env['SENTRY_DSN'], **sentry_kwargs)
 
 
 CKEDITOR_CONFIGS = {

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -1357,9 +1357,10 @@ async def async_main():
 
 def main():
     if os.environ.get('SENTRY_DSN') is not None:
-        sentry_sdk.init(
-            os.environ['SENTRY_DSN'], integrations=[AioHttpIntegration()], debug=True
-        )
+        sentry_kwargs = {"integrations": [AioHttpIntegration()]}
+        if os.environ.get('CONTAINER_TAG'):
+            sentry_kwargs['release'] = os.environ.get('CONTAINER_TAG')
+        sentry_sdk.init(os.environ['SENTRY_DSN'], **sentry_kwargs)
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(async_main())

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -67,6 +67,7 @@ data "template_file" "admin_container_definitions" {
 
   vars {
     container_image   = "${var.admin_container_image}:${data.external.admin_current_tag.result.tag}"
+    container_tag     = "${data.external.admin_current_tag.result.tag}"
     container_name    = "${local.admin_container_name}"
     container_command = "[\"/dataworkspace/start.sh\"]"
     container_port    = "${local.admin_container_port}"
@@ -187,6 +188,7 @@ data "template_file" "admin_store_db_creds_in_s3_container_definitions" {
 
   vars {
     container_image   = "${var.admin_container_image}:${data.external.admin_current_tag.result.tag}"
+    container_tag     = "${data.external.admin_current_tag.result.tag}"
     container_name    = "${local.admin_container_name}"
     container_command = "[\"django-admin\", \"store_db_creds_in_s3\"]"
     container_port    = "${local.admin_container_port}"

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -4,6 +4,10 @@
     "cpu": ${container_cpu},
     "environment": [
     {
+      "name": "CONTAINER_TAG",
+      "value": "${container_tag}"
+    },
+    {
       "name": "ADMIN_DB__HOST",
       "value": "${admin_db__host}"
     },


### PR DESCRIPTION
### Description of change
Add support for sentry to track our releases so that it can
automatically attribute errors to commits/releases, which may help track
down issues over time. Our releases here are tagged by the commit ID
that is live, which should match up with the docker image tag as well.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
