### PR TITLE
feat: flag to switch Data Explorer versions

### DIFF
--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -78,7 +78,10 @@
     {% endif %}
 
     {% for application in applications %}
-      {% include 'partials/tool_section.html' with application_name=application.nice_name application_summary=application.summary application_help_link=application.help_link instance=application.instance application_url=application.link customisable_instance=True has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
+      {# This check can be removed when the Data Explorer tool has been removed from Django-Admin/Data Workspace env altogether #}
+      {% if application.nice_name != 'Data Explorer' or not show_new_data_explorer %}
+        {% include 'partials/tool_section.html' with application_name=application.nice_name application_summary=application.summary application_help_link=application.help_link instance=application.instance application_url=application.link customisable_instance=True has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
+      {% endif %}
     {% endfor %}
 
     {% if your_files_enabled %}


### PR DESCRIPTION
### Description of change
Update the Data Explorer feature flag to hide the existing Data Explorer
tools-based application when the integrated tool is visible. This won't
affect the ability to access the tools-based version by hitting the URL
directly.