### PR TITLE
Centralise sentry config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-07-31
+
+### Changed
+
+- Sentry setup to be centralised, and start to group certain errors so they're easier to handle.
+
 ## 2020-07-30
 
 ### Added

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -4,11 +4,13 @@ import json
 import os
 import urllib.request
 
-import sentry_sdk
 from celery.schedules import crontab
 from sentry_sdk.integrations.django import DjangoIntegration
 
+import sentry
 from dataworkspace.utils import normalise_environment
+
+sentry.init_sentry(integration=DjangoIntegration())
 
 env = normalise_environment(os.environ)
 
@@ -288,9 +290,6 @@ S3_PERMISSIONS_BOUNDARY_ARN = env['S3_PERMISSIONS_BOUNDARY_ARN']
 S3_ROLE_PREFIX = env['S3_ROLE_PREFIX']
 
 YOUR_FILES_ENABLED = env.get('YOUR_FILES_ENABLED', 'False') == 'True'
-
-if env.get('SENTRY_DSN') is not None:
-    sentry_sdk.init(env['SENTRY_DSN'], integrations=[DjangoIntegration()])
 
 
 CKEDITOR_CONFIGS = {

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -14,7 +14,6 @@ import uuid
 import urllib
 
 import aiohttp
-import sentry_sdk
 from aiohttp import web
 
 import aioredis
@@ -1379,10 +1378,9 @@ async def async_main():
 
 
 def main():
-    if os.environ.get('SENTRY_DSN') is not None:
-        sentry_sdk.init(
-            os.environ['SENTRY_DSN'], integrations=[AioHttpIntegration()], debug=True
-        )
+    from sentry import init_sentry
+
+    init_sentry(integration=AioHttpIntegration())
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(async_main())

--- a/dataworkspace/sentry.py
+++ b/dataworkspace/sentry.py
@@ -1,0 +1,28 @@
+import os
+from asyncio import CancelledError
+
+import sentry_sdk
+
+
+def before_send(event, hint):
+    if 'exc_info' not in hint:
+        return event
+
+    exception = hint['exc_info'][1]
+
+    # Group together all asyncio/aiohttp cancellederrors
+    if isinstance(exception, CancelledError):
+        event['fingerprint'] = ['cancelled-error', '{{ module }}']
+    elif isinstance(exception, ConnectionResetError):
+        event['fingerprint'] = ['connection-reset-error', '{{ module }}']
+
+    return event
+
+
+def init_sentry(integration):
+    if os.environ.get('SENTRY_DSN') is not None:
+        sentry_sdk.init(
+            os.environ['SENTRY_DSN'],
+            integrations=[integration],
+            before_send=before_send,
+        )


### PR DESCRIPTION
### Description of change
Move the sentry setup code from Django settings and the proxy to a
separate file so that we can share code/config.

Group CancelledErrors together so that we only have a single event for
them in Sentry, making them less noisy and easier to handle. Same for
ConnectionResetError, which is also fairly prolific in the proxy and
pops up in various places with the same outcome.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
