### PR TITLE
feat: update home page text and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Datacut preview page design updates
+- Updated home page filter text for purpose and source
+- Only show 10 sources by default, with a button to show more (only if JavaScript available).
 
 ## 2020-08-20
 

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -12,18 +12,27 @@ class FilterWidget(forms.widgets.CheckboxSelectMultiple):
         self,
         group_label,
         hint_text=None,
+        limit_initial_options=0,
+        show_more_label="Show more",
         *args,
         **kwargs  # pylint: disable=keyword-arg-before-vararg
     ):
         super().__init__(*args, **kwargs)
         self._group_label = group_label
         self._hint_text = hint_text
+        self._limit_initial_options = limit_initial_options
+        self._show_more_label = show_more_label
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context['widget']['group_label'] = self._group_label
         context['widget']['hint_text'] = self._hint_text
+        context['widget']['limit_initial_options'] = self._limit_initial_options
+        context['widget']['show_more_label'] = self._show_more_label
         return context
+
+    class Media:
+        js = ('app-filter-show-more.js',)
 
 
 class RequestAccessForm(forms.Form):
@@ -56,11 +65,19 @@ class DatasetSearchForm(forms.Form):
             (DataSetType.VISUALISATION.value, 'View data visualisation'),
         ],
         required=False,
-        widget=FilterWidget("Purpose", hint_text="Select all that apply."),
+        widget=FilterWidget("Purpose", hint_text="What do you want to do with data?"),
     )
 
     source = forms.ModelMultipleChoiceField(
         queryset=SourceTag.objects.order_by('name').all(),
         required=False,
-        widget=FilterWidget("Source", hint_text="Select all that apply."),
+        widget=FilterWidget(
+            "Source",
+            hint_text="Source or publishing organisation",
+            limit_initial_options=10,
+            show_more_label="Show more sources",
+        ),
     )
+
+    class Media:
+        js = ('app-filter-show-more.js',)

--- a/dataworkspace/dataworkspace/static/app-filter-show-more.js
+++ b/dataworkspace/dataworkspace/static/app-filter-show-more.js
@@ -1,0 +1,35 @@
+function nodeListForEach (nodes, callback) {
+  if (window.NodeList.prototype.forEach) {
+    return nodes.forEach(callback)
+  }
+  for (let i = 0; i < nodes.length; i++) {
+    callback.call(window, nodes[i], i, nodes)
+  }
+}
+
+function FilterShowMore(module) {
+  this.module = module;
+  this.button = this.module.getElementsByClassName('js-filter-show-more')[0];
+}
+
+FilterShowMore.prototype.init = function () {
+  if (!this.module || !this.button) {
+    return
+  }
+
+  let that = this;
+
+  this.button.classList.remove('hidden');
+  this.button.addEventListener('click', function () {
+      this.classList.add('hidden');
+      let choices = that.module.getElementsByClassName('app-js-hidden');
+      for (let i = 0; i < choices.length; i++) {
+          $(choices[i]).show();
+      }
+  });
+};
+
+let modules = document.querySelectorAll('[data-module="filter-show-more"]')
+nodeListForEach(modules, function (module) {
+  new FilterShowMore(module).init()
+});

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -202,3 +202,11 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
 .app-\!-fill-width {
     width: 100%
 }
+
+.js-enabled .app-js-hidden {
+    display: none;
+}
+
+.hidden {
+    display: none;
+}

--- a/dataworkspace/dataworkspace/templates/datasets/filter.html
+++ b/dataworkspace/dataworkspace/templates/datasets/filter.html
@@ -9,10 +9,17 @@
         {{ widget.hint_text }}
       </span>
       {% endif %}
-      <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes" data-module="filter-show-more">
       {% for group, options, index in widget.optgroups %}
         {% for option in options %}
-          {% include option.template_name with widget=option %}
+          {% if widget.limit_initial_options == 0 or forloop.parentloop.counter <= widget.limit_initial_options %}
+            {% include option.template_name with widget=option hidden=False %}
+          {% elif forloop.parentloop.counter == widget.limit_initial_options|add:1 %}
+            <button class="govuk-button govuk-button--secondary js-filter-show-more hidden" type="button">{{ widget.show_more_label }}</button>
+            {% include option.template_name with widget=option hidden=True %}
+          {% else %}
+            {% include option.template_name with widget=option hidden=True %}
+          {% endif %}
         {% endfor %}
       {%endfor %}
       </div>

