### PR TITLE
Bump Python version for data-workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-19
+
+### Changed
+
+- Python version in docker container from 3.7.7-r0 to 3.7.7-r1
+
 ## 2020-07-16
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
 	apk add --no-cache --virtual .build-deps \
 		build-base=0.5-r1 \
 		git=2.22.4-r0 \
-		python3-dev=3.7.7-r0 \
+		python3-dev=3.7.7-r1 \
 		libffi-dev=3.2.1-r6 \
 		openssl-dev=1.1.1g-r0 \
 		linux-headers=4.19.36-r0 && \
@@ -23,7 +23,7 @@ RUN \
 		openssl=1.1.1g-r0 \
 		parallel=20190522-r0 \
 		py3-psycopg2=2.7.7-r1 \
-		python3=3.7.7-r0 && \
+		python3=3.7.7-r1 && \
 	rm /etc/nginx/conf.d/default.conf && \
 	rm /etc/nginx/nginx.conf && \
 	python3 -m ensurepip && \


### PR DESCRIPTION
### Description of change
The Python 3 version available in alpine 3.10 has been updated to
address CVE-2020-14422, which means our container no longer builds as
3.7.7-r0 is no longer available. This patch bumps us  to 3.7.7-r1.

https://git.alpinelinux.org/aports/commit/?id=21a5b7dd0924932b20512155471ee45dada0abf4

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
