### PR TITLE
Feature/add state filter to applicationinstances admin

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/admin.py
+++ b/dataworkspace/dataworkspace/apps/applications/admin.py
@@ -36,8 +36,9 @@ from dataworkspace.apps.eventlog.utils import log_permission_change
 
 @admin.register(ApplicationInstance)
 class ApplicationInstanceAdmin(admin.ModelAdmin):
-
-    list_display = ('owner', 'public_host', 'created_date')
+    list_display = ('owner', 'public_host', 'created_date', 'state')
+    list_filter = ('state',)
+    ordering = ('-created_date',)
     fieldsets = [
         (
             None,
@@ -64,10 +65,6 @@ class ApplicationInstanceAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request):
         return False
-
-    def get_queryset(self, request):
-        qs = super().get_queryset(request)
-        return qs.filter(state__in=['SPAWNING', 'RUNNING'])
 
     def max_cpu(self, obj):
         try:

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -3,7 +3,6 @@
 
 import datetime
 
-import hashlib
 import json
 import logging
 import os
@@ -25,7 +24,7 @@ from dataworkspace.apps.applications.gitlab import (
     gitlab_api_v4,
     gitlab_api_v4_ecr_pipeline_trigger,
 )
-from dataworkspace.apps.core.utils import create_s3_role
+from dataworkspace.apps.core.utils import create_s3_role, stable_identification_suffix
 
 logger = logging.getLogger('app')
 
@@ -265,9 +264,7 @@ class FargateSpawner:
 
             # It doesn't really matter what the suffix is: it could even be a random
             # number, but we choose the short hashed version of the SSO ID to help debugging
-            task_family_suffix = hashlib.sha256(
-                user_sso_id.encode('utf-8')
-            ).hexdigest()[:8]
+            task_family_suffix = stable_identification_suffix(user_sso_id, short=True)
             definition_arn_with_image = _fargate_new_task_definition(
                 definition_arn, container_name, tag, task_family_suffix
             )

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -1,7 +1,6 @@
 import datetime
 
 
-import hashlib
 import itertools
 import random
 import re
@@ -49,7 +48,11 @@ from dataworkspace.apps.applications.utils import (
 )
 from dataworkspace.apps.applications.spawner import get_spawner
 from dataworkspace.apps.applications.utils import stop_spawner_and_application
-from dataworkspace.apps.core.utils import source_tables_for_app, source_tables_for_user
+from dataworkspace.apps.core.utils import (
+    source_tables_for_app,
+    source_tables_for_user,
+    stable_identification_suffix,
+)
 from dataworkspace.apps.core.views import public_error_500_html_view
 from dataworkspace.apps.datasets.models import (
     MasterDataset,
@@ -158,10 +161,9 @@ def tools_html_view(request):
 
 
 def tools_html_GET(request):
-    sso_id_hex = hashlib.sha256(
-        str(request.user.profile.sso_id).encode('utf-8')
-    ).hexdigest()
-    sso_id_hex_short = sso_id_hex[:8]
+    sso_id_hex_short = stable_identification_suffix(
+        str(request.user.profile.sso_id), short=True
+    )
 
     application_instances = {
         application_instance.application_template: application_instance

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -46,7 +46,7 @@ def postgres_user(stem, suffix=''):
 
 
 def db_role_schema_suffix_for_user(user):
-    return hashlib.sha256(str(user.profile.sso_id).encode('utf-8')).hexdigest()[:8]
+    return stable_identification_suffix(str(user.profile.sso_id), short=True)
 
 
 def db_role_schema_suffix_for_app(application_template):
@@ -270,7 +270,7 @@ def write_credentials_to_bucket(user, creds):
         s3_client = boto3.client('s3')
         s3_prefix = (
             'user/federated/'
-            + hashlib.sha256(str(user.profile.sso_id).encode('utf-8')).hexdigest()
+            + stable_identification_suffix(str(user.profile.sso_id), short=False)
             + '/'
         )
 
@@ -548,9 +548,7 @@ def table_data(user_email, database, schema, table, filename=None):
 
 def get_s3_prefix(user_sso_id):
     return (
-        'user/federated/'
-        + hashlib.sha256(user_sso_id.encode('utf-8')).hexdigest()
-        + '/'
+        'user/federated/' + stable_identification_suffix(user_sso_id, short=False) + '/'
     )
 
 
@@ -652,5 +650,8 @@ class StreamingHttpResponseWithoutDjangoDbConnection(StreamingHttpResponse):
             connection.close_if_unusable_or_obsolete()
 
 
-def stable_identification_suffix(identifier):
-    return hashlib.sha256(identifier.encode('utf-8')).hexdigest()[:8]
+def stable_identification_suffix(identifier, short):
+    digest = hashlib.sha256(identifier.encode('utf-8')).hexdigest()
+    if short:
+        return digest[:8]
+    return digest


### PR DESCRIPTION
### Description of change

Sentry errors related to tools/visualisations sometimes have the application url in the stacktrace but no user email address and sometimes it's necessary to contact the user to understand what they did to trigger the error.

The user of a **running** application can be found by going to /admin/applications/applicationinstance and looking at the `PUBLIC HOST` field, but as a sentry error usually relates to a tool that has crashed, the row won't be visible.

This PR adds the state filter to the Applicationinstances admin page to allow an easy search for the user's email address when the Applicationinstance is in a `STOPPED` state.

There is also a small refactor as I noticed that the application/visualisation URL is generated using a hex digest of the user's sso id but this is repeated in loads of different places.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
