### PR TITLE
feat: bump mobius3 to be more EFS-friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-12
+
+### Changed
+
+- Bump mobius3 (used in the s3sync) to behave better when on EFS and there are existing files: use less memory and be faster on start, and don't delete files that exist locally until it's sure they're not on S3.
+
 ## 2020-10-09
 
 ### Added

--- a/s3sync/Dockerfile
+++ b/s3sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/uktrade/mobius3:v0.0.33
+FROM quay.io/uktrade/mobius3:v0.0.34
 
 COPY start.sh /
 


### PR DESCRIPTION
### Description of change

Bump mobius3 (used in the s3sync) to behave better when on EFS and there are existing files: use less memory and be faster on start, and don't delete files that exist locally until it's sure they're not on S3.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
