### PR TITLE
Use <td> for empty table cell instead of <th>

### DIFF
--- a/dataworkspace/dataworkspace/templates/files.html
+++ b/dataworkspace/dataworkspace/templates/files.html
@@ -224,7 +224,7 @@ Modified by the Department for International Trade
                 <table class="govuk-table" style="table-layout: fixed;">
                     <thead>
                         <tr class="govuk-table__row">
-                            <td scope="col" class="govuk-table__header govuk-table__header--checkbox"></td>
+                            <td class="govuk-table__header govuk-table__header--checkbox"></td>
                             <th scope="col" class="govuk-table__header">Name</th>
                             <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 15em;" >Last modified</th>
                             <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 5em;">Size</th>

--- a/dataworkspace/dataworkspace/templates/files.html
+++ b/dataworkspace/dataworkspace/templates/files.html
@@ -224,7 +224,7 @@ Modified by the Department for International Trade
                 <table class="govuk-table" style="table-layout: fixed;">
                     <thead>
                         <tr class="govuk-table__row">
-                            <th scope="col" class="govuk-table__header govuk-table__header--checkbox"></th>
+                            <td scope="col" class="govuk-table__header govuk-table__header--checkbox"></td>
                             <th scope="col" class="govuk-table__header">Name</th>
                             <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 15em;" >Last modified</th>
                             <th scope="col" class="govuk-table__header govuk-table__header--numeric" style="width: 5em;">Size</th>


### PR DESCRIPTION
### Description of change

The wave tool has picked up an empty table header cell as an accessibility error, this PR replaces the `<th>` with a `<td>`

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
