### PR TITLE
Preview filter numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Launch Data Explorer on Fargate 1.4.0 to work with users with EFS
+- Append search segment counts to filters to help users understand how many results are available based on specific filters.
 
 ## 2020-09-02
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,10 @@ RUN apk add --no-cache \
         gcc \
         musl-dev \
         postgresql-dev \
-        python3-dev
+        python3-dev \
+        chromium \
+        libxml2-dev \
+        libxslt-dev
 
 COPY requirements-dev.txt requirements-dev.txt
 RUN pip3 install -r requirements-dev.txt

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -1,3 +1,6 @@
+from collections import defaultdict
+from functools import partial
+
 from django import forms
 
 from dataworkspace.apps.datasets.constants import DataSetType
@@ -15,7 +18,7 @@ class FilterWidget(forms.widgets.CheckboxSelectMultiple):
         limit_initial_options=0,
         show_more_label="Show more",
         *args,
-        **kwargs  # pylint: disable=keyword-arg-before-vararg
+        **kwargs,  # pylint: disable=keyword-arg-before-vararg
     ):
         super().__init__(*args, **kwargs)
         self._group_label = group_label
@@ -57,13 +60,14 @@ class DatasetSearchForm(forms.Form):
         widget=FilterWidget("Access status"),
     )
 
