### PR TITLE
feat: hide other users queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-24
+
+### Changed
+- Hidden other users queries/logs in Data Explorer.
+
 ## 2020-09-22
 
 ### Added


### PR DESCRIPTION
### Description of change
The tool-based Data Explorer is a single-tenant solution, and we want to
maintain the existing design/implementation as we move across to the
integrated version.

This patch accordingly hides other users queries and makes them
inaccessible.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
