### PR TITLE
fix: Drop objects owned by a db user before dropping user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-08-14
+
+### Changed
+
+- Before dropping a db user drop any objects that are owned by them
+
 ## 2020-08-13
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -568,6 +568,11 @@ def _do_delete_unused_datasets_users():
                             'delete_unused_datasets_users: dropping user %s', usename
                         )
                         cur.execute(
+                            sql.SQL('REASSIGN OWNED BY {} TO current_user;').format(
+                                sql.Identifier(usename)
+                            )
+                        )
+                        cur.execute(
                             sql.SQL('DROP OWNED BY {};').format(sql.Identifier(usename))
                         )
                         cur.execute(

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -568,6 +568,9 @@ def _do_delete_unused_datasets_users():
                             'delete_unused_datasets_users: dropping user %s', usename
                         )
                         cur.execute(
+                            sql.SQL('DROP OWNED BY {};').format(sql.Identifier(usename))
+                        )
+                        cur.execute(
                             sql.SQL('DROP USER {};').format(sql.Identifier(usename))
                         )
                     except redis.exceptions.LockError:


### PR DESCRIPTION
Fixes issue where dropping a user with existing privileges was failing with the error "role cannot be dropped because some objects depend on it"

Closes: https://trello.com/c/4KN0gY7O/717-unable-to-delete-users-that-have-db-privileges-set

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
