### PR TITLE
Allow more time for GitLab pipelines to complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Bump mobius3 to version that better supports EFS
+- GitLab pipelines to build e.g. visualisastions now have 45 minutes to complete, up from 30.
 
 ## 2020-07-24
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -247,7 +247,7 @@ class FargateSpawner:
                     update_fields=['spawner_application_instance_id']
                 )
 
-                for _ in range(0, 600):
+                for _ in range(0, 900):
                     gevent.sleep(3)
                     pipeline = _gitlab_ecr_pipeline_get(pipeline_id)
                     logger.info('Fetched pipeline %s', pipeline)


### PR DESCRIPTION
### Description of change
Some of our visualisation pipelines take a long time to build -
especially R-based ones. Let's give them 45 minutes now rather than 30
minutes.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
