### PR TITLE
fix: strip ';' from end of CustomDatasetQuery when creating temp view

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/migrations/0053_set_custom_dataset_query_tables.py
+++ b/dataworkspace/dataworkspace/apps/datasets/migrations/0053_set_custom_dataset_query_tables.py
@@ -17,7 +17,7 @@ def set_query_tables(apps, schema_editor):
             try:
                 with transaction.atomic():
                     cursor.execute(
-                        f"create temporary view get_tables as (select 1 from ({query.query}) sq)"
+                        f"create temporary view get_tables as (select 1 from ({query.query.strip().rstrip(';')}) sq)"
                     )
             except DatabaseError:
                 continue

--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -448,7 +448,7 @@ class CustomDatasetQueryInlineForm(forms.ModelForm):
             try:
                 with transaction.atomic():
                     cursor.execute(
-                        f"create temporary view get_tables as (select 1 from ({instance.query}) sq)"
+                        f"create temporary view get_tables as (select 1 from ({instance.query.strip().rstrip(';')}) sq)"
                     )
             except DatabaseError:
                 tables = []

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2494,6 +2494,7 @@ class TestDatasetAdminPytest:
         'query, expected_tables',
         (
             ('SELECT * FROM auth_user', ['public.auth_user']),
+            ('SELECT * FROM auth_user;', ['public.auth_user']),
             (
                 'SELECT * FROM auth_user JOIN auth_user_groups ON auth_user.id = auth_user_groups.user_id',
                 ['public.auth_user', 'public.auth_user_groups'],


### PR DESCRIPTION
### Description of change

The create temporary view statement fails if the inner query has a semicolon so this PR strips it out.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
