### PR TITLE
Loop over fields via reference dataset rather than record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Bump mobius3 to version that better supports EFS
 - GitLab pipelines to build e.g. visualisastions now have 45 minutes to complete, up from 30.
+- Iterate over reference dataset record fields via reference dataset rather than each record 
 
 ## 2020-07-24
 

--- a/dataworkspace/dataworkspace/templates/admin/reference_dataset_changeform.html
+++ b/dataworkspace/dataworkspace/templates/admin/reference_dataset_changeform.html
@@ -2,58 +2,60 @@
 {% load static core_tags %}
 {% block after_related_objects %}
   {% with adminform.form.instance as instance %}
-    {% if instance.id %}
-      <div class="inline-group" data-inline-type="tabular">
-        <div class="tabular inline-related">
-          <fieldset class="module ">
-            <h2>Reference dataset records</h2>
-            <table>
-              <thead>
-                <tr>
-                  {% for field in instance.fields.all %}
-                    <th class="column-{{ field.name }}">
-                      {{ field.name }}
-                    </th>
-                  {% endfor %}
-                  <th>Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for record in instance.get_records %}
-                  <tr class="form-row">
-                    {% for field in record.reference_dataset.fields.all %}
-                      {% with record|get_attr:field.column_name as value %}
-                        <td{% if value is None %} style="color: #bfc1c3"{% endif %}>
-                          {{ value|default_if_none:"Not set" }}
-                        </td>
-                      {% endwith %}
+    {% with instance.fields.all as fields %}
+      {% if instance.id %}
+        <div class="inline-group" data-inline-type="tabular">
+          <div class="tabular inline-related">
+            <fieldset class="module ">
+              <h2>Reference dataset records</h2>
+              <table>
+                <thead>
+                  <tr>
+                    {% for field in fields %}
+                      <th class="column-{{ field.name }}">
+                        {{ field.name }}
+                      </th>
                     {% endfor %}
-                    <td class="edit">
-                      <a href="{% url 'dw-admin:reference-dataset-record-edit' reference_dataset_id=instance.id record_id=record.id %}" class="button">
-                        Edit Record
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for record in instance.get_records %}
+                    <tr class="form-row">
+                      {% for field in fields %}
+                        {% with record|get_attr:field.column_name as value %}
+                          <td{% if value is None %} style="color: #bfc1c3"{% endif %}>
+                            {{ value|default_if_none:"Not set" }}
+                          </td>
+                        {% endwith %}
+                      {% endfor %}
+                      <td class="edit">
+                        <a href="{% url 'dw-admin:reference-dataset-record-edit' reference_dataset_id=instance.id record_id=record.id %}" class="button">
+                          Edit Record
+                        </a>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                  <tr class="add-row">
+                    <td colspan="{{ instance.fields.count|add:1 }}">
+                      <a href="{% url 'dw-admin:reference-dataset-record-add' reference_dataset_id=instance.id %}">
+                        Add a record
                       </a>
                     </td>
                   </tr>
-                {% endfor %}
-                <tr class="add-row">
-                  <td colspan="{{ instance.fields.count|add:1 }}">
-                    <a href="{% url 'dw-admin:reference-dataset-record-add' reference_dataset_id=instance.id %}">
-                      Add a record
-                    </a>
-                  </td>
-                </tr>
-                <tr class="add-row">
-                  <td colspan="{{ instance.fields.count|add:1 }}">
-                    <a href="{% url 'dw-admin:reference-dataset-record-upload' reference_dataset_id=instance.id %}">
-                      Upload a CSV
-                    </a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </fieldset>
+                  <tr class="add-row">
+                    <td colspan="{{ instance.fields.count|add:1 }}">
+                      <a href="{% url 'dw-admin:reference-dataset-record-upload' reference_dataset_id=instance.id %}">
+                        Upload a CSV
+                      </a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </fieldset>
+          </div>
         </div>
