### PR TITLE
Keep Your Files modal HTML out of the DOM until it's needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Specified sizes on SVGs in the Your Files page to make it more reasonable without CSS
+- The modals of the Your Files page to not have the HTML in the DOM until they're needed, to make the page more reasonable without CSS
 
 ## 2020-08-10
 

--- a/dataworkspace/dataworkspace/templates/files.html
+++ b/dataworkspace/dataworkspace/templates/files.html
@@ -46,7 +46,7 @@ Modified by the Department for International Trade
     <!-- Icons provided by Font Awesome https://fontawesome.com/license -->
     <div ng-app="aws-js-s3-explorer">
         <div modal="add-folder" class="modal" ng-controller="AddFolderController" tabindex="-1" role="dialog" aria-labelledby="add-folder-title" aria-hidden="true" ng-cloak>
-            <form class="modal-dialog" name="add_folder_form" ng-submit="addFolder()">
+            <form class="modal-dialog" name="add_folder_form" ng-submit="addFolder()" ng-if="modalVisible">
                 <div class="modal-header">
                     <h2 class="modal-title govuk-heading-m" id="add-folder-title">New folder</h2>
                 </div>
@@ -70,7 +70,7 @@ Modified by the Department for International Trade
         </div>
 
         <div modal="trash" class="modal" ng-controller="TrashController" tabindex="-1" role="dialog" aria-labelledby="trash-title" aria-hidden="true" ng-cloak>
-            <div class="modal-dialog modal-xl">
+            <div class="modal-dialog modal-xl" ng-if="modalVisible">
                 <div class="modal-header">
                     <h2 class="modal-title govuk-heading-m" id="trash-title">Confirm delete of {{ model.count }} file{{ ((model.count > 1) ? 's' : '') }} </h2>
                 </div>
@@ -125,7 +125,7 @@ Modified by the Department for International Trade
         </div>
 
         <div modal="error" class="modal" ng-controller="ErrorController" tabindex="-1" role="dialog" aria-labelledby="error-title" aria-hidden="true" ng-cloak>
-            <div class="modal-dialog modal-lg">
+            <div class="modal-dialog modal-lg" ng-if="modalVisible">
                 <div class="modal-header">
                     <h2 class="modal-title govuk-heading-m" id="error-title">Error {{ error.code ? '(' + error.code + ')' : '' }}</h2>
                 </div>
@@ -153,7 +153,7 @@ Modified by the Department for International Trade
         </div>
 
         <div modal="upload" class="modal" ng-controller="UploadController" tabindex="-1" role="dialog" aria-labelledby="upload-title" aria-hidden="true" ng-cloak>
-            <div class="modal-dialog modal-xl">
+            <div class="modal-dialog modal-xl" ng-if="modalVisible">
                 <div class="modal-header">
                     <h2 class="modal-title govuk-heading-m" id="upload-title">Upload to {{ model.folder }}</h2>
                 </div>


### PR DESCRIPTION
### Description of change

This is to make the Your Files page more reasonable when CSS is disabled. Note that the modal HTML is there is Javascript is disabled, since the ng-if will remove elements using Javascript, but in this case, the whole interface won't work anyway.

There is some duplication here, but given the number of modals, the current uncertainty regarding the page, and the fact that to address this I suspect will have to do a lot of faffing with templates and/or transclusion that can get a bit complicated, suspect not worth it.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
