### PR TITLE
feat: launch dataset in data explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-01
+
+### Added
+- Link to master dataset pages, allowing users to launch a dataset in Data Explorer (currently behind a feature flag).
+
 ## 2020-09-30
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
+++ b/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
@@ -1,3 +1,5 @@
+from urllib import parse
+
 from django import template
 
 from dataworkspace.apps.datasets.model_utils import (
@@ -27,3 +29,8 @@ def url_replace(context, **kwargs):
         query[key] = value
 
     return f"{context['request'].build_absolute_uri('?')}?{query.urlencode()}"
+
+
+@register.filter
+def quote_plus(data):
+    return parse.quote_plus(data)

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -1,4 +1,4 @@
-{% load core_tags %}
+{% load core_tags datasets_tags waffle_tags %}
 {% load static %}
 
 {% if perms.applications.start_all_applications or perms.applications.access_appstream %}
@@ -10,16 +10,30 @@
     <h2 class="govuk-tabs__title">Contents</h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+        <a class="govuk-tabs__tab" href="#code-snippet-sql">SQL</a>
+      </li>
+      <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="#code-snippet-python">Python</a>
       </li>
       <li class="govuk-tabs__list-item">
         <a class="govuk-tabs__tab" href="#code-snippet-r">R</a>
       </li>
-      <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#code-snippet-sql">SQL</a>
-      </li>
     </ul>
-    <div class="govuk-tabs__panel" id="code-snippet-python">
+
+    <div class="govuk-tabs__panel" id="code-snippet-sql">
+      <h3 class="govuk-heading-m">SQL</h3>
+      <div class="app-example__code">
+        <pre data-module="app-copy">
+          <code class="hljs psql">{{ code_snippets.sql }}</code>
+        </pre>
+      </div>
+
+      {% flag "SHOW_NEW_DATA_EXPLORER" %}
+      <a class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}">Open in Data Explorer</a>
+      {% endflag %}
+    </div>
+
+    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-python">
       <h3 class="govuk-heading-m">Python</h3>
       <div class="app-example__code">
         <pre data-module="app-copy">
@@ -33,15 +47,6 @@
       <div class="app-example__code">
         <pre data-module="app-copy">
           <code class="hljs r">{{ code_snippets.r }}</code>
-        </pre>
-      </div>
-    </div>
-
-    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-sql">
-      <h3 class="govuk-heading-m">SQL</h3>
-      <div class="app-example__code">
-        <pre data-module="app-copy">
-          <code class="hljs psql">{{ code_snippets.sql }}</code>
         </pre>
       </div>
     </div>


### PR DESCRIPTION
### Description of change
Add a link on master dataset pages to launch a basic query of that one
of that dataset's tables in Data Explorer. For now, this is behind the
same flag that controls whether or not a user can use the integrated
Data Explorer, so that people with the tools-based version don't see
this and think it doesn't work.

### Show it
![2020-10-01 17 07 40](https://user-images.githubusercontent.com/2920760/94834754-b225c000-0408-11eb-99bb-cd03ac6c8c94.gif)


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
