### PR TITLE
fix: saving of user's Django admin page

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -47,6 +47,7 @@ class AppUserEditForm(forms.ModelForm):
         help_text='EFS Access Point ID',
         max_length=128,
         required=False,
+        empty_value=None,
         widget=AdminTextInputWidget(),
     )
     can_start_all_applications = forms.BooleanField(


### PR DESCRIPTION
### Description of change

The default is a blank string, which causes unique constraint errors (that we want to keep to mitigate risk of a user getting access to the another's home directory). Instead, the Postgres `NULL` is desired, which is derived from the Python `None`.

Note that trying to set on the model:

> unique=True, blank=True and null=True

as suggested at https://docs.djangoproject.com/en/dev/ref/models/fields/#null doesn't address the issue, since the field in Django admin is a manually added one, rather than automatically generated from the model, which is the case where the documentation applies.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
