### PR TITLE
fix: add query param to support embedding in ie11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-02
+
+### Changed
+
+- Fixed QuickSight embedded dashboards for IE11.
+
 ## 2020-09-01
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -4,7 +4,7 @@ import datetime
 import itertools
 import random
 import re
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlencode
 
 from csp.decorators import csp_exempt, csp_update
 from django.conf import settings
@@ -228,8 +228,12 @@ def _get_embedded_quicksight_dashboard(request, dashboard_id):
         dashboard_id, request.user
     )
 
+    extra_params = urlencode(
+        [("punyCodeEmbedOrigin", f"{request.scheme}://{request.get_host()}/-")]
+    )
+
     context = {
-        'visualisation_src': dashboard_url,
+        'visualisation_src': f'{dashboard_url}&{extra_params}',
         'nice_name': dashboard_name,
         'wrap': 'IFRAME_WITH_VISUALISATIONS_HEADER',
     }


### PR DESCRIPTION
### Description of change
Tested via manual deploy to analysisworkspace using an IE11 VM.

Dashboard embedding is broken in IE11. The latest update from support
suggesed using their AWS QuickSight JS embedding SDK, which we tried,
but ironically that doesn't support IE11 right now (syntax error:
awslabs/amazon-quicksight-embedding-sdk#50).
The "non-recommended" alternative was to append this query parameter
manually, which we'll now do in order to bring IE11 support back
immediately.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
