### PR TITLE
fix: unstyled Tools loading page

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -71,6 +71,8 @@ async def async_main():
         'host',
         'x-csrftoken',
         'x-data-workspace-no-modify-application-instance',
+        'x-scheme',
+        'x-forwarded-proto',
     )
 
     root_domain_no_port, _, root_port_str = root_domain.partition(':')


### PR DESCRIPTION
### Description of change

The styles on the Tools loading page depends on the <base> tag having the correct URI, including https://. However, the admin application thinks it's on HTTP and generates it with http://.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
