### PR TITLE
Sort by model id when "auto id" field is set as sort field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-16
+
+### Changed
+
+- Fix issue where sorting a reference dataset by auto id cause an error due to a missing column
+
 ## 2020-07-14
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -909,6 +909,8 @@ class ReferenceDataset(DeletableTimestampedUserModel):
                     field.column_name,
                     field.linked_reference_dataset.display_name_field.column_name,
                 )
+            elif field.data_type == field.DATA_TYPE_AUTO_ID:
+                order = 'id'
         return [''.join([prefix, order])]
 
     def get_record_model_class(self) -> object:

--- a/dataworkspace/dataworkspace/tests/test_models.py
+++ b/dataworkspace/dataworkspace/tests/test_models.py
@@ -579,6 +579,12 @@ class TestReferenceDatasets(ReferenceDatasetsMixin, BaseModelsTests):
             data_type=ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY,
             linked_reference_dataset=linked_to_dataset,
         )
+        auto_id_field = ReferenceDatasetField.objects.create(
+            reference_dataset=ref_dataset,
+            name='auto id',
+            column_name='auto_id',
+            data_type=ReferenceDatasetField.DATA_TYPE_AUTO_ID,
+        )
 
         # Add id and name fields to the linked to dataset
         ReferenceDatasetField.objects.create(
@@ -688,6 +694,17 @@ class TestReferenceDatasets(ReferenceDatasetsMixin, BaseModelsTests):
             if x.link is not None
         ]
         self.assertEqual(linked_names, list(reversed(sorted(linked_names))))
+
+        # Test sorting by auto id field
+        ref_dataset.sort_direction = ref_dataset.SORT_DIR_ASC
+        ref_dataset.sort_field = auto_id_field
+        ref_dataset.save()
+        ids = [x.auto_id for x in ref_dataset.get_records()]
+        self.assertEqual(ids, list(sorted(ids)))
+        ref_dataset.sort_direction = ref_dataset.SORT_DIR_DESC
+        ref_dataset.save()
+        ids = [x.auto_id for x in ref_dataset.get_records()]
+        self.assertEqual(ids, list(reversed(sorted(ids))))
 
 
 class TestSourceLinkModel(BaseTestCase):


### PR DESCRIPTION
### Description of change

Fixes issue where setting an "auto id" field as the sort field on a reference dataset caused a 500 due to a missing table.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
