### PR TITLE
fix: login sso-cycle from iframes

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -1,3 +1,4 @@
+DEBUG=1
 AUTHBROKER_CLIENT_ID=some-id
 AUTHBROKER_CLIENT_SECRET=some-secret
 AUTHBROKER_URL=https://url.to.staff.sso/

--- a/.envs/test.env
+++ b/.envs/test.env
@@ -85,7 +85,7 @@ QUICKSIGHT_USER_REGION=get-from-aws-quicksight
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight
 QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN=test-quicksight-embed-role
 QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS=custom-author-permissions
-VISUALISATION_EMBED_DOMAINS__1=https://authorized-embedder.com
+VISUALISATION_EMBED_DOMAINS__1=http://authorized-embedder.com:8010
 
 EFS_ID=some-id
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-07
+
+### Changed
+
+- Fixed embedding visualisations for users that haven't visited it
+
 ## 2020-10-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker-build:
 
 .PHONY: docker-test-unit
 docker-test-unit: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest /dataworkspace/dataworkspace
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run --entrypoint /dataworkspace/dataworkspace/tests/entrypoint.sh data-workspace-test pytest /dataworkspace/dataworkspace
 
 
 .PHONY: docker-test-integration

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -225,10 +225,6 @@ def tools_html_POST(request):
     return redirect(redirect_target)
 
 
