### PR TITLE
feat: don't cache pip packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Bumped Theia and vscode-python extension to support opening notebooks
 - In Theia allow Python package to be installed into their default location rather than the home directory
+- Don't cache pip packages in Theia and JupyterLab Python to use less space
 
 ## 2020-10-07
 

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -127,7 +127,8 @@ RUN \
     npm cache clean --force && \
     node /opt/conda/lib/python3.7/site-packages/jupyterlab/staging/yarn.js cache clean && \
     echo '[global]' > /etc/pip.conf && \
-    echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf
+    echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf && \
+    echo 'no-cache-dir = false' >> /etc/pip.conf
 
 COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
 

--- a/theia/Dockerfile
+++ b/theia/Dockerfile
@@ -45,7 +45,8 @@ RUN \
 
 RUN \
     echo '[global]' > /etc/pip.conf && \
-    echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf
+    echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf && \
+    echo 'no-cache-dir = false' >> /etc/pip.conf
 
 WORKDIR /root
 RUN \


### PR DESCRIPTION
### Description of change

This would result in both smaller Docker images, and so a faster start, and use less disk space. And, I suspect less likely things would go wrong down the line if some of the packages do something environment-specific like compiling.

From https://pip.pypa.io/en/stable/user_guide/, to _enable_ the boolean option `--no-cache-dir` you have to specify a falsey value.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
