### PR TITLE
adding allowed tables for autocomplete in query

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -4,6 +4,7 @@
 
 {% block title %}{% if form.errors %}Error: {% endif %}Data Explorer - Home{% endblock %}
 {% block content %}
+{{ schema_tables|json_script:"schema_tables" }}
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full" id="query_area">

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -283,6 +283,13 @@ class DeleteQueryView(DeleteView):
 
 
 class PlayQueryView(View):
+    def _schema_info(self, request):
+        schema = schema_info(
+            user=request.user, connection_alias=settings.EXPLORER_DEFAULT_CONNECTION
+        )
+        # used for autocomplete
+        return schema, ['.'.join(schema_table) for schema_table, _ in schema]
+
     def get(self, request):
         if url_get_query_id(request):
             query = get_object_or_404(
@@ -297,6 +304,8 @@ class PlayQueryView(View):
             query = Query(sql=log.sql, title="Playground", connection=log.connection)
             return self.render_with_sql(request, query)
 
+        schema, tables_columns = self._schema_info(request)
+
         return render(
             self.request,
             'explorer/home.html',
@@ -304,10 +313,8 @@ class PlayQueryView(View):
                 'title': 'Playground',
                 'form': QueryForm(initial={"sql": request.GET.get('sql')}),
                 'form_action': self.get_form_action(request),
-                'schema': schema_info(
-                    user=request.user,
-                    connection_alias=settings.EXPLORER_DEFAULT_CONNECTION,
-                ),
+                'schema': schema,
+                'schema_tables': tables_columns,
             },
         )
 
@@ -395,9 +402,11 @@ class PlayQueryView(View):
             form=form,
             log=log,
         )
-        context['schema'] = schema_info(
-            user=request.user, connection_alias=settings.EXPLORER_DEFAULT_CONNECTION
-        )
+
+        schema, tables_columns = self._schema_info(request)
+
+        context['schema'] = schema
+        context['schema_tables'] = tables_columns
         context['form_action'] = self.get_form_action(request)
         return render(self.request, 'explorer/home.html', context)
 

--- a/dataworkspace/dataworkspace/static/explorer_query.js
+++ b/dataworkspace/dataworkspace/static/explorer_query.js
@@ -13,10 +13,37 @@ var editor = ace.edit("ace-sql-editor", {
   fontSize: 18,
   showLineNumbers: false,
   showGutter: false,
+  enableBasicAutocompletion: true,
   enableLiveAutocompletion: true,
   showPrintMargin: false,
   readOnly: document.getElementById('ace-sql-editor').dataset.disabled || false,
 });
+
+
+var table_list = document.getElementById("schema_tables").textContent;
+
+var staticWordCompleter = {
+  getCompletions: function(editor, session, pos, prefix, callback) {
+      var wordList = JSON.parse(table_list)
+
+      callback(null, [...wordList.map(function(word) {
+          return {
+              caption: word,
+              value: word,
+              meta: "static"
+          };
+      }), ...session.$mode.$highlightRules.$keywordList.map(function(word) {
+          return {
+              caption: word,
+              value: word,
+              meta: 'keyword',
+          };
+      })
+    ]);
+  }
+}
+
+editor.completers = [staticWordCompleter]
 
 editor.commands.removeCommand(editor.commands.byName.indent);
 editor.commands.removeCommand(editor.commands.byName.outdent);


### PR DESCRIPTION
### Description of change
As part of Firebreak, this is an attempt to update autocomplete to include schema, table names that the user has access to.


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
