### PR TITLE
(feat) Send to Google Analytics from the proxy for visualisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-13
+
+### Added
+
+- Sending of analytics to Google for requests to tools and visualisations
+
 ## 2020-07-10
 
 ### Changed


### PR DESCRIPTION
### Description of change

We can't talk to GA from the browser in visualisations, so doing so from the server

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
