### PR TITLE
dev: add pylint dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,8 @@ freezegun==0.3.15
 beautifulsoup4==4.9.1
 mock==4.0.2
 mohawk==1.1.0
+pylint==2.5.3
+pylint-django==2.3.0
 pytest==5.4.3
 pytest-cov==2.10.0
 pytest-mock==3.2.0


### PR DESCRIPTION
We use these dependencies in our pre-commit hooks so they should be in
our dev requirements.
