### PR TITLE
Fix GTM initial setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Launch DNS resolver in a single fixed subnet: will be the same subnet as the upcoming EFS mount target
+- Add GTM initial events block to base template for injecting data before GTM startup (fix)
 
 ## 2020-07-19
 

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -21,6 +21,14 @@
   <link rel="stylesheet" href="{% get_static_prefix %}govuk-frontend-including-fonts-3.3.0-v1.min.css">
   <link rel="stylesheet" href="{% get_static_prefix %}data-workspace.css">
 
+  {% if not debug and gtm_container_id %}
+    {% block initialGTMDataLayer %}
+      <script nonce="{{ request.csp_nonce }}">
+        window.dataLayer = window.dataLayer || [];
+      </script>
+    {% endblock %}
+  {% endif %}
+
   {% include 'partials/gtm_head.html' %}
 
   {% block head %}{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -19,8 +19,9 @@
   {% endif %}
 {% endblock %}
 
-{% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "datacut"})</script>
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "datacut"})</script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -12,21 +12,22 @@
     <script nonce="{{ request.csp_nonce }}" src="{% get_static_prefix %}search.js"></script>
 {% endblock %}
 
-{% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">
-  dataLayer.push(
-    {
-      "event": "filter",
-      "searchTerms": "{{ query }}",
-      "resultsReturned": {{ datasets.paginator.count }},
-      {% for field in form %}
-        {% if field.field|is_choice_field %}
-      "filterData{{ field.name | title }}": "{{ field | get_choice_field_data_for_gtm }}"{% if not forloop.last %},{% endif %}
-        {% endif %}
-      {% endfor %}
-    }
-  )
-</script>
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}">
+    dataLayer.push(
+      {
+        "event": "filter",
+        "searchTerms": "{{ query }}",
+        "resultsReturned": {{ datasets.paginator.count }},
+        {% for field in form %}
+          {% if field.field|is_choice_field %}
+        "filterData{{ field.name | title }}": "{{ field | get_choice_field_data_for_gtm }}"{% if not forloop.last %},{% endif %}
+          {% endif %}
+        {% endfor %}
+      }
+    )
+  </script>
 {% endblock %}
 
 {% block page_title %}Search - {{ block.super }}{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -4,8 +4,9 @@
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
-{% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "master"})</script>
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "master"})</script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -3,8 +3,9 @@
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
-{% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "reference"})</script>
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "reference"})</script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -5,8 +5,11 @@
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
-{% block extraGTMDataLayer %}
-<script nonce="{{ request.csp_nonce }}">dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "visualisation"})</script>
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}">
+    dataLayer.push({"event": "catalogueView", "catalogueId": "{{ model.id }}", "catalogueName": "{{ model.name }}", "catalogueType": "visualisation"})
+  </script>
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/partials/gtm_head.html
+++ b/dataworkspace/dataworkspace/templates/partials/gtm_head.html
@@ -1,12 +1,4 @@
 {% if not debug and gtm_container_id %}
-    <!-- Google Tag Manager's "Data Layer" -->
-    <script nonce="{{ request.csp_nonce }}">
-      window.dataLayer = window.dataLayer || [];
-    </script>
-    {% block extraGTMDataLayer %}
-    {% endblock %}
-    <!-- End Google Tag Manager's "Data Layer" -->
-
     <!-- Google Tag Manager -->
     <script nonce="{{ request.csp_nonce }}">
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
@@ -137,6 +137,20 @@ class TestDatasetViews:
         response = client.get(ds.get_absolute_url())
         assert response.status_code == 404
 
+    @override_settings(DEBUG=False, GTM_CONTAINER_ID="test")
+    @pytest.mark.parametrize(
+        'factory',
+        [
+            factories.MasterDataSetFactory,
+            factories.DatacutDataSetFactory,
+            factories.ReferenceDatasetFactory,
+        ],
+    )
+    def test_renders_gtm_push(self, client, factory):
+        ds = factory.create(published=True, deleted=False)
+        response = client.get(ds.get_absolute_url())
+        assert "dataLayer.push({" in response.content.decode(response.charset)
+
     @pytest.mark.parametrize(
         'request_client,published',
         [('client', True), ('staff_client', True), ('staff_client', False)],


### PR DESCRIPTION
### Description of change
A recent patch split the GTM head/body scripts into files that were
included into templates, rather than using blocks directly. The head GTM
snippet had a nested block that provided a hook to inject initial GTM
events. When this was switched over to use includes rather than blocks,
the injected events were no longer rendered to the page. This patch adds
a block above the head snippet that provides a point at which these
initial events can be injected again.

Ticket: https://trello.com/c/7TU1vgTH/562

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
