### PR TITLE
Revert "fix: login sso-cycle from iframes"

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -1,4 +1,3 @@
-DEBUG=1
 AUTHBROKER_CLIENT_ID=some-id
 AUTHBROKER_CLIENT_SECRET=some-secret
 AUTHBROKER_URL=https://url.to.staff.sso/

--- a/.envs/test.env
+++ b/.envs/test.env
@@ -85,7 +85,7 @@ QUICKSIGHT_USER_REGION=get-from-aws-quicksight
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight
 QUICKSIGHT_DASHBOARD_EMBEDDING_ROLE_ARN=test-quicksight-embed-role
 QUICKSIGHT_AUTHOR_CUSTOM_PERMISSIONS=custom-author-permissions
-VISUALISATION_EMBED_DOMAINS__1=http://authorized-embedder.com:8010
+VISUALISATION_EMBED_DOMAINS__1=https://authorized-embedder.com
 
 EFS_ID=some-id
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker-build:
 
 .PHONY: docker-test-unit
 docker-test-unit: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run --entrypoint /dataworkspace/dataworkspace/tests/entrypoint.sh data-workspace-test pytest /dataworkspace/dataworkspace
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest /dataworkspace/dataworkspace
 
 
 .PHONY: docker-test-integration

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -225,6 +225,10 @@ def tools_html_POST(request):
     return redirect(redirect_target)
 
 
+@csp_update(
+    frame_src=settings.QUICKSIGHT_DASHBOARD_HOST,
+    frame_ancestors=settings.VISUALISATION_EMBED_DOMAINS,
+)
 def _get_embedded_quicksight_dashboard(request, dashboard_id):
     dashboard_name, dashboard_url = get_quicksight_dashboard_name_url(
         dashboard_id, request.user
@@ -257,15 +261,11 @@ def quicksight_start_polling_sync_and_redirect(request):
 
 
 @require_GET
-@csp_update(
-    frame_src=settings.QUICKSIGHT_DASHBOARD_HOST,
-    frame_ancestors=settings.VISUALISATION_EMBED_DOMAINS,
-)
 def visualisation_link_html_view(request, link_id):
     try:
         visualisation_link = VisualisationLink.objects.get(id=link_id)
     except VisualisationLink.DoesNotExist:
-        return HttpResponse('Visualisation not found', status=404)
+        return HttpResponse(status=404)
 
     if not visualisation_link.visualisation_catalogue_item.user_has_access(
         request.user

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 ENVIRONMENT = env.get("ENVIRONMENT", "Dev")
 SECRET_KEY = env['SECRET_KEY']
-DEBUG = bool(env.get('DEBUG'))
+DEBUG = 'dataworkspace.test' in env['ALLOWED_HOSTS']
 
 
 def aws_fargate_private_ip():
@@ -30,13 +30,13 @@ def aws_fargate_private_ip():
         ]['IPv4Addresses'][0]
 
 
-IS_LOCAL = 'dataworkspace.test' in env['ALLOWED_HOSTS']
 ALLOWED_HOSTS = (
     (env['ALLOWED_HOSTS'])
-    if IS_LOCAL
+    if DEBUG
     else (env['ALLOWED_HOSTS'] + [aws_fargate_private_ip()])
 )
-INTERNAL_IPS = ['127.0.0.1'] if IS_LOCAL else []
+
+INTERNAL_IPS = ['127.0.0.1'] if DEBUG else []
 
 ELASTIC_APM_URL = env.get("ELASTIC_APM_URL")
 ELASTIC_APM_SECRET_TOKEN = env.get("ELASTIC_APM_SECRET_TOKEN")
@@ -189,11 +189,11 @@ CACHES = {
 SESSION_COOKIE_NAME = 'data_workspace_session'
 root_domain_no_port, _, _ = env['APPLICATION_ROOT_DOMAIN'].partition(':')
 SESSION_COOKIE_DOMAIN = root_domain_no_port
-SESSION_COOKIE_SECURE = not IS_LOCAL
+SESSION_COOKIE_SECURE = not DEBUG
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 SESSION_CACHE_ALIAS = 'default'
 
-CSRF_COOKIE_SECURE = not IS_LOCAL
+CSRF_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_NAME = 'data_workspace_csrf'
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -210,7 +210,7 @@ APPLICATION_SPAWNER_OPTIONS = env.get('APPLICATION_SPAWNER_OPTIONS', {})
 # CSP Headers
 CSP_DEFAULT_SRC = [APPLICATION_ROOT_DOMAIN]
 CSP_OBJECT_SRC = ["'none'"]
-CSP_UPGRADE_INSECURE_REQUESTS = not IS_LOCAL
+CSP_UPGRADE_INSECURE_REQUESTS = not DEBUG
 CSP_BASE_URI = [APPLICATION_ROOT_DOMAIN]
 CSP_FONT_SRC = [APPLICATION_ROOT_DOMAIN, 'data:', 'https://fonts.gstatic.com']
 CSP_FORM_ACTION = [APPLICATION_ROOT_DOMAIN, f'*.{APPLICATION_ROOT_DOMAIN}']

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1090,7 +1090,7 @@ class TestVisualisationLinkView:
             in response['content-security-policy']
         )
         assert (
-            'frame-ancestors dataworkspace.test:8000 http://authorized-embedder.com'
+            'frame-ancestors dataworkspace.test:8000 https://authorized-embedder.com'
             in response['content-security-policy']
         )
 

--- a/dataworkspace/dataworkspace/tests/entrypoint.sh
+++ b/dataworkspace/dataworkspace/tests/entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-django-admin collectstatic --noinput
-$@

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -80,13 +80,6 @@ async def async_main():
     # will be sent when the site is embedded in an iframe
     embed_path = '/visualisations/link'
 
-    def _is_embed_path(url):
-        url_parsed = URL(url)
-        return (
-            url_parsed.path.startswith(f'{embed_path}/')
-            and url_parsed.host == root_domain_no_port
-        )
-
     root_domain_no_port, _, root_port_str = root_domain.partition(':')
     try:
         root_port = int(root_port_str)
@@ -704,7 +697,7 @@ async def async_main():
             upstream_ws = await upstream_connection
             _, _, _, with_session_cookie = downstream_request[SESSION_KEY]
             downstream_ws = await with_session_cookie(
-                web.WebSocketResponse(protocols=protocols), '/', 'Lax'
+                web.WebSocketResponse(protocols=protocols)
             )
 
             await downstream_ws.prepare(downstream_request)
@@ -807,9 +800,7 @@ async def async_main():
                     headers=CIMultiDict(
                         without_transfer_encoding(upstream_response) + response_headers
                     ),
-                ),
-                '/',
-                'Lax',
+                )
             )
             await downstream_response.prepare(downstream_request)
             async for chunk in upstream_response.content.iter_any():
