### PR TITLE
Remove unnecessary utf8 BOM write from csv downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Remove unnecessary utf8 BOM write from csv downloads
+
+## 2020-08-05
+
+### Added
+
 - '6-monthly' and 'ad hoc' frequencies to datasets.
 
 ## 2020-07-31

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1,4 +1,3 @@
-import codecs
 import datetime
 import hashlib
 import itertools
@@ -479,7 +478,6 @@ def streaming_query_response(user_email, database, query, filename):
                 return value
 
         pseudo_buffer = PseudoBuffer()
-        pseudo_buffer.write(codecs.BOM_UTF8)
         csv_writer = csv.writer(pseudo_buffer, quoting=csv.QUOTE_NONNUMERIC)
 
         with connect(


### PR DESCRIPTION
### Description of change

Removes the BOM write

- GDS data standards require removal of BOM
- In this instance writing the BOM had no effect anyway

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
