### PR TITLE
fix: remove quotes around explorer connections

### DIFF
--- a/.envs/test.env
+++ b/.envs/test.env
@@ -89,5 +89,5 @@ VISUALISATION_EMBED_DOMAINS__1=https://authorized-embedder.com
 
 EFS_ID=some-id
 
-EXPLORER_CONNECTIONS='{"Postgres": "my_database"}'
+EXPLORER_CONNECTIONS={"Postgres": "my_database"}
 EXPLORER_DEFAULT_CONNECTION=my_database


### PR DESCRIPTION
### Description of change

Running make docker-test-unit locally fails as the env var is quoted when it shouldn't be: https://dev.to/tvanantwerp/don-t-quote-environment-variables-in-docker-268h

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
