### PR TITLE
feat: by default install Python packages in standard location, not in home directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Bumped Theia and vscode-python extension to support opening notebooks
+- In Theia allow Python package to be installed into their default location rather than the home directory
 
 ## 2020-10-07
 

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -68,13 +68,14 @@ RUN \
 COPY requirements.txt /root
 
 RUN \
-	python3 -m pip install pip --upgrade && \
-	pip3 install setuptools==49.2.0 --upgrade && \
-	pip3 install -r requirements.txt
-
-RUN \
 	addgroup --system --gid 4356 theia && \
 	adduser --disabled-password --gecos '' --ingroup theia --uid 4357 theia
+
+RUN \
+	python3 -m pip install pip --upgrade && \
+	pip3 install setuptools==49.2.0 --upgrade && \
+	pip3 install -r requirements.txt && \
+	chown -R theia:theia /usr/local
 
 RUN \
 	mkdir /tmp/.yarn-cache && \


### PR DESCRIPTION
### Description of change

pip would try to install into /usr/local/lib/, but it wasn't writable

In addition to using home directory less space, this means executables end up in the path, and so are easier to run. This is more consistent with JupyterLab Python.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
