### PR TITLE
Fix data vis count

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -86,7 +86,7 @@ class DatasetSearchForm(forms.Form):
     class Media:
         js = ('app-filter-show-more-v2.js',)
 
-    def annotate_and_update_filters(self, *querysets, matcher, number_of_matches):
+    def annotate_and_update_filters(self, datasets, matcher, number_of_matches):
         counts = {
             "access": defaultdict(int),
             "use": defaultdict(int),
@@ -101,26 +101,25 @@ class DatasetSearchForm(forms.Form):
         use_choices = list(self.fields['use'].choices)
         source_choices = list(self.fields['source'].choices)
 
-        for datasets in querysets:
-            for dataset in datasets.all():
-                dataset_matcher = partial(
-                    matcher,
-                    data=dataset,
-                    access=selected_access,
-                    use=selected_uses,
-                    source_ids=selected_source_ids,
-                )
+        for dataset in datasets:
+            dataset_matcher = partial(
+                matcher,
+                data=dataset,
+                access=selected_access,
+                use=selected_uses,
+                source_ids=selected_source_ids,
+            )
 
-                if dataset_matcher(access=True):
-                    counts['access']['yes'] += 1
+            if dataset_matcher(access=True):
+                counts['access']['yes'] += 1
 
-                for use_id, _ in use_choices:
-                    if dataset_matcher(use={use_id}):
-                        counts['use'][use_id] += 1
+            for use_id, _ in use_choices:
+                if dataset_matcher(use={use_id}):
+                    counts['use'][use_id] += 1
 
-                for source_id, _ in source_choices:
-                    if dataset_matcher(source_ids={source_id}):
-                        counts['source'][source_id] += 1
+            for source_id, _ in source_choices:
+                if dataset_matcher(source_ids={source_id}):
+                    counts['source'][source_id] += 1
 
         self.fields['access'].choices = [
             (access_id, access_text + f" ({counts['access'][access_id]})")

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -16,8 +16,8 @@ from dataworkspace.apps.datasets.models import (
     VisualisationCatalogueItem,
 )
 from dataworkspace.apps.datasets.views import (
-    preprocess_datasets,
-    preprocess_visualisations,
+    get_datasets_data_for_user_matching_query,
+    get_visualisations_data_for_user_matching_query,
 )
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.tests import factories
@@ -458,9 +458,7 @@ def test_find_datasets_filters_by_source(client):
     assert len(list(response.context["form"].fields['source'].choices)) == 3
 
 
-def test_preprocess_datasets_and_visualisations_doesnt_return_duplicate_results(
-    staff_client,
-):
+def test_datasets_and_visualisations_doesnt_return_duplicate_results(staff_client,):
     normal_user = get_user_model().objects.create(
         username='bob.user@test.com', is_staff=False, is_superuser=False
     )
@@ -518,17 +516,21 @@ def test_preprocess_datasets_and_visualisations_doesnt_return_duplicate_results(
         )
 
     for u in [normal_user, staff_user]:
-        datasets = preprocess_datasets(DataSet.objects.live(), query='', use={}, user=u)
-        assert len(datasets) == len(set(dataset.id for dataset in datasets))
+        datasets = get_datasets_data_for_user_matching_query(
+            DataSet.objects.live(), query='', use={}, user=u
+        )
+        assert len(datasets) == len(set(dataset['id'] for dataset in datasets))
 
-        datasets = preprocess_datasets(ReferenceDataset.objects.live(), '', {}, user=u)
-        assert len(datasets) == len(set(dataset.id for dataset in datasets))
+        references = get_datasets_data_for_user_matching_query(
+            ReferenceDataset.objects.live(), '', {}, user=u
+        )
+        assert len(references) == len(set(reference['id'] for reference in references))
 
-        visualisations = preprocess_visualisations(
+        visualisations = get_visualisations_data_for_user_matching_query(
             VisualisationCatalogueItem.objects, query='', user=u
         )
         assert len(visualisations) == len(
-            set(visualisation.id for visualisation in visualisations)
+            set(visualisation['id'] for visualisation in visualisations)
         )
 
 


### PR DESCRIPTION
### Description of change
Two regressions slipped into the search filters feature.

1) Datasets would be counted twice if they required explicit access and
   multiple users, including the current user, were granted access, due
   to the query grouping on all values including `has_access`, which
   with multiple permissions would return one row saying the user has
   access and another saying it doesn't. These two are now aggregated
   with `bool_or` to return one true row if any of the user permissions
   confirm access.
2) Visualisations would be counted multiple times in the search filter
   counts, once for every user with explicit permission grants, due to a
   join that wasn't aggregated properly.

Adds a test that should prevent duplicate regressions.


### Before
<img width="1119" alt="Screen Shot 2020-09-05 at 09 42 05" src="https://user-images.githubusercontent.com/2920760/92301484-2715ef00-ef5c-11ea-8815-f23fef5fb890.png">


### After
<img width="1045" alt="Screen Shot 2020-09-05 at 09 42 24" src="https://user-images.githubusercontent.com/2920760/92301481-24b39500-ef5c-11ea-8fc3-63512d1e641f.png">


### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
