### PR TITLE
(feat) Populate APP_SCHEMA in RStudio environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-02
+
+### Added
+
+- The APP_SCHEMA environment variable to RStudio, so it can access the current user's schema
+
 ## 2020-07-01
 
 ### Changed

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -10,8 +10,8 @@ RUN \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ buster/updates main" >> /etc/apt/sources.list && \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
-	apt-get update && \
-	apt-get install -y --no-install-recommends \
+	apt-get update -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 && \
+	apt-get install -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 -y --no-install-recommends \
 		locales=2.28-10 && \
 	echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
 	locale-gen en_US.utf8 && \
@@ -29,8 +29,8 @@ ENV \
 COPY exploretiva /exploretiva
 
 RUN \
-	apt-get update && \
-	apt-get install -y --no-install-recommends \
+	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
+	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
 		ca-certificates \
 		dirmngr \
 		gnupg2 && \

--- a/rstudio/rstudio-start.sh
+++ b/rstudio/rstudio-start.sh
@@ -28,6 +28,7 @@ while IFS='=' read -r name value ; do
   fi
 done < <(env)
 
+echo "APP_SCHEMA='${APP_SCHEMA}'" >> /etc/R/Renviron.site
 echo "S3_PREFIX='${S3_PREFIX}'" >> /etc/R/Renviron.site
 echo "AWS_DEFAULT_REGION='${AWS_DEFAULT_REGION}'" >> /etc/R/Renviron.site
 echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI='${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}'" >> /etc/R/Renviron.site


### PR DESCRIPTION
### Description of change

I actually thought APP_SCHEMA was already in the RStudio environment, but not sure how it could have been without this change...

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
