### PR TITLE
Stop authors creating quicksight data sources

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -105,3 +105,4 @@ METABASE_BOT_USER_PASSWORD=password1
 QUICKSIGHT_USER_REGION=get-from-aws-quicksight
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight
 QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN=aws:arn:from:terraform
+QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS=custom-author-permissions

--- a/.envs/test.env
+++ b/.envs/test.env
@@ -91,3 +91,4 @@ METABASE_BOT_USER_PASSWORD=password1
 QUICKSIGHT_USER_REGION=get-from-aws-quicksight
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight
 QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN=test-quicksight-embed-role
+QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS=custom-author-permissions

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -789,10 +789,30 @@ def sync_quicksight_permissions(user_sso_ids_to_update=tuple()):
                 user_arn = quicksight_user['Arn']
                 user_email = quicksight_user['Email']
                 user_role = quicksight_user['Role']
+                user_username = quicksight_user['UserName']
 
                 if user_role != 'AUTHOR' and user_role != 'ADMIN':
                     logger.info(f"Skipping {user_email} with role {user_role}.")
                     continue
+
+                if user_role == "ADMIN":
+                    user_client.update_user(
+                        AwsAccountId=account_id,
+                        Namespace='default',
+                        Role=user_role,
+                        UnapplyCustomPermissions=True,
+                        UserName=user_username,
+                        Email=user_email,
+                    )
+                else:
+                    user_client.update_user(
+                        AwsAccountId=account_id,
+                        Namespace="default",
+                        Role=user_role,
+                        CustomPermissionsName=settings.QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS,
+                        UserName=user_username,
+                        Email=user_email,
+                    )
 
                 dw_user = get_user_model().objects.filter(email=user_email).first()
                 if not dw_user:

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -380,6 +380,7 @@ QUICKSIGHT_DASHBOARD_HOST = 'https://eu-west-2.quicksight.aws.amazon.com'  # For
 QUICKSIGHT_DASHBOARD_GROUP = "DataWorkspace"
 QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN = env['QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN']
 QUICKSIGHT_SSO_URL = "https://sso.trade.gov.uk/idp/sso/init?sp=aws-quicksight&RelayState=https://quicksight.aws.amazon.com"
+QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS = 'author-custom-permissions'
 
 METABASE_ROOT = env['METABASE_ROOT']
 METABASE_SITE_URL = "metabase." + APPLICATION_ROOT_DOMAIN

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -62,7 +62,14 @@ class TestSyncQuickSightPermissions:
 
         mock_user_client = mock.Mock()
         mock_user_client.list_users.return_value = {
-            "UserList": [{"Arn": "Arn", "Email": "fake@email.com", "Role": "AUTHOR"}]
+            "UserList": [
+                {
+                    "Arn": "Arn",
+                    "Email": "fake@email.com",
+                    "Role": "AUTHOR",
+                    "UserName": "user/fake@email.com",
+                }
+            ]
         }
         mock_data_client = mock.Mock()
         mock_sts_client = mock.Mock()
@@ -77,6 +84,16 @@ class TestSyncQuickSightPermissions:
         sync_quicksight_permissions()
 
         # Assert
+        assert mock_user_client.update_user.call_args_list == [
+            mock.call(
+                AwsAccountId=mock.ANY,
+                Namespace='default',
+                Role='AUTHOR',
+                CustomPermissionsName='author-custom-permissions',
+                UserName='user/fake@email.com',
+                Email='fake@email.com',
+            )
+        ]
         assert mock_data_client.create_data_source.call_args_list == [
             mock.call(
                 AwsAccountId=mock.ANY,
@@ -138,7 +155,14 @@ class TestSyncQuickSightPermissions:
 
         mock_user_client = mock.Mock()
         mock_user_client.list_users.return_value = {
-            "UserList": [{"Arn": "Arn", "Email": "fake@email.com", "Role": "AUTHOR"}]
+            "UserList": [
+                {
+                    "Arn": "Arn",
+                    "Email": "fake@email.com",
+                    "Role": "AUTHOR",
+                    "UserName": "user/fake@email.com",
+                }
+            ]
         }
         mock_data_client = mock.Mock()
         mock_data_client.create_data_source.side_effect = [
@@ -163,6 +187,16 @@ class TestSyncQuickSightPermissions:
         sync_quicksight_permissions()
 
         # Assert
+        assert mock_user_client.update_user.call_args_list == [
+            mock.call(
+                AwsAccountId=mock.ANY,
+                Namespace='default',
+                Role='AUTHOR',
+                CustomPermissionsName='author-custom-permissions',
+                UserName='user/fake@email.com',
+                Email='fake@email.com',
+            )
+        ]
         assert mock_data_client.create_data_source.call_args_list == [
             mock.call(
                 AwsAccountId=mock.ANY,
@@ -251,7 +285,14 @@ class TestSyncQuickSightPermissions:
                 },
                 'DescribeUser',
             ),
-            {"User": {"Arn": "Arn", "Email": "fake2@email.com", "Role": "AUTHOR"}},
+            {
+                "User": {
+                    "Arn": "Arn",
+                    "Email": "fake2@email.com",
+                    "Role": "ADMIN",
+                    "UserName": "user/fake2@email.com",
+                }
+            },
         ]
         mock_data_client = mock.Mock()
         mock_sts_client = mock.Mock()
@@ -267,6 +308,16 @@ class TestSyncQuickSightPermissions:
         )
 
         # Assert
+        assert mock_user_client.update_user.call_args_list == [
+            mock.call(
+                AwsAccountId=mock.ANY,
+                Namespace='default',
+                Role='ADMIN',
+                UnapplyCustomPermissions=True,
+                UserName='user/fake2@email.com',
+                Email='fake2@email.com',
+            )
+        ]
         assert mock_user_client.describe_user.call_args_list == [
             mock.call(
                 AwsAccountId=mock.ANY,


### PR DESCRIPTION
### Description of change
For the initial release, we want QuickSight authors to focus on creating
dashboards with Data Workspace data as opposed to arbitrary other data.
QuickSight now lets us apply custom permissions to users so that we can
lock down creating data sources, so let's apply that permission and
enforce it as part of the regular sync.

Ticket: https://trello.com/c/YFHckT4L/664-prevent-authors-creating-data-sources-in-quicksight

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
