### PR TITLE
(fix) Allow Theia user to run apt-get via sudo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Visualisation header text to be more in keeping with design
 
+### Added
+
+- Ability for the theia user in Theia to run apt-get via sudo, in line with other tools.
+
 ## 2020-06-26
 
 ### Changed

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -67,8 +67,7 @@ RUN \
 
 RUN \
 	addgroup --system --gid 4356 theia && \
-	adduser --disabled-password --gecos '' --ingroup theia --uid 4357 theia && \
-	echo "theia ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers
+	adduser --disabled-password --gecos '' --ingroup theia --uid 4357 theia
 
 RUN \
 	mkdir /tmp/.yarn-cache && \
@@ -76,7 +75,7 @@ RUN \
 	touch /root/yarn-error.log && \
 	chown theia:theia /root/yarn-error.log && \
 	echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
-	echo "rstudio ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get,/usr/bin/R" >> /etc/sudoers && \
+	echo "theia ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
 	echo 'PS1="\w\\\\$ \[$(tput sgr0)\]"' >> /etc/bash.bashrc && \
 	rm /home/theia/.bashrc
 


### PR DESCRIPTION
### Description of change

We allow users to run apt-get to install packages from our Debian mirror, but only via sudo. This should have been possible already in Theia, but there was a blind copy+paste from the RStudio image.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
