### PR TITLE
Bump gitlab runner volume size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-21
+
+### Added
+
+- Configurable root volume size for the GitLab runner, so it can be bumped in production to reduce frequency of running out of space
+
 ## 2020-09-17
 
 ### Added

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -522,6 +522,11 @@ resource "aws_launch_configuration" "gitlab_runner" {
     create_before_destroy = true
   }
 
+  root_block_device {
+    volume_size = "${var.gitlab_runner_root_volume_size}"
+    encrypted = true
+  }
+
   user_data = <<EOF
   #!/bin/bash
   #

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -107,6 +107,7 @@ variable gitlab_instance_type {}
 variable gitlab_memory {}
 variable gitlab_cpu {}
 variable gitlab_runner_instance_type {}
+variable gitlab_runner_root_volume_size {}
 variable gitlab_db_instance_class {}
 variable gitlab_runner_visualisations_deployment_project_token {}
 


### PR DESCRIPTION
### Description of change

The default is apparently 30gb, which is a bit small given usage and the frequency of running out of space.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
