### PR TITLE
Sync quicksight perms from user form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-21
+
+### Changed
+
+- Sync quicksight permissions when changing master dataset access from the user admin page.
+
 ## 2020-07-20
 
 ### Changed


### PR DESCRIPTION
### Description of change
Access to master datasets can also be granted to users on the user admin
form, so we should sync permissions if any permissions are changed from
that view as well.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