-      </div>
-    {% endif %}
+      {% endif %}
+    {% endwith %}
   {% endwith %}
 {% endblock after_related_objects %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -29,180 +29,182 @@
 {% endblock %}
 
 {% block content %}
-  {% if not model.published %}
-    {% include 'partials/unpublished_banner.html' with type='dataset' %}
-  {% endif %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">{{ model.name }}</h1>
-      <div class="govuk-body">
-        {{ model.description|safe }}
+  {% with model.fields.all as fields %}
+    {% if not model.published %}
+      {% include 'partials/unpublished_banner.html' with type='dataset' %}
+    {% endif %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">{{ model.name }}</h1>
+        <div class="govuk-body">
+          {{ model.description|safe }}
+        </div>
       </div>
     </div>
-  </div>
 
-  <div class="govuk-grid-row" style="overflow-x: auto;">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">Data links</h2>
-      <table class="govuk-table">
-        <thead>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header">Link to the data</th>
-            <th class="govuk-table__header">Format</th>
-            <th class="govuk-table__header">Version</th>
-            <th class="govuk-table__header">Last updated</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <a class="govuk-link" href="{% url 'datasets:reference_dataset_download' model.uuid 'json'%}">
-                {{ model.slug }}-{{ model.published_version }}.json
-              </a>
-            </td>
-            <td class="govuk-table__cell">JSON</td>
-            <td class="govuk-table__cell">{{ model.published_version }}</td>
-            <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">
-              <a class="govuk-link" href="{% url 'datasets:reference_dataset_download' model.uuid 'csv' %}">
-                {{ model.slug }}-{{ model.published_version }}.csv
-              </a>
-            </td>
-            <td class="govuk-table__cell">
-              CSV
-            </td>
-            <td class="govuk-table__cell">{{ model.published_version }}</td>
-            <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">
-        Field definitions
-      </h2>
-      <dl class="govuk-summary-list">
-        {% for field in model.fields.all %}
-            {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">{% linked_field_identifier_name field %}</dt>
-              {% if field.linked_reference_dataset and field.linked_reference_dataset.identifier_field %}
-                <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.identifier_field.description }}</dd>
-              {% else %}
-                <dd class="govuk-summary-list__value">{{ field.description }}</dd>
-              {% endif %}
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">{% linked_field_display_name field %}</dt>
-              {% if field.linked_reference_dataset and field.linked_reference_dataset.display_name_field %}
-                <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.display_name_field.description }}</dd>
-              {% else %}
-                <dd class="govuk-summary-list__value">{{ field.description }}</dd>
-              {% endif %}
-            </div>
-            {% else %}
-              <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">{{ field.name }}</dt>
-                <dd class="govuk-summary-list__value">{{ field.description }}</dd>
-              </div>
-            {% endif %}
-        {% empty %}
-          <div class="govuk-summary-list__row">
-            <p>No fields have been defined for this reference dataset yet.</p>
-          </div>
-        {% endfor %}
-      </dl>
-    </div>
-  </div>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m govuk-!-margin-top-8">
-        Data preview
-      </h2>
-      <p class="govuk-body">
-        Showing {% if preview_limit < record_count %}first {% endif %}<strong>{{ preview_limit }}</strong> record{{ preview_limit|pluralize }} {% if preview_limit < record_count %} of <strong>{{ record_count }}</strong>{% endif %}
-      </p>
-      <div class="scrollable-table">
-        <table class="govuk-table govuk-!-font-size-16">
+    <div class="govuk-grid-row" style="overflow-x: auto;">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m govuk-!-margin-top-8">Data links</h2>
+        <table class="govuk-table">
           <thead>
             <tr class="govuk-table__row">
