### PR TITLE
Use immutable DB users for quicksight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-22
+
+### Changed
+
+- Quicksight users will now be immutable with a random slug to prevent overlaps, similar to application credentials. They will last 7 days and be deleted when they expire.
+
 ## 2020-07-21
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
+++ b/dataworkspace/dataworkspace/apps/accounts/management/commands/store_db_creds_in_s3.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
@@ -27,7 +29,10 @@ class Command(BaseCommand):
             source_tables = source_tables_for_user(user)
             db_role_schema_suffix = db_role_schema_suffix_for_user(user)
             creds = new_private_database_credentials(
-                db_role_schema_suffix, source_tables, postgres_user(user.email)
+                db_role_schema_suffix,
+                source_tables,
+                postgres_user(user.email),
+                valid_for=datetime.timedelta(days=31),
             )
             write_credentials_to_bucket(user, creds)
             self.stdout.write(str(creds))

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import re
@@ -184,7 +185,10 @@ def application_api_PUT(request, public_host):
     )
 
     credentials = new_private_database_credentials(
-        db_role_schema_suffix, source_tables, db_user
+        db_role_schema_suffix,
+        source_tables,
+        db_user,
+        valid_for=datetime.timedelta(days=31),
     )
 
     if app_type == 'TOOL':

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -35,7 +35,7 @@ from dataworkspace.apps.core.utils import (
     stable_identification_suffix,
     source_tables_for_user,
     new_private_database_credentials,
-    persistent_postgres_user,
+    postgres_user,
 )
 from dataworkspace.apps.applications.gitlab import gitlab_has_developer_access
 from dataworkspace.apps.datasets.models import VisualisationCatalogueItem
@@ -459,7 +459,10 @@ def _do_delete_unused_datasets_users():
             cur.execute(
                 """
                 SELECT usename FROM pg_catalog.pg_user
-                WHERE valuntil != 'infinity' AND usename LIKE 'user_%' AND usename NOT LIKE '%_quicksight'
+                WHERE
+                (valuntil != 'infinity' AND usename LIKE 'user_%' AND usename NOT LIKE '%_qs')
+                OR
+                (valuntil != 'infinity' AND valuntil < now() AND usename LIKE 'user_%' AND usename LIKE '%_qs')
                 ORDER BY usename;
             """
             )
