### PR TITLE
feature: parse datacut sql queries and display queried tables on admin screen

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.http import HttpResponse
 from django.urls import reverse
+import psqlparse
 
 from dataworkspace.apps.applications.models import VisualisationTemplate
 from dataworkspace.apps.applications.utils import sync_quicksight_permissions
@@ -153,6 +154,17 @@ class CustomDatasetQueryInline(admin.TabularInline, SourceReferenceInlineMixin):
     manage_unpublished_permission_codename = (
         'datasets.manage_unpublished_datacut_datasets'
     )
+    readonly_fields = ('query_tables',)
+
+    def query_tables(self, obj):
+        try:
+            tables = obj.parsed_query_tables
+        except psqlparse.exceptions.PSqlParseError:
+            return "SQL syntax error"
+        else:
+            if not tables:
+                return ''
+            return '\n'.join(tables)
 
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = super().get_readonly_fields(request, obj)

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -11,6 +11,7 @@ from psycopg2 import sql
 import boto3
 from botocore.exceptions import ClientError
 from ckeditor.fields import RichTextField
+import psqlparse
 
 from django import forms
 from django.apps import apps
@@ -613,6 +614,13 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
     @property
     def type(self):
         return DataLinkType.CUSTOM_QUERY.value
+
+    @property
+    def parsed_query_tables(self):
+        if not self.query:
+            return None
+        statements = psqlparse.parse(self.query)
+        return list(statements[0].tables())
 
 
 class ReferenceDataset(DeletableTimestampedUserModel):

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -1,3 +1,4 @@
+import psqlparse
 import pytest
 
 from dataworkspace.apps.datasets.models import SourceLink
@@ -137,3 +138,29 @@ def test_source_link_filename(db):
         link_type=SourceLink.TYPE_EXTERNAL,
     )
     assert source3.get_filename() == 'a-test-source.csv'
+
+
+def test_dataset_parsed_query_tables(db):
+    ds = factories.DataSetFactory.create(published=True)
+
+    blank_query = factories.CustomDatasetQueryFactory(dataset=ds)
+    assert not blank_query.parsed_query_tables
+
+    standard_query = factories.CustomDatasetQueryFactory(
+        dataset=ds, query='select * from foo'
+    )
+    assert standard_query.parsed_query_tables == ['foo']
+
+    join_query = factories.CustomDatasetQueryFactory(
+        dataset=ds, query='select * from foo join bar on foo.id = bar.id'
+    )
+    assert sorted(join_query.parsed_query_tables) == ['bar', 'foo']
+
+    with_query = factories.CustomDatasetQueryFactory(
+        dataset=ds, query='with test as (select * from foo) select * from test'
+    )
+    assert sorted(with_query.parsed_query_tables) == ['foo', 'test']
+
+    bad_query = factories.CustomDatasetQueryFactory(dataset=ds, query='select * from')
+    with pytest.raises(psqlparse.exceptions.PSqlParseError):
+        bad_query.parsed_query_tables  # pylint: disable=pointless-statement

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ hawk-server-asyncio==0.0.13
 Markdown==3.2.2
 MarkupSafe==1.1.1
 notifications-python-client==5.7.0
+psqlparse==1.0rc7
 psutil==5.7.2
 psycogreen==1.0.2
 redis==3.5.3


### PR DESCRIPTION
### Description of change

This PR uses the https://github.com/alculquicondor/psqlparse library to parse the sql query on the CustomDatasetQuery model. 

The parser uses the Postgres source code to parse the query so it doesn't need to connect to the database or run any additional queries. 

The parser generates a list of database tables derived from a query's FROM clause and these are exposed on the CustomDatasetQuery model as a property called `parsed_query_tables`. 

For now this is only displayed on the admin screen as a readonly field as shown below but will be shown on the front end eventually:

<img width="1250" alt="Screenshot 2020-09-02 at 16 50 40" src="https://user-images.githubusercontent.com/915598/92007036-56024a00-ed3d-11ea-86eb-51339b310ef7.png">

It was decided to do this parsing dynamically rather than on save to avoid having to migrate all of the existing queries on production. We should probably re-evaluate this once we are happy with the quality and accuracy of the parsing and once we know exactly what we will be doing with the table names.


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
