### PR TITLE
feat: timeout long statements and idle transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2020-09-17
+
+### Changed
+
+- Timeouts associated with database users to try to make them not hold locks on tables swapped by Airflow
+
 ## 2020-09-08
 
 ### Added

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -100,6 +100,18 @@ def new_private_database_credentials(
                 )
 
         with connections[database_obj.memorable_name].cursor() as cur:
+            # Give the user reasonable timeouts...
+            cur.execute(
+                sql.SQL(
+                    "ALTER USER {} SET idle_in_transaction_session_timeout = '60min';"
+                ).format(sql.Identifier(db_user))
+            )
+            cur.execute(
+                sql.SQL("ALTER USER {} SET statement_timeout = '60min';").format(
+                    sql.Identifier(db_user)
+                )
+            )
+
             # ... create a role (if it doesn't exist)
             cur.execute(
                 sql.SQL(


### PR DESCRIPTION
### Description of change

This is an attempt to avoid holding locks that prevents data-flow from swapping tables.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