-              {% for field in model.fields.all %}
-                {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
-                  <th class="govuk-table__header ref-data-col-id">{% linked_field_identifier_name field %}</th>
-                  <th class="govuk-table__header ref-data-col-character-field">{% linked_field_display_name field %}</th>
-                {% else %}
-                  <th class="govuk-table__header ref-data-col-{{ field.get_data_type_display|slugify }}{% if field.is_identifier %} ref-data-col-id{% endif %}">
-                    {{ field.name }}
-                  </th>
-                {% endif %}
-              {% endfor %}
-              {% if perms.datasets_referencedataset.change %}
-                <th class="govuk-table__header">Admin</th>
-              {% endif %}
+              <th class="govuk-table__header">Link to the data</th>
+              <th class="govuk-table__header">Format</th>
+              <th class="govuk-table__header">Version</th>
+              <th class="govuk-table__header">Last updated</th>
             </tr>
           </thead>
           <tbody>
-            {% for record in records %}
-              <tr class="govuk-table__row">
-                {% for field in record.reference_dataset.fields.all %}
-                  {% with record|get_attr:field.column_name as value %}
-                    {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
-                      <td class="govuk-table__cell">
-                        {{ value.get_identifier|not_set_if_none }}
-                      </td>
-                      <td class="govuk-table__cell">
-                        {{ value.get_display_name|not_set_if_none }}
-                      </td>
-                    {% else %}
-                      <td class="govuk-table__cell">
-                        {{ value|not_set_if_none }}
-                      </td>
-                    {% endif %}
-                  {% endwith %}
-                {% endfor %}
-                {% if perms.datasets_referencedataset.change %}
-                  <td class="govuk-table__cell">
-                    <a href="{% url 'dw-admin:reference-dataset-record-edit' model.id record.id %}">
-                      Edit
-                    </a>
-                  </td>
-                {% endif %}
-              </tr>
-            {% empty %}
-              <tr class="govuk-table__row">
-                <td colspan="{{ model.field_names|length }}">
-                  This reference dataset doesn't have any data yet.
-                </td>
-              </tr>
-            {% endfor %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <a class="govuk-link" href="{% url 'datasets:reference_dataset_download' model.uuid 'json'%}">
+                  {{ model.slug }}-{{ model.published_version }}.json
+                </a>
+              </td>
+              <td class="govuk-table__cell">JSON</td>
+              <td class="govuk-table__cell">{{ model.published_version }}</td>
+              <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <a class="govuk-link" href="{% url 'datasets:reference_dataset_download' model.uuid 'csv' %}">
+                  {{ model.slug }}-{{ model.published_version }}.csv
+                </a>
+              </td>
+              <td class="govuk-table__cell">
+                CSV
+              </td>
+              <td class="govuk-table__cell">{{ model.published_version }}</td>
+              <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
+            </tr>
           </tbody>
         </table>
       </div>
     </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-l govuk-!-margin-top-8">Additional information</h2>
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Licence</dt>
-          <dd class="govuk-summary-list__value">{{ model.licence }}</dd>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">Restrictions on usage</dt>
-          <dd class="govuk-summary-list__value">{{ model.restrictions_on_usage | linebreaksbr }}</dd>
-        </div>
-      </dl>
-      {% if model.enquiries_contact %}
-        {% include 'partials/contact.html' with model=model.enquiries_contact as_section=True only %}
-      {% endif %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m govuk-!-margin-top-8">
+          Field definitions
+        </h2>
+        <dl class="govuk-summary-list">
+          {% for field in fields %}
+              {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">{% linked_field_identifier_name field %}</dt>
+                {% if field.linked_reference_dataset and field.linked_reference_dataset.identifier_field %}
+                  <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.identifier_field.description }}</dd>
+                {% else %}
+                  <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+                {% endif %}
+              </div>
+              <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">{% linked_field_display_name field %}</dt>
+                {% if field.linked_reference_dataset and field.linked_reference_dataset.display_name_field %}
+                  <dd class="govuk-summary-list__value">{{ field.linked_reference_dataset.display_name_field.description }}</dd>
+                {% else %}
+                  <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+                {% endif %}
+              </div>
+              {% else %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">{{ field.name }}</dt>
+                  <dd class="govuk-summary-list__value">{{ field.description }}</dd>
+                </div>
+              {% endif %}
+          {% empty %}
+            <div class="govuk-summary-list__row">
+              <p>No fields have been defined for this reference dataset yet.</p>
+            </div>
+          {% endfor %}
+        </dl>
+      </div>
     </div>
-  </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h2 class="govuk-heading-m govuk-!-margin-top-8">
+          Data preview
+        </h2>
+        <p class="govuk-body">
+          Showing {% if preview_limit < record_count %}first {% endif %}<strong>{{ preview_limit }}</strong> record{{ preview_limit|pluralize }} {% if preview_limit < record_count %} of <strong>{{ record_count }}</strong>{% endif %}
+        </p>
+        <div class="scrollable-table">
+          <table class="govuk-table govuk-!-font-size-16">
+            <thead>
+              <tr class="govuk-table__row">
+                {% for field in fields %}
+                  {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
+                    <th class="govuk-table__header ref-data-col-id">{% linked_field_identifier_name field %}</th>
+                    <th class="govuk-table__header ref-data-col-character-field">{% linked_field_display_name field %}</th>
+                  {% else %}
+                    <th class="govuk-table__header ref-data-col-{{ field.get_data_type_display|slugify }}{% if field.is_identifier %} ref-data-col-id{% endif %}">
+                      {{ field.name }}
+                    </th>
+                  {% endif %}
+                {% endfor %}
+                {% if perms.datasets_referencedataset.change %}
+                  <th class="govuk-table__header">Admin</th>
+                {% endif %}
+              </tr>
+            </thead>
+            <tbody>
+              {% for record in records %}
+                <tr class="govuk-table__row">
+                  {% for field in fields %}
+                    {% with record|get_attr:field.column_name as value %}
+                      {% if field.data_type == field.DATA_TYPE_FOREIGN_KEY %}
+                        <td class="govuk-table__cell">
+                          {{ value.get_identifier|not_set_if_none }}
+                        </td>
+                        <td class="govuk-table__cell">
+                          {{ value.get_display_name|not_set_if_none }}
+                        </td>
+                      {% else %}
+                        <td class="govuk-table__cell">
+                          {{ value|not_set_if_none }}
+                        </td>
+                      {% endif %}
+                    {% endwith %}
+                  {% endfor %}
+                  {% if perms.datasets_referencedataset.change %}
+                    <td class="govuk-table__cell">
+                      <a href="{% url 'dw-admin:reference-dataset-record-edit' model.id record.id %}">
+                        Edit
+                      </a>
+                    </td>
+                  {% endif %}
+                </tr>
+              {% empty %}
+                <tr class="govuk-table__row">
+                  <td colspan="{{ model.field_names|length }}">
+                    This reference dataset doesn't have any data yet.
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-l govuk-!-margin-top-8">Additional information</h2>
+        <dl class="govuk-summary-list">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Licence</dt>
+            <dd class="govuk-summary-list__value">{{ model.licence }}</dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Restrictions on usage</dt>
+            <dd class="govuk-summary-list__value">{{ model.restrictions_on_usage | linebreaksbr }}</dd>
+          </div>
+        </dl>
+        {% if model.enquiries_contact %}
+          {% include 'partials/contact.html' with model=model.enquiries_contact as_section=True only %}
+        {% endif %}
+      </div>
+    </div>
+  {% endwith %}
 {% endblock %}


### PR DESCRIPTION
### Description of change

Trello card: https://trello.com/c/Uk5Shu5p/480-improve-loading-time-on-reference-dataset-pages

Get reference dataset fields via the reference dataset model rather than through the record itself when looping through records. This was causing extra queries on each record (thousands in total) when looping through a recordset.

Before:
![ui-ref-datasets-before](https://user-images.githubusercontent.com/594496/88937423-0af7a180-d27c-11ea-84c9-98919fdd976d.png)

After:
![ui-ref-datasets-after](https://user-images.githubusercontent.com/594496/88937461-14810980-d27c-11ea-9840-ae02374279bd.png)


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
