### PR TITLE
Open help centre in new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Sentry setup to be centralised, and start to group certain errors so they're easier to handle.
+- Open help centre link in a new tab.
 
 ## 2020-07-30
 

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -83,8 +83,8 @@
             </a>
           </li>
           <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="https://data-services-help.trade.gov.uk/data-workspace">
-              Help centre
+            <a class="govuk-header__link" href="https://data-services-help.trade.gov.uk/data-workspace" target="_blank" rel="noopener noreferrer">
+              Help centre <span class="govuk-visually-hidden">(opens in a new tab)</span>
             </a>
           </li>
         </ul>
@@ -141,8 +141,8 @@
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="https://data-services-help.trade.gov.uk/data-workspace">
-                  Help centre
+                <a class="govuk-header__link" href="https://data-services-help.trade.gov.uk/data-workspace" target="_blank" rel="noopener noreferrer">
+                  Help centre <span class="govuk-visually-hidden">(opens in a new tab)</span>
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -103,9 +103,7 @@ def test_header_links(request_client):
     soup = BeautifulSoup(response.content.decode(response.charset))
     header_links = soup.find("header").find_all("a")
 
-    link_labels = [
-        (link.get_text(strip=True), link.get('href')) for link in header_links
-    ]
+    link_labels = [(link.get_text().strip(), link.get('href')) for link in header_links]
 
     expected_links = [
         ("Data Workspace", "http://dataworkspace.test:8000/"),
@@ -113,7 +111,10 @@ def test_header_links(request_client):
         ("Tools", "/tools/"),
         ("About", "/about/"),
         ("Support and feedback", "/support-and-feedback/"),
-        ("Help centre", "https://data-services-help.trade.gov.uk/data-workspace"),
+        (
+            "Help centre (opens in a new tab)",
+            "https://data-services-help.trade.gov.uk/data-workspace",
+        ),
     ]
 
     assert link_labels == expected_links
@@ -128,16 +129,17 @@ def test_footer_links(request_client):
     soup = BeautifulSoup(response.content.decode(response.charset))
     footer_links = soup.find("footer").find_all("a")
 
-    link_labels = [
-        (link.get_text(strip=True), link.get('href')) for link in footer_links
-    ]
+    link_labels = [(link.get_text().strip(), link.get('href')) for link in footer_links]
 
     expected_links = [
         ('Home', 'http://dataworkspace.test:8000/'),
         ("Tools", "/tools/"),
         ('About', '/about/'),
         ("Support and feedback", "/support-and-feedback/"),
-        ('Help centre', 'https://data-services-help.trade.gov.uk/data-workspace'),
+        (
+            'Help centre (opens in a new tab)',
+            'https://data-services-help.trade.gov.uk/data-workspace',
+        ),
         (
             'Privacy Policy',
             'https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/data-workspace-privacy-policy',


### PR DESCRIPTION
### Description of change
The help centre looks visually similar to Data Workspace and we believe
some users are finding it hard to navigate when taken away from our
services into the help centre.

Let's open the help centre in a new tab, with some extra content to help
screenreading users understand what navigation is happening.

Ticket: https://trello.com/c/kwX9SnKz/534

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
