### PR TITLE
fix: init GOV.UK frontend before schema search

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
@@ -163,20 +163,18 @@
         </footer>
 
         {% block javascript %}
-            {% block footer_additions %} {% endblock footer_additions %}
             <script nonce="{{ request.csp_nonce }}" src="{% get_static_prefix %}govuk-frontend-3.8.1.min.js"></script>
-            <script nonce="{{ request.csp_nonce }}">
-              var govukFrontendInitialised = false;
-              document.onreadystatechange = function () {
-                if (document.readyState === 'complete' && govukFrontendInitialised === false) {
-                  window.GOVUKFrontend.initAll();
-                  govukFrontendInitialised = true;
-                }
-              };
-            </script>
-        {% endblock %}
 
-        {% load render_bundle from webpack_loader %}
-        {% render_bundle 'index' %}
+            {% block init_govuk_frontend %}
+              <script nonce="{{ request.csp_nonce }}">
+                window.GOVUKFrontend.initAll();
+              </script>
+            {% endblock %}
+
+            {% load render_bundle from webpack_loader %}
+            {% render_bundle 'index' %}
+
+            {% block footer_additions %} {% endblock footer_additions %}
+        {% endblock %}
     </body>
 </html>

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -216,8 +216,15 @@
 
   </div>
 
-  {% load render_bundle from webpack_loader %}
-  {% render_bundle 'query' %}
-  {% render_bundle 'schema' %}
+  {% block init_govuk_frontend %}
+    {% load render_bundle from webpack_loader %}
+    {% render_bundle 'query' %}
+    {% render_bundle 'schema' %}
+
+    <script nonce="{{ request.csp_nonce }}">
+      window.GOVUKFrontend.initAll()
+      window.initSchemaSearch();
+    </script>
+  {% endblock %}
 
 {% endblock content %}

--- a/dataworkspace/dataworkspace/static/explorer_schema.js
+++ b/dataworkspace/dataworkspace/static/explorer_schema.js
@@ -1,17 +1,19 @@
 import List from 'list.js';
 
+export var initSchemaSearch = function () {
+  // Slight hack to support up to 100 column names in the search. List.JS expects each searchable datapoint within
+  // a record to have a unique class.
+  var numSupportedColumns = 100;
+  var columnClasses = ['js-schema-table']
+  for (var i = 0; i < numSupportedColumns; i++) {
+    columnClasses.push('js-schema-column-' + (i+1));
+  }
 
-// Slight hack to support up to 100 column names in the search. List.JS expects each searchable datapoint within
-// a record to have a unique class.
-var numSupportedColumns = 100;
-var columnClasses = ['js-schema-table']
-for (var i = 0; i < numSupportedColumns; i++) {
-  columnClasses.push('js-schema-column-' + (i+1));
+  var tableList = new List('js-tables', {
+    indexAsync: true,
+    listClass: "js-list",
+    searchClass: "js-search",
+    valueNames: columnClasses,
+  });
 }
-
-var tableList = new List('js-tables', {
-  indexAsync: true,
-  listClass: "js-list",
-  searchClass: "js-search",
-  valueNames: columnClasses,
-});
+window.initSchemaSearch = initSchemaSearch


### PR DESCRIPTION
### Description of change
We've had an issue lately where the schema search panel doesn't fully
initialise its GOV.UK Design System accordion sections. After
investigating (with the kind help of the GDS Design System team ...)
this is an incompatibility with list.js, which was also building the
dynamic search for the schema panel at the same time. By instead
initialising GOV.UK Frontend first, and then when that's complete kick
off the search indexing, we can avoid this issue.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
