### PR TITLE
feat: add last updated time to data cut and master dataset pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
 ## 2020-09-08
 
 ### Added
 
 - Add CustomDatasetQueryTable model to store the table names extracted from the CustomDatasetQuery query FROM clause.
+
+## 2020-09-04
+
+### Changed
+
+- Add "data last updated" date to data cut download and master dataset table listings
 
 ## 2020-09-03
 

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -43,6 +43,7 @@ from dataworkspace.apps.datasets.model_utils import (
     get_linked_field_display_name,
     get_linked_field_identifier_name,
 )
+from dataworkspace.datasets_db import get_tables_last_updated_date
 
 
 class DataGroupingManager(DeletableQuerySet):
@@ -470,10 +471,6 @@ class SourceTable(BaseSource):
         return DataLinkType.SOURCE_TABLE.value
 
     def get_data_last_updated_date(self):
-        from dataworkspace.datasets_db import (
-            get_tables_last_updated_date,
-        )  # pylint: disable=import-outside-toplevel
-
         return get_tables_last_updated_date(
             self.database.memorable_name, ['.'.join([self.schema, self.table])]
         )
@@ -652,10 +649,6 @@ class CustomDatasetQueryTable(models.Model):
     )
 
     def get_data_last_updated_date(self):
-        from dataworkspace.datasets_db import (
-            get_tables_last_updated_date,
-        )  # pylint: disable=import-outside-toplevel
-
         # Ensure all tables have a schema as `public` is not always specified in queries
         tables = [
             f'{"public." if len(table_name.split(".")) == 1 else ""}{table_name}'

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -1,4 +1,5 @@
 import logging
+from typing import List
 
 import psycopg2
 from django.conf import settings
@@ -33,3 +34,32 @@ def query_columns(connection, source):
     with connection.cursor() as cursor:
         cursor.execute(sql)
         return [c[0] for c in cursor.description]
+
+
+def get_tables_last_updated_date(database_name: str, tables: List[str]):
+    """
+    Return the earliest of the last updated dates for a list of tables.
+    """
+    with psycopg2.connect(
+        database_dsn(settings.DATABASES_DATA[database_name])
+    ) as connection, connection.cursor() as cursor:
+        # Check the metadata table exists before we query it
+        cursor.execute("SELECT to_regclass('dataflow.metadata')")
+        if cursor.fetchone()[0] != 'dataflow.metadata':
+            return None
+
+        cursor.execute(
+            '''
+            SELECT MIN(run_date)
+            FROM (
+                SELECT
+                    CONCAT(metadata.table_schema, '.', metadata.table_name),
+                    MAX(dataflow_swapped_tables_utc) run_date
+                FROM dataflow.metadata
+                WHERE CONCAT(metadata.table_schema, '.', metadata.table_name) = ANY(%s)
+                GROUP BY 1
+            ) a
+            ''',
+            [tables],
+        )
+        return cursor.fetchone()[0]

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -33,11 +33,6 @@ def get_tables_last_updated_date(database_name: str, tables: Tuple[Tuple[str, st
     Return the earliest of the last updated dates for a list of tables.
     """
     with connections[database_name].cursor() as cursor:
-        # Check the metadata table exists before we query it
-        cursor.execute("SELECT to_regclass('dataflow.metadata')")
-        if cursor.fetchone()[0] != 'dataflow.metadata':
-            return None
-
         cursor.execute(
             '''
             SELECT MIN(modified_date)

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -54,7 +54,7 @@ def get_tables_last_updated_date(database_name: str, tables: List[str]):
             FROM (
                 SELECT
                     CONCAT(metadata.table_schema, '.', metadata.table_name),
-                    MAX(dataflow_swapped_tables_utc) run_date
+                    MAX(source_data_modified_utc) run_date
                 FROM dataflow.metadata
                 WHERE CONCAT(metadata.table_schema, '.', metadata.table_name) = ANY(%s)
                 GROUP BY 1

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -97,6 +97,7 @@
                     <th class="govuk-table__header">Link to the data</th>
                     <th class="govuk-table__header">Format</th>
                     <th class="govuk-table__header">Frequency</th>
+                    <th class="govuk-table__header">Data last updated</th>
                     {% if has_access %}
                     <th class="govuk-table__header">Details</th>
                     {% endif %}
@@ -124,6 +125,9 @@
                           {% else %}
                             {{ data_link.frequency }}
                           {% endif %}
+                        </td>
+                        <td class="govuk-table__cell">
+                          {{ data_link.get_data_last_updated_date|default_if_none:"N/A" }}
                         </td>
                         {% if has_access %}
                         <td class="govuk-table__cell">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -72,6 +72,7 @@
           <th class="govuk-table__header">Name</th>
           <th class="govuk-table__header">Identifier</th>
           <th class="govuk-table__header">Update frequency</th>
+          <th class="govuk-table__header">Data last updated</th>
           {% if user.is_superuser and data_links_with_link_toggle %}
             <th class="govuk-table__header">Tools*</th>
           {% endif %}
@@ -87,6 +88,7 @@
             <td class="govuk-table__cell">{{ data_link.name }}</td>
             <td class="govuk-table__cell">"{{ data_link.schema }}"."{{ data_link.table }}"</td>
             <td class="govuk-table__cell">{{ data_link.get_frequency_display }}</td>
+            <td class="govuk-table__cell">{{ data_link.get_data_last_updated_date|default_if_none:"N/A" }}</td>
             {% if user.is_superuser %}
               <td class="govuk-table__cell">
                 {% if data_link.get_google_data_studio_link and data_link.accessible_by_google_data_studio %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
@@ -15,7 +15,7 @@ from dataworkspace.tests import factories
 
 
 @pytest.fixture
-def dataset_db(db):
+def dataset_db(metadata_db):
     database = factories.DatabaseFactory(memorable_name='my_database')
     with psycopg2.connect(database_dsn(settings.DATABASES_DATA['my_database'])) as conn:
         conn.cursor().execute(

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -188,6 +188,7 @@ def metadata_db(db):
             INSERT INTO dataflow.metadata VALUES(1, 'public', 'table1', '2020-09-02 00:01:00.0');
             INSERT INTO dataflow.metadata VALUES(1, 'public', 'table2', '2020-09-01 00:01:00.0');
             INSERT INTO dataflow.metadata VALUES(1, 'public', 'table1', '2020-01-01 00:01:00.0');
+            INSERT INTO dataflow.metadata VALUES(1, 'public', 'table4', NULL);
             '''
         )
         conn.commit()
@@ -243,6 +244,12 @@ def test_custom_query_data_last_updated(metadata_db):
     query = factories.CustomDatasetQueryFactory(
         dataset=dataset, database=metadata_db, query='select * from table3',
     )
+
+    # Ensure None is returned if the last updated date is null
+    query = factories.CustomDatasetQueryFactory(
+        dataset=dataset, database=metadata_db, query='select * from table4',
+    )
+
     assert query.get_data_last_updated_date() is None
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -183,7 +183,7 @@ def metadata_db(db):
             '''
             CREATE SCHEMA IF NOT EXISTS dataflow;
             CREATE TABLE IF NOT EXISTS dataflow.metadata (
-                id int, table_schema text, table_name text, dataflow_swapped_tables_utc timestamp
+                id int, table_schema text, table_name text, source_data_modified_utc timestamp
             );
             INSERT INTO dataflow.metadata VALUES(1, 'public', 'table1', '2020-09-02 00:01:00.0');
             INSERT INTO dataflow.metadata VALUES(1, 'public', 'table2', '2020-09-01 00:01:00.0');

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -27,7 +27,7 @@ def test_dataset_type_to_manage_unpublished_permission_codename():
 
 
 @pytest.mark.django_db
-def test_get_code_snippets():
+def test_get_code_snippets(metadata_db):
     ds = DataSetFactory.create(type=DataSetType.MASTER.value)
 
     assert get_code_snippets(ds) == {}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -37,7 +37,9 @@ from dataworkspace.tests.factories import (
         (['Criteria 1', 'Criteria 2'], 'datasets:eligibility_criteria'),
     ],
 )
-def test_dataset_has_request_access_link(client, eligibility_criteria, view_name):
+def test_dataset_has_request_access_link(
+    client, eligibility_criteria, view_name, metadata_db
+):
     ds = factories.DataSetFactory.create(
         eligibility_criteria=eligibility_criteria, published=True
     )
@@ -906,12 +908,15 @@ def test_dataset_shows_external_link_warning(source_urls, show_warning):
 
 
 @pytest.mark.django_db
-def test_dataset_shows_code_snippets_to_tool_user():
+def test_dataset_shows_code_snippets_to_tool_user(metadata_db):
     ds = factories.DataSetFactory.create(type=DataSetType.MASTER.value, published=True)
     user = get_user_model().objects.create(is_superuser=False)
     factories.DataSetUserPermissionFactory.create(user=user, dataset=ds)
     factories.SourceTableFactory.create(
-        dataset=ds, schema="public", table="MY_LOVELY_TABLE"
+        dataset=ds,
+        schema="public",
+        table="MY_LOVELY_TABLE",
+        database=factories.DatabaseFactory(memorable_name='my_database'),
     )
 
     client = Client(**get_http_sso_data(user))

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -122,6 +122,15 @@ class CustomDatasetQueryFactory(factory.django.DjangoModelFactory):
         model = 'datasets.CustomDatasetQuery'
 
 
+class CustomDatasetQueryTableFactory(factory.django.DjangoModelFactory):
+    query = factory.SubFactory(CustomDatasetQueryFactory)
+    table = factory.fuzzy.FuzzyText()
+    schema = factory.fuzzy.FuzzyText()
+
+    class Meta:
+        model = 'datasets.CustomDatasetQueryTable'
+
+
 class DatasetReferenceCodeFactory(factory.django.DjangoModelFactory):
     id = factory.Sequence(lambda n: n)
     code = factory.fuzzy.FuzzyText(length=3)


### PR DESCRIPTION
Closes: https://trello.com/c/U2f069TH/779-spike-show-last-updated-date-and-time-against-data-cuts-and-master-datasets

- Query the new data flow metadata table for master dataset and query last update date
- Query s3 for data cut source link last updated date
 
#### Data cut page before
![before](https://user-images.githubusercontent.com/594496/92385128-39815b80-f109-11ea-99f2-06bd4b8d7035.png)


#### Data cut page after
![after](https://user-images.githubusercontent.com/594496/92385133-3d14e280-f109-11ea-8c6c-4276c46b5c1a.png)


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
