### PR TITLE
fix: add retries to address eventual consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Fixed QuickSight embedded dashboards for IE11.
+- Add retries to QuickSight dashboard embed URL creation step.
 
 ## 2020-09-01
 


### PR DESCRIPTION
### Description of change
QuickSight user creation is eventually consistent, so after the
CreateUser call returns 200, when we call CreateGroupMembership, the
user might not have synced yet so it may return a
ResourceNotFoundException. Add some retries with increasing delays to
help offset this.

Addresses a recent sentry error I encountered in Staging.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