-@csp_update(
-    frame_src=settings.QUICKSIGHT_DASHBOARD_HOST,
-    frame_ancestors=settings.VISUALISATION_EMBED_DOMAINS,
-)
 def _get_embedded_quicksight_dashboard(request, dashboard_id):
     dashboard_name, dashboard_url = get_quicksight_dashboard_name_url(
         dashboard_id, request.user
@@ -261,11 +257,15 @@ def quicksight_start_polling_sync_and_redirect(request):
 
 
 @require_GET
+@csp_update(
+    frame_src=settings.QUICKSIGHT_DASHBOARD_HOST,
+    frame_ancestors=settings.VISUALISATION_EMBED_DOMAINS,
+)
 def visualisation_link_html_view(request, link_id):
     try:
         visualisation_link = VisualisationLink.objects.get(id=link_id)
     except VisualisationLink.DoesNotExist:
-        return HttpResponse(status=404)
+        return HttpResponse('Visualisation not found', status=404)
 
     if not visualisation_link.visualisation_catalogue_item.user_has_access(
         request.user

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 ENVIRONMENT = env.get("ENVIRONMENT", "Dev")
 SECRET_KEY = env['SECRET_KEY']
-DEBUG = 'dataworkspace.test' in env['ALLOWED_HOSTS']
+DEBUG = bool(env.get('DEBUG'))
 
 
 def aws_fargate_private_ip():
@@ -30,13 +30,13 @@ def aws_fargate_private_ip():
         ]['IPv4Addresses'][0]
 
 
+IS_LOCAL = 'dataworkspace.test' in env['ALLOWED_HOSTS']
 ALLOWED_HOSTS = (
     (env['ALLOWED_HOSTS'])
-    if DEBUG
+    if IS_LOCAL
     else (env['ALLOWED_HOSTS'] + [aws_fargate_private_ip()])
 )
-
-INTERNAL_IPS = ['127.0.0.1'] if DEBUG else []
+INTERNAL_IPS = ['127.0.0.1'] if IS_LOCAL else []
 
 ELASTIC_APM_URL = env.get("ELASTIC_APM_URL")
 ELASTIC_APM_SECRET_TOKEN = env.get("ELASTIC_APM_SECRET_TOKEN")
@@ -189,11 +189,11 @@ CACHES = {
 SESSION_COOKIE_NAME = 'data_workspace_session'
 root_domain_no_port, _, _ = env['APPLICATION_ROOT_DOMAIN'].partition(':')
 SESSION_COOKIE_DOMAIN = root_domain_no_port
-SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SECURE = not IS_LOCAL
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 SESSION_CACHE_ALIAS = 'default'
 
-CSRF_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not IS_LOCAL
 CSRF_COOKIE_NAME = 'data_workspace_csrf'
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -210,7 +210,7 @@ APPLICATION_SPAWNER_OPTIONS = env.get('APPLICATION_SPAWNER_OPTIONS', {})
 # CSP Headers
 CSP_DEFAULT_SRC = [APPLICATION_ROOT_DOMAIN]
 CSP_OBJECT_SRC = ["'none'"]
-CSP_UPGRADE_INSECURE_REQUESTS = not DEBUG
+CSP_UPGRADE_INSECURE_REQUESTS = not IS_LOCAL
 CSP_BASE_URI = [APPLICATION_ROOT_DOMAIN]
 CSP_FONT_SRC = [APPLICATION_ROOT_DOMAIN, 'data:', 'https://fonts.gstatic.com']
 CSP_FORM_ACTION = [APPLICATION_ROOT_DOMAIN, f'*.{APPLICATION_ROOT_DOMAIN}']

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1090,7 +1090,7 @@ class TestVisualisationLinkView:
             in response['content-security-policy']
         )
         assert (
-            'frame-ancestors dataworkspace.test:8000 https://authorized-embedder.com'
+            'frame-ancestors dataworkspace.test:8000 http://authorized-embedder.com'
             in response['content-security-policy']
         )
 

--- a/dataworkspace/dataworkspace/tests/entrypoint.sh
+++ b/dataworkspace/dataworkspace/tests/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+django-admin collectstatic --noinput
+$@

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -24,6 +24,7 @@ services:
       - "testvisualisation--11372717--8888.dataworkspace.test:127.0.0.1"
       - "testvisualisation-a.dataworkspace.test:127.0.0.1"
       - "testvisualisation-b.dataworkspace.test:127.0.0.1"
+      - "authorized-embedder.com:127.0.0.1"
       - "api.ecr.my-region-1.amazonaws.com:127.0.0.1"
   data-workspace-postgres:
     build:

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2284,6 +2284,47 @@ class TestApplication(unittest.TestCase):
         assert "ONS (1)" in with_dit_and_ons_filters
         assert "HMRC (1)" in with_dit_and_ons_filters
 
+    @async_test
+    async def test_can_embed_visualisation(self):
+        cleanup_application = await create_application()
+        self.add_async_cleanup(cleanup_application)
+
+        cleanup_embedder = await create_embedder()
+        self.add_async_cleanup(cleanup_embedder)
+
+        is_logged_in = True
+        codes = iter(['some-code'])
+        tokens = iter(['token-1'])
+        auth_to_me = {
+            'Bearer token-1': {
+                'email': 'test@test.com',
+                'contact_email': 'test@test.com',
+                'related_emails': [],
+                'first_name': 'Peter',
+                'last_name': 'Piper',
+                'user_id': '7f93c2c7-bc32-43f3-87dc-40d0b8fb2cd2',
+            }
+        }
+        sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
+        self.add_async_cleanup(sso_cleanup)
+
+        await until_succeeds('http://dataworkspace.test:8000/healthcheck')
+
+        browser = await get_browser()
+        self.add_async_cleanup(browser.close)
+
+        page = await browser.newPage()
+        await page.goto('http://authorized-embedder.com:8010/embed')
+
+        iframe_element = await page.querySelector('iframe')
+        iframe_content_frame = await iframe_element.contentFrame()
+        iframe_html = await iframe_content_frame.content()
+
+        # A "Visualisation not found" showing in the iframe is a success for a
+        # visualisation that doesn't exist, since it means we've got all the
+        # CSP headers right
+        assert 'Visualisation not found' in iframe_html
+
 
 def client_session():
     session = aiohttp.ClientSession()
@@ -2375,6 +2416,24 @@ async def create_mirror():
     await mirror_site.start()
 
     return mirror_runner.cleanup
+
+
+async def create_embedder():
+    async def handle(request):
+        return web.Response(
+            body=b'<iframe src="http://dataworkspace.test:8000/visualisations/link/9a7953c8-b4a9-473b-b16e-f5f79cc8af52">',
+            content_type='text/html',
+            status=200,
+        )
+
+    embedder_app = web.Application()
+    embedder_app.add_routes([web.get('/embed', handle)])
+    embedder_runner = web.AppRunner(embedder_app)
+    await embedder_runner.setup()
+    embedder_site = web.TCPSite(embedder_runner, '0.0.0.0', 8010)
+    await embedder_site.start()
+
+    return embedder_runner.cleanup
 
 
 async def create_sentry():


### PR DESCRIPTION
### Description of change

The previous change worked fine if the user already had the path-specific cookie from visiting a visualisation. However, for a new user, they would get sent to SSO and then back, and then back to SSO, in an infinite loop. This was due to the proxy initially setting a `SameSite=Lax` cookie on the first visit inside the iframe which redirects to SSO. This means that it _won't_ be used when it comes back from SSO, and sends the user to SSO again.

This is fixed by ensuring we have a `SameSite=None` cookie, restricted to the path `/__redirect_from_sso` initially sent along with the redirect to SSO. This allows the browser to use it when it comes back from SSO in the iframe.

Debug mode is now disabled in tests, since django-csp doesn't set the CSP for 404s in debug mode, which is one of the test cases.

### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
