### PR TITLE
Fix loading tools with None as access_point_id

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -637,7 +637,7 @@ def create_file_access_role(user_email_address, user_sso_id, access_point_id):
                 PolicyName=policy_name,
                 PolicyDocument=policy_document_template.replace(
                     '__S3_PREFIX__', s3_prefix
-                ).replace('__ACCESS_POINT_ID__', access_point_id),
+                ).replace('__ACCESS_POINT_ID__', access_point_id or ''),
             )
         except iam_client.exceptions.NoSuchEntityException:
             if i == max_attempts - 1:


### PR DESCRIPTION
### Description of change

The string replace fails when the access_point_id is None, which would be the case for literally everyone when this is deployed.

The alternative would be to make the field not be nullable. However, since everyone won't have an access_point_id, this means we would have to remove the unique constraint from the DB. Choosing to avoid that since users accidentally being assigned the same access point ID would be very bad.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
