### PR TITLE
(feat) Install more useful Python packages in Theia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix issue where sorting a reference dataset by auto id cause an error due to a missing column
 
+### Added
+
+- More packages in Theia so it's more useful from the get-go
+
 ## 2020-07-14
 
 ### Changed

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -68,6 +68,8 @@ RUN \
 COPY requirements.txt /root
 
 RUN \
+	python3 -m pip install pip --upgrade && \
+	pip3 install setuptools==49.2.0 --upgrade && \
 	pip3 install -r requirements.txt
 
 RUN \

--- a/theia/requirements.in
+++ b/theia/requirements.in
@@ -1,1 +1,4 @@
-pylint==2.5.3
+numpy
+pandas
+pylint==2.5.2
+tensorflow

--- a/theia/requirements.txt
+++ b/theia/requirements.txt
@@ -4,11 +4,52 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
+absl-py==0.9.0            # via tensorboard, tensorflow
 astroid==2.4.1            # via pylint
+astunparse==1.6.3         # via tensorflow
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via requests
+chardet==3.0.4            # via requests
+gast==0.3.3               # via tensorflow
+google-auth-oauthlib==0.4.1  # via tensorboard
+google-auth==1.18.0       # via google-auth-oauthlib, tensorboard
+google-pasta==0.2.0       # via tensorflow
+grpcio==1.30.0            # via tensorboard, tensorflow
+h5py==2.10.0              # via tensorflow
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via markdown
 isort==4.3.21             # via pylint
+keras-preprocessing==1.1.2  # via tensorflow
 lazy-object-proxy==1.4.3  # via astroid
+markdown==3.2.2           # via tensorboard
 mccabe==0.6.1             # via pylint
-pylint==2.5.3             # via -r theia/requirements.in
-six==1.15.0               # via astroid
+numpy==1.19.0             # via -r requirements.in, h5py, keras-preprocessing, opt-einsum, pandas, scipy, tensorboard, tensorflow
+oauthlib==3.1.0           # via requests-oauthlib
+opt-einsum==3.2.1         # via tensorflow
+pandas==1.0.5             # via -r requirements.in
+protobuf==3.12.2          # via tensorboard, tensorflow
+pyasn1-modules==0.2.8     # via google-auth
+pyasn1==0.4.8             # via pyasn1-modules, rsa
+pylint==2.5.2             # via -r requirements.in
+python-dateutil==2.8.1    # via pandas
+pytz==2020.1              # via pandas
+requests-oauthlib==1.3.0  # via google-auth-oauthlib
+requests==2.24.0          # via requests-oauthlib, tensorboard
+rsa==4.0                  # via google-auth
+scipy==1.4.1              # via tensorflow
+six==1.15.0               # via absl-py, astroid, astunparse, google-auth, google-pasta, grpcio, h5py, keras-preprocessing, protobuf, python-dateutil, tensorboard, tensorflow
+tensorboard-plugin-wit==1.7.0  # via tensorboard
+tensorboard==2.2.2        # via tensorflow
+tensorflow-estimator==2.2.0  # via tensorflow
+tensorflow==2.2.0         # via -r requirements.in
+termcolor==1.1.0          # via tensorflow
 toml==0.10.1              # via pylint
-wrapt==1.12.1             # via astroid
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.9           # via requests
+werkzeug==1.0.0           # via tensorboard
+wheel==0.34.2             # via astunparse, tensorboard, tensorflow
+wrapt==1.12.1             # via astroid, tensorflow
+zipp==3.1.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools


### PR DESCRIPTION
### Description of change

Full disclosure: for some reason the latest Pylint is not installable from our mirror. I don't know what happened here. However, given usage of Theia (almost zero) and the consequences of going back a patch version are likely minor, am fine with it.

### Checklist

~* [ ] Have tests been added to cover any changes?~

* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?

~* [ ] Has the README been updated (if needed)?~