@@ -983,9 +974,7 @@ async def async_main():
                             set_session_value, redirect_uri_final
                         )
                     },
-                ),
-                redirect_from_sso_path,
-                'None' if _is_embed_path(redirect_uri_final) else 'Lax',
+                )
             )
 
         @web.middleware
@@ -1041,19 +1030,11 @@ async def async_main():
                 await set_session_value(
                     session_token_key, sso_response_json['access_token']
                 )
-
-                cookie_path, cookie_same_site = (
-                    (embed_path, 'None')
-                    if _is_embed_path(redirect_uri_final_from_session)
-                    else ('/', 'Lax')
-                )
                 return await with_new_session_cookie(
                     web.Response(
                         status=302,
                         headers={'Location': redirect_uri_final_from_session},
-                    ),
-                    cookie_path,
-                    cookie_same_site,
+                    )
                 )
 
             # Get profile from Redis cache to avoid calling SSO on every request

--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -70,12 +70,12 @@ def redis_session_middleware(redis_pool, root_domain_no_port, embed_path):
         # prepared, which is done explicitly for streaming responses before
         # the handler returns
 
-        async def with_new_cookie(response, path, same_site):
+        async def with_new_cookie(response):
             nonlocal cookie_value
             cookie_value = get_secret_cookie_value()
-            return await with_cookie(response, path, same_site)
+            return await with_cookie(response)
 
-        async def with_cookie(response, path, same_site):
+        async def with_cookie(response):
             nonlocal cookie_value
 
             if not cookie_value:
@@ -101,6 +101,12 @@ def redis_session_middleware(redis_pool, root_domain_no_port, embed_path):
                 == 'https'
                 else ''
             )
+
+            # Visualisations embedded in other sites must have SameSite=None cookies. We restrict
+            # those cookies to only be sent for visualisation paths. So, for example, they cannot
+            # be used for Django admin
+            is_embed = request.url.path.startswith(f'{embed_path}/')
+            path, same_site = (embed_path, 'None') if is_embed else ('/', 'Lax')
 
             # aiohttp's set_cookie doesn't seem to support the SameSite attribute
             response.headers.add(

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -24,7 +24,6 @@ services:
       - "testvisualisation--11372717--8888.dataworkspace.test:127.0.0.1"
       - "testvisualisation-a.dataworkspace.test:127.0.0.1"
       - "testvisualisation-b.dataworkspace.test:127.0.0.1"
-      - "authorized-embedder.com:127.0.0.1"
       - "api.ecr.my-region-1.amazonaws.com:127.0.0.1"
   data-workspace-postgres:
     build:


### PR DESCRIPTION
This reverts commit 1c88ad375e4a137555d820137652c2673eef12e7.

The recent change to allow embedding visualisaitons in iframes I think
caused apparent occasional infinite loops round to SSO. Suspect this is
due to multiple cookies of the same name in some cases during login on
the /__redirect_from_sso path

Reverting as nothing in production depends on this behaviour yet.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
