### PR TITLE
Sleep when attempting to create new IAM credentials for running tools

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 import re
+import time
 
 import boto3
 
@@ -304,6 +305,8 @@ def aws_credentials_api_GET(request):
             if i == max_attempts - 1:
                 raise
         else:
+            # To try compensating for eventual consistency
+            time.sleep(5)
             break
 
     return JsonResponse(

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -2,9 +2,9 @@ import datetime
 import json
 import logging
 import re
-import time
 
 import boto3
+import gevent
 
 from django.conf import settings
 from django.db import IntegrityError
@@ -306,7 +306,7 @@ def aws_credentials_api_GET(request):
                 raise
         else:
             # To try compensating for eventual consistency
-            time.sleep(5)
+            gevent.sleep(1)
             break
 
     return JsonResponse(


### PR DESCRIPTION
### Description of change

When a user accesses tools for the first time, IAM credentials need to be created but as the various IAM operations are eventually consistent, this may fail. This is currently attempted 3 times but it will be useful to add a sleep for 5 seconds in between attempts to reduce the chance of this failing.

Sentry error where this was picked up: https://sentry.ci.uktrade.digital/dit/data-workspace/issues/28536/

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
