### PR TITLE
fix: suppress invalid pagination input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-09-30
+
+### Changed
+- Suppress errors from invalid form entry in Data Explorer pagination fields.
+
 ## 2020-09-28
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -100,11 +100,17 @@ def get_params_for_url(query):  # pylint: disable=inconsistent-return-statements
 
 
 def url_get_rows(request):
-    return int(request.POST.get("query-rows", app_settings.EXPLORER_DEFAULT_ROWS))
+    rows = request.POST.get("query-rows", str(app_settings.EXPLORER_DEFAULT_ROWS))
+    if not rows.isnumeric():
+        return app_settings.EXPLORER_DEFAULT_ROWS
+    return int(rows)
 
 
 def url_get_page(request):
-    return int(request.POST.get("query-page", 1))
+    page = request.POST.get("query-page", "1")
+    if not page.isnumeric():
+        return 1
+    return int(page)
 
 
 def url_get_query_id(request):


### PR DESCRIPTION
### Description of change
Entering non-numeric values results in a form error. These fields are not properly part of the form due to historical implementation, so this is the simplest fix (we also don't have a design for how these fields would look in an error state, so leaving that for now).

https://trello.com/c/nS5Gcpta/941


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
