### PR TITLE
fix: add missing quote marks in cran repo name

### DIFF
--- a/visualisation-base-r/Dockerfile
+++ b/visualisation-base-r/Dockerfile
@@ -34,7 +34,7 @@ RUN \
 	sed -i '$d' /etc/apt/sources.list && \
 	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r = getOption("repos")' >> /usr/lib/R/etc/Rprofile.site && \
-	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '  options(repos = r)' >> /usr/lib/R/etc/Rprofile.site && \
 	echo '})' >> /usr/lib/R/etc/Rprofile.site


### PR DESCRIPTION
### Description of change

Fix typo in CRAN repo name

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
