### PR TITLE
fix: preview design updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add weighting to dataset search
 - Allow for searching of datasets by source tag name
 
+### Changed
+
+- Datacut preview page design updates
+
 ## 2020-08-20
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -881,5 +881,7 @@ class CustomDatasetQueryPreviewView(DetailView):
                 'records': records,
                 'preview_limit': sample_size,
                 'record_count': len(records),
+                'fixed_table_height_limit': 10,
+                'truncate_limit': 100,
             },
         )

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -15,6 +15,9 @@
   overflow-x: auto;
   max-height: 560px;
 }
+.fixed-table-height {
+  max-height: 100% !important;
+}
 .scrollable-table table thead th {
   padding: 15px;
   background-color: #dee0e2;

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -103,6 +103,7 @@
     </div>
 
     {% block breadcrumbs %}{% endblock %}
+    {% block go_back %}{% endblock %}
 
     {% block main %}{% endblock %}
   </div>

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_preview.html
@@ -3,32 +3,21 @@
 
 {% block page_title %}Preview {{ query.name }} - {{ block.super }}{% endblock %}
 
-{% block breadcrumbs %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-         <a class="govuk-breadcrumbs__link" href=
-                 "{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}
-        </a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        Preview {{ query.name }}
-      </li>
-    </ol>
-  </div>
+{% block go_back %}
+  <a class="govuk-back-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
+    Back
+  </a>
 {% endblock %}
 
 {% block content %}
+
   <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Preview {{ query.name }}</h1>
-          <div class="govuk-body">
-              See data fields and example data below.
-          </div>
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Preview {{ query.name }}</h1>
+      <div class="govuk-body">
+          See data fields and example data below.
       </div>
+    </div>
   </div>
 
   {% if fields %}
@@ -57,7 +46,7 @@
       <p class="govuk-body">
         Showing {% if record_count < preview_limit %}all {% else %}<strong>{{ preview_limit }}</strong> random {% endif %}rows from data.
       </p>
-      <div class="scrollable-table">
+      <div class="scrollable-table {% if record_count <= fixed_table_height_limit %}fixed-table-height{% endif %}">
         <table class="govuk-table govuk-!-font-size-16">
           <thead>
             <tr class="govuk-table__row">
@@ -74,7 +63,7 @@
                 {% for field in fields %}
                   {% with record|get_key:field as value %}
                       <td class="govuk-table__cell">
-                        {{ value|not_set_if_none }}
+                        {{ value|not_set_if_none|truncatechars:truncate_limit }}
                       </td>
                   {% endwith %}
                 {% endfor %}
@@ -89,6 +78,7 @@
           </tbody>
         </table>
       </div>
+      <br/>
       <a class="govuk-button" href="{% url "datasets:dataset_query_download" dataset_uuid=dataset.id query_id=query.id %}">
         Download Data
       </a>


### PR DESCRIPTION
design changes:
- back button on preview page instead of breadcrumbs
- no vertical scrollbar for 10 or less preview records
- truncate preview results if more then 100 chars

### Description of change

![image](https://user-images.githubusercontent.com/5279350/91072581-a25cd400-e631-11ea-8b1f-9a175c7a6223.png)


### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
