### PR TITLE
fix: Data Explorer when a user has an EFS access point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-03
+
+### Changed
+
+- Launch Data Explorer on Fargate 1.4.0 to work with users with EFS
+
 ## 2020-09-02
 
 ### Changed

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -856,6 +856,10 @@
   "value": "120"
 },
 {
+  "name": "APPLICATION_TEMPLATES__12__SPAWNER_OPTIONS__PLATFORM_VERSION",
+  "value": "1.4.0"
+},
+{
   "name": "APPLICATION_TEMPLATES__12__SPAWNER_OPTIONS__CLUSTER_NAME",
   "value": "${fargate_spawner__task_custer_name}"
 },


### PR DESCRIPTION
### Description of change

It tries to bind EFS when the version of Fargate doesn't support it, and it raises PlatformTaskDefinitionIncompatibilityException.

Once this is done, we could probably make Fargate 1.4.0 the default, but for now, baby steps. There are some subtle differences with volumes, users, /etc/hosts that means 1.3.0 -> 1.4.0 may break things.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
