### PR TITLE
Update link for responsible for info course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-14
+
+### Changed
+
+- The link to the 'Responsible for Information' e-learning course frm a `civilservicelearning.civilservice.gov.uk` URL to a `learn.civilservice.gov.uk` one.
+
 ## 2020-07-13
 
 ### Added

--- a/dataworkspace/dataworkspace/templates/tools-unauthorised.html
+++ b/dataworkspace/dataworkspace/templates/tools-unauthorised.html
@@ -25,7 +25,7 @@
             <p class="govuk-body">
                 Users will need to complete the
                 <a class="govuk-link" href="https://app.ihasco.co.uk/lgjg02">GDPR Essentials</a> and
-                <a class="govuk-link" href="https://civilservicelearning.civilservice.gov.uk/responsible-information">Responsible for Information</a>
+                <a class="govuk-link" href="https://learn.civilservice.gov.uk/courses/-20CQRZLS4qIPaCW8rF58g">Responsible for Information</a>
                 online training in order to access tools. Click the button below to request access to a specific tool.
             </p>
 


### PR DESCRIPTION
### Description of change
Civil Service Learning website is changing, apparently, and this is the
new link to the course that users will need to complete.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
