### PR TITLE
Polling sync for quicksight on launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Datacut preview page
-
-## 2020-08-20
+- A background polling job when redirecting to QuickSight to setup and sync users.
 
 ### Changed
 

--- a/dataworkspace/dataworkspace/apps/applications/urls.py
+++ b/dataworkspace/dataworkspace/apps/applications/urls.py
@@ -5,10 +5,16 @@ from dataworkspace.apps.applications.views import (
     application_spawning_html_view,
     application_running_html_view,
     tools_html_view,
+    quicksight_start_polling_sync_and_redirect,
 )
 
 urlpatterns = [
     path('', login_required(tools_html_view), name='tools'),
     path('<str:public_host>/spawning', login_required(application_spawning_html_view)),
     path('<str:public_host>/running', login_required(application_running_html_view)),
+    path(
+        'quicksight/redirect',
+        login_required(quicksight_start_polling_sync_and_redirect),
+        name='quicksight_redirect',
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -743,76 +743,75 @@ def create_update_delete_quicksight_user_data_sources(
 def sync_quicksight_permissions(
     user_sso_ids_to_update=tuple(), poll_for_user_creation=False
 ):
-    try:
-        # Lightly enforce that only instance is running the task at a time. The job normally takes just a few minutes.
-        with cache.lock(
-            "sync-quicksight-permissions", blocking_timeout=360, timeout=3600
-        ):
-            logger.info(
-                f'sync_quicksight_user_datasources({user_sso_ids_to_update}, '
-                f'poll_for_user_creation={poll_for_user_creation}) started'
-            )
+    logger.info(
+        f'sync_quicksight_user_datasources({user_sso_ids_to_update}, '
+        f'poll_for_user_creation={poll_for_user_creation}) started'
+    )
 
-            # QuickSight manages users in a single specific regions
-            user_client = boto3.client(
-                'quicksight', region_name=settings.QUICKSIGHT_USER_REGION
-            )
-            # Data sources can be in other regions - so here we use the Data Workspace default from its env vars.
-            data_client = boto3.client('quicksight')
+    # QuickSight manages users in a single specific regions
+    user_client = boto3.client(
+        'quicksight', region_name=settings.QUICKSIGHT_USER_REGION
+    )
+    # Data sources can be in other regions - so here we use the Data Workspace default from its env vars.
+    data_client = boto3.client('quicksight')
 
-            account_id = boto3.client('sts').get_caller_identity().get('Account')
+    account_id = boto3.client('sts').get_caller_identity().get('Account')
 
-            quicksight_user_list: List[Dict[str, str]]
-            if len(user_sso_ids_to_update) > 0:
-                quicksight_user_list = []
+    quicksight_user_list: List[Dict[str, str]]
+    if len(user_sso_ids_to_update) > 0:
+        quicksight_user_list = []
 
-                for user_sso_id in user_sso_ids_to_update:
-                    # Poll for the user for 5 minutes
-                    attempts = (5 * 60) if poll_for_user_creation else 1
-                    for _ in range(attempts):
-                        attempts -= 1
+        for user_sso_id in user_sso_ids_to_update:
+            # Poll for the user for 5 minutes
+            attempts = (5 * 60) if poll_for_user_creation else 1
+            for _ in range(attempts):
+                attempts -= 1
 
-                        try:
-                            quicksight_user_list.append(
-                                user_client.describe_user(
-                                    AwsAccountId=account_id,
-                                    Namespace='default',
-                                    # \/ This is the format of the user name created by DIT SSO \/
-                                    UserName=f'quicksight_federation/{user_sso_id}',
-                                )['User']
+                try:
+                    quicksight_user_list.append(
+                        user_client.describe_user(
+                            AwsAccountId=account_id,
+                            Namespace='default',
+                            # \/ This is the format of the user name created by DIT SSO \/
+                            UserName=f'quicksight_federation/{user_sso_id}',
+                        )['User']
+                    )
+                    break
+
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                        if attempts > 0:
+                            gevent.sleep(1)
+                        elif poll_for_user_creation:
+                            logger.exception(
+                                "Did not find user with sso id `%s` after 5 minutes",
+                                user_sso_id,
                             )
-                            break
+                    else:
+                        raise e
 
-                        except botocore.exceptions.ClientError as e:
-                            if (
-                                e.response['Error']['Code']
-                                == 'ResourceNotFoundException'
-                            ):
-                                if attempts > 0:
-                                    gevent.sleep(1)
-                                elif poll_for_user_creation:
-                                    logger.exception(
-                                        "Did not find user with sso id `%s` after 5 minutes",
-                                        user_sso_id,
-                                    )
-                            else:
-                                raise e
+    else:
+        quicksight_user_list: List[Dict[str, str]] = user_client.list_users(
+            AwsAccountId=account_id, Namespace='default'
+        )['UserList']
 
-            else:
-                quicksight_user_list: List[Dict[str, str]] = user_client.list_users(
-                    AwsAccountId=account_id, Namespace='default'
-                )['UserList']
+    for quicksight_user in quicksight_user_list:
+        user_arn = quicksight_user['Arn']
+        user_email = quicksight_user['Email']
+        user_role = quicksight_user['Role']
+        user_username = quicksight_user['UserName']
 
-            for quicksight_user in quicksight_user_list:
-                user_arn = quicksight_user['Arn']
-                user_email = quicksight_user['Email']
-                user_role = quicksight_user['Role']
-                user_username = quicksight_user['UserName']
+        if user_role != 'AUTHOR' and user_role != 'ADMIN':
+            logger.info(f"Skipping {user_email} with role {user_role}.")
+            continue
 
-                if user_role != 'AUTHOR' and user_role != 'ADMIN':
-                    logger.info(f"Skipping {user_email} with role {user_role}.")
-                    continue
-
+        try:
+            # Lightly enforce that only instance can edit permissions for a user at a time.
+            with cache.lock(
+                f"sync-quicksight-permissions-{user_arn}",
+                blocking_timeout=60,
+                timeout=360,
+            ):
                 try:
                     if user_role == "ADMIN":
                         user_client.update_user(
@@ -872,10 +871,12 @@ def sync_quicksight_permissions(
                     data_client, account_id, quicksight_user, creds
                 )
 
-            logger.info(
-                f'sync_quicksight_user_datasources({user_sso_ids_to_update}, '
-                f'poll_for_user_creation={poll_for_user_creation}) finished'
+        except redis.exceptions.LockError:
+            logger.exception(
+                "Unable to sync permissions for %s", quicksight_user['Arn']
             )
 
-    except redis.exceptions.LockError:
-        pass
+    logger.info(
+        f'sync_quicksight_user_datasources({user_sso_ids_to_update}, '
+        f'poll_for_user_creation={poll_for_user_creation}) finished'
+    )

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -332,3 +332,77 @@ class TestSyncQuickSightPermissions:
         ]
         assert len(mock_data_client.create_data_source.call_args_list) == 1
         assert len(mock_data_client.update_data_source.call_args_list) == 0
+
+    @pytest.mark.django_db
+    @mock.patch('dataworkspace.apps.core.utils.new_private_database_credentials')
+    @mock.patch('dataworkspace.apps.applications.utils.boto3.client')
+    @mock.patch('dataworkspace.apps.applications.utils.cache')
+    def test_poll_until_user_created(self, mock_cache, mock_boto3_client, mock_creds):
+        # Arrange
+        user = UserFactory.create(username='fake@email.com')
+        SourceTableFactory(
+            dataset=MasterDataSetFactory.create(
+                user_access_type='REQUIRES_AUTHENTICATION'
+            )
+        )
+
+        mock_user_client = mock.Mock()
+        mock_user_client.describe_user.side_effect = [
+            botocore.exceptions.ClientError(
+                {
+                    "Error": {
+                        "Code": "ResourceNotFoundException",
+                        "Message": "User not found",
+                    }
+                },
+                'DescribeUser',
+            ),
+        ] * 10 + [
+            {
+                "User": {
+                    "Arn": "Arn",
+                    "Email": "fake@email.com",
+                    "Role": "AUTHOR",
+                    "UserName": "user/fake@email.com",
+                }
+            }
+        ]
+        mock_data_client = mock.Mock()
+        mock_sts_client = mock.Mock()
+        mock_boto3_client.side_effect = [
+            mock_user_client,
+            mock_data_client,
+            mock_sts_client,
+        ]
+
+        # Act
+        with mock.patch('dataworkspace.apps.applications.utils.gevent.sleep'):
+            sync_quicksight_permissions(
+                user_sso_ids_to_update=[str(user.profile.sso_id)],
+                poll_for_user_creation=True,
+            )
+
+        # Assert
+        assert mock_user_client.update_user.call_args_list == [
+            mock.call(
+                AwsAccountId=mock.ANY,
+                Namespace='default',
+                Role='AUTHOR',
+                CustomPermissionsName='author-custom-permissions',
+                UserName='user/fake@email.com',
+                Email='fake@email.com',
+            )
+        ]
+        assert (
+            mock_user_client.describe_user.call_args_list
+            == [
+                mock.call(
+                    AwsAccountId=mock.ANY,
+                    Namespace='default',
+                    UserName=f'quicksight_federation/{user.profile.sso_id}',
+                ),
+            ]
+            * 11
+        )
+        assert len(mock_data_client.create_data_source.call_args_list) == 1
+        assert len(mock_data_client.update_data_source.call_args_list) == 0

--- a/dataworkspace/dataworkspace/tests/common.py
+++ b/dataworkspace/dataworkspace/tests/common.py
@@ -95,7 +95,7 @@ def get_http_sso_data(user):
         'HTTP_SSO_PROFILE_EMAIL': user.email,
         'HTTP_SSO_PROFILE_CONTACT_EMAIL': user.email,
         'HTTP_SSO_PROFILE_RELATED_EMAILS': '',
-        'HTTP_SSO_PROFILE_USER_ID': uuid.uuid4(),
+        'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id,
         'HTTP_SSO_PROFILE_LAST_NAME': user.last_name,
         'HTTP_SSO_PROFILE_FIRST_NAME': user.first_name,
     }

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -158,7 +158,7 @@ def test_footer_links(request_client):
 @pytest.mark.parametrize(
     "has_quicksight_access, expected_href, expected_text",
     (
-        (True, "https://quicksight", "Open AWS QuickSight"),
+        (True, "/tools/quicksight/redirect", "Open AWS QuickSight"),
         (False, "/support-and-feedback/", "Request access to AWS QuickSight"),
     ),
 )


### PR DESCRIPTION
### Description of change
Users have to create their own accounts for QuickSight, which they do through a DIT SSO journey we can't easily hook into. This means that we aren't able to configure their QuickSight account the moment it's created. As a slight workaround to this, we change the 'Launch QuickSight' button on the tools page to go to an intermediate page on Data Workspace, where we can kick off a background job that polls for their account to be created in QuickSight, before redirecting them to the QuickSight SSO login flow. This background job will check once a second for 5 minutes for the user account to be created, and when it is, it will create their data source and apply our custom permissions. We hypothesis that this should catch the majority of users, as the only sign-up step when you get to QuickSight is entering your email address, which should be done by most within 5 minutes.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
