### PR TITLE
(feat) Run DNS resolver in fixed single subnet for upcoming EFS home directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-20
+
+### Changed
+
+- Launch DNS resolver in a single fixed subnet: will be the same subnet as the upcoming EFS mount target
+
 ## 2020-07-19
 
 ### Changed

--- a/infra/ecs_main_dnsmaq.tf
+++ b/infra/ecs_main_dnsmaq.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "dnsmasq" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
     security_groups = ["${aws_security_group.dnsmasq.id}"]
   }
 }


### PR DESCRIPTION
### Description of change

The subnet in which tools and visualisations run does not use AWS's DNS resolver, and instead our own, that conditionally forwards requests to AWS's DNS resolver. This is so we can filter outgoing DNS requests to only DNS servers we control or trust.

EFS use the concept of "mount target": essentially a hostname that resolves to an IP address for one availability zone, which each EFS client uses to mount the filesystem. Each of these only resolves in a single AZ, and so for this to resolve in the AZ that the DNS resolver is in, the DNS resolver must in that same AZ. So here we fix the AZ to later be able to create the mount target in a fixed AZ.

Potentially we could have a mount target per AZ. However, we would always want tools to use the mount target for the AZ they are launched in, and each is launched in a single subnet.

Note that the DNS resolver is not HA. Potentially we could have a UDP internal network load balancer in front of several instances, all in the same AZ, and make it more HA, but leaving that for now. Especially since they would all have to be in the same AZ there would be limited benefit of this.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