@@ -812,8 +815,10 @@ def sync_quicksight_permissions(user_sso_ids_to_update=tuple()):
                 creds = new_private_database_credentials(
                     db_role_schema_suffix,
                     source_tables,
-                    persistent_postgres_user(user_email, suffix='quicksight'),
-                    allow_existing_user=True,
+                    postgres_user(user_email, suffix='qs'),
+                    valid_for=datetime.timedelta(
+                        days=7
+                    ),  # We refresh these creds every night, so they don't need to last long at all.
                 )
 
                 create_update_delete_quicksight_user_data_sources(

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -460,7 +460,7 @@ def _do_delete_unused_datasets_users():
                 """
                 SELECT usename FROM pg_catalog.pg_user
                 WHERE
-                (valuntil != 'infinity' AND usename LIKE 'user_%' AND usename NOT LIKE '%_qs')
+                (valuntil != 'infinity' AND usename LIKE 'user_%' AND usename NOT LIKE '%_qs' AND usename NOT LIKE '%_quicksight')
                 OR
                 (valuntil != 'infinity' AND valuntil < now() AND usename LIKE 'user_%' AND usename LIKE '%_qs')
                 ORDER BY usename;

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -48,9 +48,10 @@ class TestDeleteUnusedDatasetsUsers:
 
 class TestSyncQuickSightPermissions:
     @pytest.mark.django_db
+    @mock.patch('dataworkspace.apps.core.utils.new_private_database_credentials')
     @mock.patch('dataworkspace.apps.applications.utils.boto3.client')
     @mock.patch('dataworkspace.apps.applications.utils.cache')
-    def test_create_new_data_source(self, mock_cache, mock_boto3_client):
+    def test_create_new_data_source(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
         UserFactory.create(username='fake@email.com')
         SourceTableFactory(
@@ -70,6 +71,7 @@ class TestSyncQuickSightPermissions:
             mock_data_client,
             mock_sts_client,
         ]
+        mock_creds.return_value = [mock.Mock()]
 
         # Act
         sync_quicksight_permissions()
@@ -88,10 +90,7 @@ class TestSyncQuickSightPermissions:
                     }
                 },
                 Credentials={
-                    'CredentialPair': {
-                        'Username': 'user_fake_email_com_quicksight',
-                        'Password': mock.ANY,
-                    }
+                    'CredentialPair': {'Username': mock.ANY, 'Password': mock.ANY}
                 },
                 VpcConnectionProperties={'VpcConnectionArn': mock.ANY},
                 Type='AURORA_POSTGRESQL',
@@ -123,9 +122,12 @@ class TestSyncQuickSightPermissions:
         ]
 
     @pytest.mark.django_db
+    @mock.patch('dataworkspace.apps.core.utils.new_private_database_credentials')
     @mock.patch('dataworkspace.apps.applications.utils.boto3.client')
     @mock.patch('dataworkspace.apps.applications.utils.cache')
-    def test_update_existing_data_source(self, mock_cache, mock_boto3_client):
+    def test_update_existing_data_source(
+        self, mock_cache, mock_boto3_client, mock_creds
+    ):
         # Arrange
         UserFactory.create(username='fake@email.com')
         SourceTableFactory(
@@ -174,10 +176,7 @@ class TestSyncQuickSightPermissions:
                     }
                 },
                 Credentials={
-                    'CredentialPair': {
-                        'Username': 'user_fake_email_com_quicksight',
-                        'Password': mock.ANY,
-                    }
+                    'CredentialPair': {'Username': mock.ANY, 'Password': mock.ANY}
                 },
                 VpcConnectionProperties={'VpcConnectionArn': mock.ANY},
                 Type='AURORA_POSTGRESQL',
@@ -206,10 +205,7 @@ class TestSyncQuickSightPermissions:
                     }
                 },
                 Credentials={
-                    'CredentialPair': {
-                        'Username': 'user_fake_email_com_quicksight',
-                        'Password': mock.ANY,
-                    }
+                    'CredentialPair': {'Username': mock.ANY, 'Password': mock.ANY}
                 },
                 VpcConnectionProperties={'VpcConnectionArn': mock.ANY},
             )
@@ -229,9 +225,12 @@ class TestSyncQuickSightPermissions:
         ]
 
     @pytest.mark.django_db
+    @mock.patch('dataworkspace.apps.core.utils.new_private_database_credentials')
     @mock.patch('dataworkspace.apps.applications.utils.boto3.client')
     @mock.patch('dataworkspace.apps.applications.utils.cache')
-    def test_missing_user_handled_gracefully(self, mock_cache, mock_boto3_client):
+    def test_missing_user_handled_gracefully(
+        self, mock_cache, mock_boto3_client, mock_creds
+    ):
         # Arrange
         user = UserFactory.create(username='fake@email.com')
         user2 = UserFactory.create(username='fake2@email.com')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,77 @@
+import datetime
+import time
+
+import mock
+import pytest
+from django.db import connections
+
+from dataworkspace.apps.applications.utils import delete_unused_datasets_users
+from dataworkspace.apps.core.utils import (
+    source_tables_for_user,
+    db_role_schema_suffix_for_user,
+    new_private_database_credentials,
+    postgres_user,
+)
+from dataworkspace.apps.datasets.management.commands.ensure_databases_configured import (
+    Command as ensure_databases_configured,
+)
+from dataworkspace.tests.factories import (
+    UserFactory,
+    SourceTableFactory,
+    MasterDataSetFactory,
+)
+
+
+class TestDeleteUnusedDatasetsUsers:
+    @pytest.mark.django_db(transaction=True)
+    def test_deletes_expired_and_unused_users(self):
+        ensure_databases_configured().handle()
+
+        user = UserFactory(email='test@foo.bar')
+        st = SourceTableFactory(
+            dataset=MasterDataSetFactory.create(
+                user_access_type='REQUIRES_AUTHENTICATION'
+            )
+        )
+
+        source_tables = source_tables_for_user(user)
+        db_role_schema_suffix = db_role_schema_suffix_for_user(user)
+        user_creds_to_drop = new_private_database_credentials(
+            db_role_schema_suffix,
+            source_tables,
+            postgres_user(user.email),
+            valid_for=datetime.timedelta(days=31),
+        )
+        qs_creds_to_drop = new_private_database_credentials(
+            db_role_schema_suffix,
+            source_tables,
+            postgres_user(user.email, suffix='qs'),
+            valid_for=datetime.timedelta(seconds=0),
+        )
+        qs_creds_to_keep = new_private_database_credentials(
+            db_role_schema_suffix,
+            source_tables,
+            postgres_user(user.email, suffix='qs'),
+            valid_for=datetime.timedelta(minutes=1),
+        )
+
+        connections[st.database.memorable_name].cursor().execute('COMMIT')
+
+        # Make sure that `qs_creds_to_drop` has definitely expired
+        time.sleep(1)
+
+        with mock.patch('dataworkspace.apps.applications.utils.gevent.sleep'):
+            delete_unused_datasets_users()
+
+        with connections[st.database.memorable_name].cursor() as cursor:
+            cursor.execute(
+                "SELECT usename FROM pg_catalog.pg_user WHERE usename IN %s",
+                [
+                    (
+                        user_creds_to_drop[0]['db_user'],
+                        qs_creds_to_drop[0]['db_user'],
+                        qs_creds_to_keep[0]['db_user'],
+                    )
+                ],
+            )
+            assert cursor.fetchall() == [(qs_creds_to_keep[0]['db_user'],)]


### PR DESCRIPTION
At the moment we have a static DB user for quicksight and whenever we
grant new permissions we re-generate credentials for the same username
and push those to QuickSight. However, we didn't have an implementation
for revoking permissions. After a little time looking at adding more
thorough grant/revoke to the single mutable user, it felt easier to
instead go for immutable users that grant all the right permissions as a
one-off and then we simply discard that user and generate a new one if
we need a different set of permissions.

Our immutable quicksight users last 7 days rather than 31 for tool
users. This is for a few reasons:

1) We re-sync permissions for all QuickSight users every night, so
really they are unlikely to be used after 24 hours. 7 days gives us some
grace if this nightly job fails for some reason.
2) We can't tell when QuickSight credentials are in use, unlike with
tools - so rather than checking if the application is in use, we will
instead delete old quicksight users when their password expires. 7 days
means that there (hopefully) won't be too many old quicksight users
hanging around for too long.

### Description of change


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
