### PR TITLE
fix: data explorer celery async tasks

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -511,13 +511,14 @@ en_formats.SHORT_DATE_FORMAT = "d/m/Y"
 en_formats.SHORT_DATETIME_FORMAT = "d/m/Y H:i"
 
 
-for alias in EXPLORER_CONNECTIONS:
-    CELERY_BEAT_SCHEDULE.update(
-        {
-            f"trigger-build-schema-{alias}": {
-                "task": "dataworkspace.apps.explorer.tasks.build_schema_cache_async",
-                "schedule": timedelta(minutes=8),
-                "args": (alias,),
+if EXPLORER_TASKS_ENABLED and EXPLORER_ASYNC_SCHEMA:
+    for alias in EXPLORER_CONNECTIONS:
+        CELERY_BEAT_SCHEDULE.update(
+            {
+                f"trigger-build-schema-{alias}": {
+                    "task": "dataworkspace.apps.explorer.tasks.build_schema_cache_async",
+                    "schedule": timedelta(minutes=8),
+                    "args": (alias,),
+                }
             }
-        }
-    )
+        )


### PR DESCRIPTION
### Description of change
* Only schedule the data explorer schema tasks when we have enabled them
in the settings.
* Use the main Data Workspace celery app to schedule the tasks.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
