### PR TITLE
fix: pin greenlet temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django==3.0.8
 djangorestframework==3.11.1
 elastic-apm==5.8.1
 gevent==20.6.2
+greenlet==0.4.16  # Not a direct dependency but need to pin this temporarily as 0.4.17 is broken.
 hawk-server-asyncio==0.0.13
 Markdown==3.2.2
 MarkupSafe==1.1.1


### PR DESCRIPTION
### Description of change
Greenlet has just released a new version, 0.4.17, that is currently
breaking our deploys. This is a transitive dependency of gevent, and at
the moment we don't pin sub-dependencies, so the latest release is
getting pulled in. Let's pin this temporarily while we address that
problem more widely.