-    use = forms.MultipleChoiceField(
+    use = forms.TypedMultipleChoiceField(
         choices=[
             (DataSetType.DATACUT.value, 'Download'),
             (DataSetType.MASTER.value, 'Analyse in tools'),
             (DataSetType.REFERENCE.value, 'Use as reference data'),
             (DataSetType.VISUALISATION.value, 'View data visualisation'),
         ],
+        coerce=int,
         required=False,
         widget=FilterWidget("Purpose", hint_text="What do you want to do with data?"),
     )
@@ -81,3 +85,55 @@ class DatasetSearchForm(forms.Form):
 
     class Media:
         js = ('app-filter-show-more.js',)
+
+    def annotate_and_update_filters(self, *querysets, matcher, number_of_matches):
+        counts = {
+            "access": defaultdict(int),
+            "use": defaultdict(int),
+            "source": defaultdict(int),
+        }
+
+        selected_access = bool(self.cleaned_data['access'])
+        selected_uses = set(self.cleaned_data['use'])
+        selected_source_ids = set(source.id for source in self.cleaned_data['source'])
+
+        # Cache these locally for performance. The source model choice field can end up hitting the DB each time.
+        use_choices = list(self.fields['use'].choices)
+        source_choices = list(self.fields['source'].choices)
+
+        for datasets in querysets:
+            for dataset in datasets.all():
+                dataset_matcher = partial(
+                    matcher,
+                    data=dataset,
+                    access=selected_access,
+                    use=selected_uses,
+                    source_ids=selected_source_ids,
+                )
+
+                if dataset_matcher(access=True):
+                    counts['access']['yes'] += 1
+
+                for use_id, _ in use_choices:
+                    if dataset_matcher(use={use_id}):
+                        counts['use'][use_id] += 1
+
+                for source_id, _ in source_choices:
+                    if dataset_matcher(source_ids={source_id}):
+                        counts['source'][source_id] += 1
+
+        self.fields['access'].choices = [
+            (access_id, access_text + f" ({counts['access'][access_id]})")
+            for access_id, access_text in self.fields['access'].choices
+        ]
+
+        self.fields['use'].choices = [
+            (use_id, use_text + f" ({counts['use'][use_id]})")
+            for use_id, use_text in use_choices
+        ]
+
+        self.fields['source'].choices = [
+            (source_id, source_text + f" ({counts['source'][source_id]})")
+            for source_id, source_text in source_choices
+            if source_id in selected_source_ids or counts['source'][source_id] != 0
+        ]

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -118,10 +118,10 @@ def filter_datasets(
                 datacut_type
             )
 
-            if user.has_perm(master_perm) and (not use or str(master_type) in use):
+            if user.has_perm(master_perm) and (not use or master_type in use):
                 dataset_filter |= Q(published=False, type=master_type)
 
-            if user.has_perm(datacut_perm) and (not use or str(datacut_type) in use):
+            if user.has_perm(datacut_perm) and (not use or datacut_type in use):
                 dataset_filter |= Q(published=False, type=datacut_type)
 
     datasets = datasets.filter(dataset_filter).annotate(

--- a/dataworkspace/dataworkspace/static/app-filter-show-more.js
+++ b/dataworkspace/dataworkspace/static/app-filter-show-more.js
@@ -7,6 +7,8 @@ function nodeListForEach (nodes, callback) {
   }
 }
 
+let showMoreClicked = {};
+
 function FilterShowMore(module) {
   this.module = module;
   this.button = this.module.getElementsByClassName('js-filter-show-more')[0];
@@ -17,19 +19,37 @@ FilterShowMore.prototype.init = function () {
     return
   }
 
-  let that = this;
+  if (this.hasBeenRevealed()) {
+    this.revealChoices();
+  } else {
+    let that = this;
 
-  this.button.classList.remove('hidden');
-  this.button.addEventListener('click', function () {
-      this.classList.add('hidden');
-      let choices = that.module.getElementsByClassName('app-js-hidden');
-      for (let i = 0; i < choices.length; i++) {
-          $(choices[i]).show();
-      }
-  });
+    this.button.classList.remove('hidden');
+    this.button.addEventListener('click', function () {
+      that.revealChoices();
+    });
+  }
 };
 
-let modules = document.querySelectorAll('[data-module="filter-show-more"]')
-nodeListForEach(modules, function (module) {
-  new FilterShowMore(module).init()
-});
+FilterShowMore.prototype.hasBeenRevealed = function() {
+  return showMoreClicked[this.module.getAttribute('data-show-more-id')] !== undefined;
+}
+
+FilterShowMore.prototype.revealChoices = function () {
+  this.button.classList.add('hidden');
+
+  let choices = this.module.getElementsByClassName('app-js-hidden');
+  for (let i = 0; i < choices.length; i++) {
+      $(choices[i]).show();
+  }
+  showMoreClicked[this.module.getAttribute('data-show-more-id')] = true;
+}
+
+function installFilterShowMore() {
+  let modules = document.querySelectorAll('[data-module="filter-show-more"]');
+  nodeListForEach(modules, function (module) {
+    new FilterShowMore(module).init()
+  });
+}
+
+installFilterShowMore();

--- a/dataworkspace/dataworkspace/static/search.js
+++ b/dataworkspace/dataworkspace/static/search.js
@@ -151,6 +151,11 @@
     }
 
     this.$wrapper.css('opacity', '1')
