### PR TITLE
feat: allow master datasets to be views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Hidden other users queries/logs in Data Explorer.
+- Allow views to be master datasets accessible in tools
 
 ## 2020-09-22
 


### PR DESCRIPTION
### Description of change

For the TAP/TARIC dataset that we manually pg_dumped-in, apparently the tables are not really useful, but the views that came with it are. We could convert the views to tables, but leaving them as views so they can be tweaked more easily if necessary.

This would be the first case of a master dataset being a view, but I'm tempted to treat this a bit of an investigation. I think we might want _all_ master datasets to be views, since they _might_ offer more mechanisms to swap data while being used

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