--- a/dataworkspace/dataworkspace/templates/datasets/filter_option.html
+++ b/dataworkspace/dataworkspace/templates/datasets/filter_option.html
@@ -1,4 +1,4 @@
-<div class="govuk-checkboxes__item">
+<div class="govuk-checkboxes__item {% if hidden %}app-js-hidden{% endif %}">
   <input class="govuk-checkboxes__input" name="{{ widget.name }}" type="checkbox" {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
 
   <label class="govuk-label govuk-checkboxes__label" for="{{ widget.attrs.id }}">

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -45,8 +45,11 @@
   </div>
 
     <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-hint">
+        Search in data name and description
+      </div>
       <div class="search-field govuk-!-margin-bottom-9">
-        <label class="govuk-label search-field__label" for="search">Search data</label>
+        <label class="govuk-label search-field__label" for="search">Enter your search term(s)</label>
         <div class="search-field-wrapper">
           <input type="search" name="q" id="search" title="Search" class="govuk-input search-field__item search-field__input js-class-toggle" value="{{ query }}" aria-controls="">
           <div class="search-field-submit-wrapper search-field__item">
@@ -136,4 +139,10 @@
 </div>
 </form>
 
+{% endblock %}
+
+{% block footer_scripts %}
+  {% if form.source.field.choices %}
+    {{ form.media }}
+  {% endif %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -140,7 +140,10 @@ def test_footer_links(request_client):
         ),
         (
             'Accessibility statement',
-            'https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/data-workspace-accessibility-statement/',
+            (
+                'https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/'
+                'data-workspace-accessibility-statement/'
+            ),
         ),
         (
             'Privacy Policy',

--- a/dataworkspace/dataworkspace/tests/datasets/test_forms.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_forms.py
@@ -1,0 +1,41 @@
+import pytest
+from bs4 import BeautifulSoup
+from django import forms
+from django.template import Template, Context
+
+from dataworkspace.apps.datasets.forms import FilterWidget
+
+
+class TestFilterWidget:
+    @pytest.mark.parametrize(
+        "num_choices, limit_options, expect_show_more_button, expect_hidden_choices",
+        ((5, 0, False, 0), (5, 2, True, 3), (5, 5, False, 0), (5, 10, False, 0),),
+    )
+    def test_limit_initial_choices(
+        self, num_choices, limit_options, expect_show_more_button, expect_hidden_choices
+    ):
+        class _Form(forms.Form):
+            field = forms.MultipleChoiceField(
+                choices=list((i, i) for i in range(num_choices)),
+                required=False,
+                widget=FilterWidget(
+                    "Field",
+                    limit_initial_options=limit_options,
+                    show_more_label="Show more choices",
+                ),
+            )
+
+        html = Template("{{ form }}").render(Context({"form": _Form()}))
+        soup = BeautifulSoup(html)
+
+        assert (
+            len(soup.find_all("div", class_="govuk-checkboxes__item")) == num_choices
+        ), "Widget should renderall of the choices"
+        assert (
+            bool(soup.find_all("button", text="Show more choices"))
+            is expect_show_more_button
+        ), "Widget should render a 'show more' button if there are more choices than we want to initially show."
+        assert (
+            len(soup.find_all("div", class_="govuk-checkboxes__item app-js-hidden"))
+            == expect_hidden_choices
+        ), "Widget should render excess options as hidden."


### PR DESCRIPTION
### Description of change
Add some clearer explanatory text around our filters and search box to
help users understand what they are for. Also update the source filter
choice field to only render 10 sources initially, with an option for the
user to reveal more if needed.

### Show the thing
<img width="855" alt="Screen Shot 2020-08-25 at 17 19 17" src="https://user-images.githubusercontent.com/2920760/91200468-1e6d1f80-e6f7-11ea-8872-2cec7f288c63.png">

![2020-08-25 17 18 12](https://user-images.githubusercontent.com/2920760/91200397-05fd0500-e6f7-11ea-9965-56c188ef8830.gif)

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?