+
+    if (window.installFilterShowMore !== undefined) {
+        // Hook into app-filter-show-more.js to un-hide the "show more" button on search filters.
+        window.installFilterShowMore();
+    }
   }
 
   LiveSearch.prototype.replaceBlock = function replaceBlock(selector, html) {

--- a/dataworkspace/dataworkspace/templates/datasets/filter.html
+++ b/dataworkspace/dataworkspace/templates/datasets/filter.html
@@ -9,7 +9,7 @@
         {{ widget.hint_text }}
       </span>
       {% endif %}
-      <div class="govuk-checkboxes" data-module="filter-show-more">
+      <div class="govuk-checkboxes" data-module="filter-show-more" data-show-more-id="{{ id }}">
       {% for group, options, index in widget.optgroups %}
         {% for option in options %}
           {% if widget.limit_initial_options == 0 or forloop.parentloop.counter <= widget.limit_initial_options %}

--- a/dataworkspace/dataworkspace/templates/datasets/filter.html
+++ b/dataworkspace/dataworkspace/templates/datasets/filter.html
@@ -5,7 +5,7 @@
         <h2 class="govuk-fieldset__heading">{{ widget.group_label }}</h2>
       </legend>
       {% if widget.hint_text %}
-      <span id="waste-hint" class="govuk-hint">
+      <span id="{{ id }}-hint" class="govuk-hint">
         {{ widget.hint_text }}
       </span>
       {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -60,7 +60,7 @@
     </div>
 </div>
 
-<div class="govuk-grid-row">
+<div id="live-search-wrapper" class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
     <h2 class="govuk-heading-l">Filters</h2>
     {{ form.access }}
@@ -69,7 +69,7 @@
       {{ form.source }}
     {% endif %}
   </div>
-  <div id="live-search-wrapper" class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body"><span id="search-results-count">{{ datasets.paginator.count }}</span> results</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {% for dataset in datasets %}

--- a/dataworkspace/dataworkspace/tests/common.py
+++ b/dataworkspace/dataworkspace/tests/common.py
@@ -98,3 +98,8 @@ def get_http_sso_data(user):
         'HTTP_SSO_PROFILE_LAST_NAME': user.last_name,
         'HTTP_SSO_PROFILE_FIRST_NAME': user.first_name,
     }
+
+
+class MatchUnorderedMembers(list):
+    def __eq__(self, other):
+        return len(self) == len(other) and all(o in self for o in other)

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile
       target: test
     image: data-workspace-test
+    stdin_open: true
+    tty: true
     env_file:
       - ./.envs/test.env
     ports:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,3 +18,6 @@ pytest-django==3.9.0
 pytest-timeout==1.4.2
 django-debug-toolbar==2.2
 requests-mock==1.8.0
+pyppeteer
+ipdb
+lxml

--- a/test/pages.py
+++ b/test/pages.py
@@ -1,0 +1,49 @@
+from pyppeteer import launch
+from pyppeteer.browser import Browser
+
+
+async def get_browser() -> Browser:
+    browser = await launch(
+        headless=True,
+        executablePath='/usr/bin/chromium-browser',
+        args=['--no-sandbox', '--disable-gpu'],
+    )
+    return browser
+
+
+class _BasePage:
+    _url_path = ''
+
+    def __init__(self, browser: Browser, base_url='http://dataworkspace.test:8000'):
+        self._browser = browser
+        self._page = None
+        self._base_url = base_url
+
+    @property
+    def url(self) -> str:
+        return self._base_url + self._url_path
+
+    async def open(self) -> "_BasePage":
+        self._page = await self._browser.newPage()
+        await self._page.goto(self.url)
+        return self
+
+    async def toggle_filter(self, label) -> "_BasePage":
+        if not self._page:
+            await self.open()
+
+        element = (
+            await self._page.xpath(
+                f"//input[@id = //label[contains(text(), '{label}')]/@for]"
+            )
+        )[0]
+        await element.click()
+        await self._page.waitForNavigation()
+        return self
+
+    async def get_html(self) -> str:
+        return await self._page.content()
+
+
+class HomePage(_BasePage):
+    _url_path = '/'


### PR DESCRIPTION
### Description of change
Appends search result numbers to the filters on the homepage, showing users how many results will be available if that filter option is toggled on/off.

Adds a functional test using `pyppeteer` to launch chromium and interact with the site. This is the first browser-based test we have, so would be interesting to get some feedback on implementation/choice as this could be expanded/reused for any smoke tests we want to run on the live service. The test itself is quite specific in order to test variations of filters against datasets - open to ways to increase the flexibility and range of the test.

Includes a minor HTML semantic fix to make sure that filter hints have unique IDs rather than a strangely-hardcoded one, and another fix to properly filter unpublished datasets for admin users.

Ticket: https://trello.com/c/ZEyoaZXo/792

### Show the thing
![2020-09-02 00 02 01](https://user-images.githubusercontent.com/2920760/91914364-c6fb2080-ecaf-11ea-9de2-13419d308093.gif)


### Checklist
* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
* [ ] Has the README been updated (if needed)?
