### PR TITLE
fix: don't attempt to bind to EFS when starting a visualisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Hidden other users queries/logs in Data Explorer.
 - Allow views to be master datasets accessible in tools
+- Don't attempt to bind to EFS when a user starts a visualisation
 
 ## 2020-09-22
 

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -233,12 +233,17 @@ def application_api_PUT(request, public_host):
             )
 
         app_schema = f'{USER_SCHEMA_STEM}{db_role_schema_suffix}'
+        home_directory_efs_access_point_id = (
+            request.user.profile.home_directory_efs_access_point_id
+            if app_type == 'TOOL'
+            else None,
+        )
 
         spawn.delay(
             application_template.spawner,
             request.user.email,
             str(request.user.profile.sso_id),
-            request.user.profile.home_directory_efs_access_point_id,
+            home_directory_efs_access_point_id,
             tag,
             application_instance.id,
             spawner_options,


### PR DESCRIPTION
### Description of change

It fails to start, since the task definition of visualisation is not written with a volume. However, it shouldn't bind to the EFS access point of the person that happened to start the visualisation.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
