### PR TITLE
fix: remove unused admin.css static file references

### DIFF
--- a/dataworkspace/dataworkspace/templates/admin/reference_data_delete_record.html
+++ b/dataworkspace/dataworkspace/templates/admin/reference_data_delete_record.html
@@ -1,9 +1,5 @@
 {% extends "admin/delete_selected_confirmation.html" %}
 {% load static admin_urls core_tags %}
-{% block extrastyle %}
-  {{ block.super }}
-  <link rel="stylesheet" href="{% static "admin.css" %}">
-{% endblock extrastyle %}
 {% block breadcrumbs %}
   <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}">Home</a>

--- a/dataworkspace/dataworkspace/templates/admin/reference_dataset_edit_record.html
+++ b/dataworkspace/dataworkspace/templates/admin/reference_dataset_edit_record.html
@@ -6,7 +6,6 @@
   {{ media }}
 {% endblock %}{% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'admin.css' %}">
   <link rel="stylesheet" href="{% static 'data-workspace-admin.css' %}">
 {% endblock extrastyle %}
 {% block breadcrumbs %}


### PR DESCRIPTION
### Description of change
Remove missing `admin.css` staticfiles from 2 Django-Admin templates. This file has been missing for a while, but the recently-integrated Data Explorer now raises errors when trying to lookup the file.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
