### PR TITLE
Data explorer logs redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2020-10-12
 
 ### Changed
-
+- Redesigned the query list and query logs pages of the Data Explorer.
 - Bump mobius3 (used in the s3sync) to behave better when on EFS and there are existing files: use less memory and be faster on start, and don't delete files that exist locally until it's sure they're not on S3.
 
 ## 2020-10-09

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -113,7 +113,7 @@
                     <div class="govuk-textarea" id="gov-uk-sql-wrapper" style="display: none;">
                         <div id="ace-sql-editor" data-disabled="true">{% if form.sql.value %}{{ form.sql.value }}{% endif %}</div>
                     </div>
-                    <textarea class="govuk-textarea" aria-label="Sql" name="sql" id="original-sql" rows="15" readonly>{% if form.sql.value %}{{ form.sql.value }}{% endif %}</textarea>
+                    <textarea class="govuk-textarea app-readonly-sql" aria-label="Sql" name="sql" id="original-sql" rows="15" readonly>{% if form.sql.value %}{{ form.sql.value }}{% endif %}</textarea>
                 </div>
 
                 <div class="govuk-form-group">

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
@@ -2,21 +2,23 @@
 
 {% block title %}Data Explorer - Queries{% endblock %}
 {% block content %}
-<h1 class="govuk-heading-m govuk-!-margin-bottom-6">Home</h1>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Saved queries</h1>
+
+<p class="govuk-body govuk-!-margin-bottom-7">You can see your saved and recently run queries on this page.</p>
     
 <div class="govuk-grid-row">
   <div class="govuk-width-container">
     {% if recent_queries|length > 0 %}
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">
-      Your&nbsp;{{ recent_queries|length }}&nbsp;Most Recently Run
+    <h2 class="govuk-heading-l">
+      Your most recently run queries
     </h2>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
 	<tr class="govuk-table__row">
-	  <th scope="col" class="govuk-table__header">Query</th>
-	  <th scope="col" class="govuk-table__header">Last Run</th>
-	  <th scope="col" class="govuk-table__header">CSV</th>
+	  <th scope="col" class="govuk-table__header">Query title</th>
+	  <th scope="col" class="govuk-table__header" style="width: 25%">Date and time run</th>
+	  <th scope="col" class="govuk-table__header" style="width: 20%">Action</th>
 	</tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -30,7 +32,7 @@
 	  <td class="govuk-table__cell">{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
 	  <td class="govuk-table__cell">
 	    <a class="govuk-link" href="{% url 'explorer:download_query' object.query_id %}">
-	      Download
+	      Download result (CSV)
 	    </a>
 	  </td>
 	</tr>
@@ -42,48 +44,38 @@
   </div>
   
   <div class="govuk-width-container">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">All Queries</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-9">Your queries</h2>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">
 	<tr class="govuk-table__row">
-	  <th scope="col" class="govuk-table__header">Query</th>
-	  <th scope="col" class="govuk-table__header">Download</th>
-	  <th scope="col" class="govuk-table__header">Created</th>
-	  <th scope="col" class="govuk-table__header">Play</th>
-	  <th scope="col" class="govuk-table__header">Delete</th>
-	  <th scope="col" class="govuk-table__header">Run Count</th>
+	  <th scope="col" class="govuk-table__header" style="width: 30%">Query title</th>
+	  <th scope="col" class="govuk-table__header" style="width: 15%">Date created</th>
+	  <th scope="col" class="govuk-table__header" style="width: 15%">Run count</th>
+	  <th scope="col" class="govuk-table__header">Actions</th>
 	</tr>
       </thead>
       <tbody class="govuk-table__body">
 	{% for object in object_list %}
-	<tr {% if object.is_in_category %}class="collapse in collapse-{{ object.collapse_target }} govuk-table__row"{% endif %}>
-          {% if object.is_header %}
-          <td class="govuk-table__cell" colspan="100">
-            <strong>
-              <span data-toggle="collapse" data-target=".collapse-{{object.collapse_target}}"
-                    class="toggle">
-		{{ object.title }} ({{ object.count }})</span>
-            </strong>
-          </td>
-          {% else %}
-          <td class="name{% if object.is_in_category %} indented{% endif %} govuk-table__cell">
-            <a class="govuk-link" href="{% url 'explorer:query_detail' object.id %}">{{ object.title }}</a>
-          </td>
-          <td class="govuk-table__cell">
-            <a class="govuk-link" href="{% url 'explorer:download_query' object.id %}">Download</a>
-          </td>
-          <td class="govuk-table__cell">{{ object.created_at|date:"SHORT_DATE_FORMAT" }}
-          </td>
-          <td class="govuk-table__cell">
-            <a class="govuk-link" href="{% url 'explorer:index' %}?query_id={{ object.id }}">Play</a>
-          </td>
-          <td class="govuk-table__cell">
-            <a class="govuk-link" href="{% url 'explorer:query_delete' object.id %}">Delete</a>
-          </td>
-          <td class="govuk-table__cell">{{ object.run_count }}</td>
-
-          {% endif %}
+	<tr>
+        <td class="name govuk-table__cell">
+          <a class="govuk-link" href="{% url 'explorer:query_detail' object.id %}">
+            {{ object.title }}
+          </a>
+        </td>
+        <td class="govuk-table__cell">
+          {{ object.created_at|date:"SHORT_DATE_FORMAT" }}
+        </td>
+        <td class="govuk-table__cell">
+          {{ object.run_count }}
+        </td>
+        <td class="govuk-table__cell">
+          <a class="govuk-link govuk-!-margin-right-4 govuk-!-display-inline-block" href="{% url 'explorer:index' %}?query_id={{ object.id }}">Run</a>
+          <a class="govuk-link govuk-!-margin-right-4 govuk-!-display-inline-block" href="{% url 'explorer:query_delete' object.id %}">Delete</a>
+          <a class="govuk-link govuk-!-display-inline-block" href="{% url 'explorer:download_query' object.id %}">
+            Download result (CSV)
+          </a>
+        </td>
 	</tr>
 	{% endfor %}
 	

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/querylog_list.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/querylog_list.html
@@ -1,32 +1,37 @@
 {% extends "explorer/base.html" %}
+
+{% load explorer_tags %}
+
 {% block title %}Data Explorer - Logs{% endblock %}
+
 {% block content %}
-<h1 class="govuk-heading-m govuk-!-margin-bottom-2">Recent Query Logs - Page {{ page_obj.number }}</h1>
+<h1 class="govuk-heading-xl">Logs</h1>
+<h2 class="govuk-heading-l">Query logs</h2>
 <table class="govuk-table">
     <thead>
     <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">Run At</th>
-        <th scope="col" class="govuk-table__header">Run By</th>
-        <th scope="col" class="govuk-table__header">Duration</th>
+        <th scope="col" class="govuk-table__header">Query title</th>
         <th scope="col" class="govuk-table__header">SQL</th>
-        <th scope="col" class="govuk-table__header">Query ID</th>
-        <th scope="col" class="govuk-table__header">Playground</th>
+        <th scope="col" class="govuk-table__header">Run duration</th>
+        <th scope="col" class="govuk-table__header">Actions</th>
     </tr>
     </thead>
     <tbody class="govuk-table__body">
     {% for object in recent_logs %}
     <tr class="govuk-table__row">
-        <td class="govuk-table__cell">{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
-        <td class="govuk-table__cell log-user">{{ object.run_by_user.first_name }} {{ object.run_by_user.last_name }}</td>
-        <td class="govuk-table__cell">{{ object.duration|floatformat:2 }}ms</td>
-        <td class="govuk-table__cell log-sql"><div><pre>{{ object.sql }}</pre></div></td>
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell" style="width: 25%">
             {% if object.query_id %}
-            <a class="govuk-link" href="{% url 'explorer:query_detail' object.query_id %}">Query {{ object.query_id }}</a>
-            {% elif object.is_playground %}Playground{% else %}--{% endif %}
+              <a class="govuk-link" href="{% url 'explorer:query_detail' object.query_id %}">{{ object.query.title }}</a>
+            {% else %}
+              N/A
+            {% endif %}
         </td>
-        <td class="govuk-table__cell">
-            <a class="govuk-link" href="{% url 'explorer:index' %}?querylog_id={{ object.id }}">Open</a>
+        <td class="govuk-table__cell log-sql">
+          <textarea class="govuk-textarea app-readonly-sql govuk-!-margin-bottom-0 govuk-!-font-size-16" rows="2" readonly style="width: 100%">{{ object.sql }}</textarea>
+        </td>
+        <td class="govuk-table__cell" style="width: 15%">{% if object.duration %}{{ object.duration|format_duration_short }}{% else %}N/A{% endif %}</td>
+        <td class="govuk-table__cell" style="width: 10%">
+            <a class="govuk-link" href="{% url 'explorer:index' %}?querylog_id={{ object.id }}">Run</a>
         </td>
     </tr>
     {% endfor %}
@@ -35,7 +40,7 @@
 
 {% if is_paginated %}
 <nav role="navigation" class="govuk-body">
-    Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+    Displaying logs {{ page_obj.start_index }}-{{ page_obj.end_index }} of {{ page_obj.paginator.count }}
     <ul class="pagination govuk-list">
         {% if page_obj.has_previous %}
         <li><a class="govuk-link" href="?page={{ page_obj.previous_page_number }}">Previous</a></li>

--- a/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
+++ b/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
@@ -23,17 +23,23 @@ def get_item(dictionary, key):
 
 
 @register.filter
-def format_duration(milli_seconds):
+def format_duration(milli_seconds, short=False):
     q, r = divmod(milli_seconds, 1000)
     millis = round(r, 2)
     seconds = int(q % 60)
     minutes = int((q // 60) % 60)
     hours = int(q // 3600)
 
-    hour_unit = f'hour{"s" if hours != 1 else ""}'
-    minute_unit = f'minute{"s" if minutes != 1 else ""}'
-    second_unit = f'second{"s" if seconds != 1 else ""}'
-    millis_unit = f'millisecond{"s" if millis != 1 else ""}'
+    if short:
+        hour_unit = 'h'
+        minute_unit = 'm'
+        second_unit = 's'
+        millis_unit = 'ms'
+    else:
+        hour_unit = f'hour{"s" if hours != 1 else ""}'
+        minute_unit = f'minute{"s" if minutes != 1 else ""}'
+        second_unit = f'second{"s" if seconds != 1 else ""}'
+        millis_unit = f'millisecond{"s" if millis != 1 else ""}'
 
     if hours:
         return (
@@ -45,3 +51,8 @@ def format_duration(milli_seconds):
     elif seconds:
         return f'{seconds} {second_unit} {millis} {millis_unit}'
     return f'{millis} {millis_unit}'
+
+
+@register.filter
+def format_duration_short(milli_seconds):
+    return format_duration(milli_seconds, short=True)

--- a/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
+++ b/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
@@ -36,21 +36,19 @@ def format_duration(milli_seconds, short=False):
         second_unit = 's'
         millis_unit = 'ms'
     else:
-        hour_unit = f'hour{"s" if hours != 1 else ""}'
-        minute_unit = f'minute{"s" if minutes != 1 else ""}'
-        second_unit = f'second{"s" if seconds != 1 else ""}'
-        millis_unit = f'millisecond{"s" if millis != 1 else ""}'
+        hour_unit = f' hour{"s" if hours != 1 else ""}'
+        minute_unit = f' minute{"s" if minutes != 1 else ""}'
+        second_unit = f' second{"s" if seconds != 1 else ""}'
+        millis_unit = f' millisecond{"s" if millis != 1 else ""}'
 
     if hours:
-        return (
-            f'{hours} {hour_unit} {minutes} {minute_unit} '
-            f'{seconds} {second_unit} {millis} {millis_unit}'
-        )
+        return f'{hours}{hour_unit} {minutes}{minute_unit} ' f'{seconds}{second_unit}'
     elif minutes:
-        return f'{minutes} {minute_unit} {seconds} {second_unit} {millis} {millis_unit}'
+        return f'{minutes}{minute_unit} {seconds}{second_unit}'
     elif seconds:
-        return f'{seconds} {second_unit} {millis} {millis_unit}'
-    return f'{millis} {millis_unit}'
+        millis = int(r)
+        return f'{seconds}{second_unit} {millis}{millis_unit}'
+    return f'{millis}{millis_unit}'
 
 
 @register.filter

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -195,7 +195,7 @@ class ListQueryLogView(ListView):
 
     context_object_name = "recent_logs"
     model = QueryLog
-    paginate_by = 20
+    paginate_by = 15
 
 
 class CreateQueryView(CreateView):

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -1,6 +1,3 @@
-import re
-
-from collections import Counter
 from urllib.parse import urlencode
 
 from psycopg2 import DatabaseError
@@ -8,7 +5,6 @@ from psycopg2 import DatabaseError
 from django.conf import settings
 from django.contrib.auth.views import LoginView
 from django.db.models import Count
-from django.forms.models import model_to_dict
 from django.http import (
     HttpResponse,
     HttpResponseRedirect,
@@ -115,75 +111,20 @@ class ListQueryView(ListView):
 
     def get_context_data(self, **kwargs):
         context = super(ListQueryView, self).get_context_data(**kwargs)
-        context['object_list'] = self._build_queries_and_headers()
+        context['object_list'] = self.object_list
         context['recent_queries'] = self.recently_viewed()
         return context
 
     def get_queryset(self):
-        qs = Query.objects.filter(created_by_user=self.request.user).all()
+        qs = (
+            Query.objects.filter(created_by_user=self.request.user)
+            .order_by('-created_at')
+            .all()
+        )
         return qs.annotate(run_count=Count('querylog'))
 
-    def _build_queries_and_headers(self):
-        """
-        Build a list of query information and headers (pseudo-folders)
-        for consumption by the template.
-
-        Strategy: Look for queries with titles of the form "something - else"
-        (eg. with a ' - ' in the middle)
-        and split on the ' - ', treating the left side as a "header" (or folder). Interleave the
-        headers into the ListView's object_list as appropriate. Ignore headers that only have one
-        child. The front end uses bootstrap's JS Collapse plugin, which necessitates generating CSS
-        classes to map the header onto the child rows, hence the collapse_target variable.
-
-        To make the return object homogeneous, convert the object_list models into dictionaries for
-        interleaving with the header "objects". This necessitates special handling of 'created_at'
-        and 'created_by_user' because model_to_dict doesn't include non-editable fields (created_at)
-        and will give the int representation of the user instead of the string representation.
-
-        :return: A list of model dictionaries representing all the query objects,
-        interleaved with header dictionaries.
-        """
-
-        dict_list = []
-        rendered_headers = []
-        pattern = re.compile(r'[\W_]+')
-
-        headers = Counter([q.title.split(' - ')[0] for q in self.object_list])
-
-        for q in self.object_list:
-            model_dict = model_to_dict(q)
-            header = q.title.split(' - ')[0]
-            collapse_target = pattern.sub('', header)
-
-            if headers[header] > 1 and header not in rendered_headers:
-                dict_list.append(
-                    {
-                        'title': header,
-                        'is_header': True,
-                        'is_in_category': False,
-                        'collapse_target': collapse_target,
-                        'count': headers[header],
-                    }
-                )
-                rendered_headers.append(header)
-
-            model_dict.update(
-                {
-                    'is_in_category': headers[header] > 1,
-                    'collapse_target': collapse_target,
-                    'created_at': q.created_at,
-                    'is_header': False,
-                    'run_count': q.run_count,
-                    'created_by_user': q.created_by_user.email
-                    if q.created_by_user
-                    else None,
-                }
-            )
-
-            dict_list.append(model_dict)
-        return dict_list
-
     model = Query
+    paginate_by = 15
 
 
 class ListQueryLogView(ListView):
@@ -191,7 +132,7 @@ class ListQueryLogView(ListView):
         kwargs = {'sql__isnull': False, 'run_by_user': self.request.user}
         if url_get_query_id(self.request):
             kwargs['query_id'] = url_get_query_id(self.request)
-        return QueryLog.objects.filter(**kwargs).all()
+        return QueryLog.objects.filter(**kwargs).order_by('-run_at').all()
 
     context_object_name = "recent_logs"
     model = QueryLog

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -467,7 +467,7 @@ CELERY_ACCEPT_CONTENT = ['pickle', 'json']
 
 # date and time formats
 en_formats.SHORT_DATE_FORMAT = "d/m/Y"
-en_formats.SHORT_DATETIME_FORMAT = "d/m/Y H:i"
+en_formats.SHORT_DATETIME_FORMAT = "d/m/Y P"
 
 
 EXPLORER_DEFAULT_ROWS = int(env.get("EXPLORER_DEFAULT_ROWS", 1000))

--- a/dataworkspace/dataworkspace/static/explorer_custom.css
+++ b/dataworkspace/dataworkspace/static/explorer_custom.css
@@ -97,6 +97,6 @@
     display: inline;
 }
 
-#original-sql:read-only {
+.app-readonly-sql {
     background-color: #F0F0F0
 }

--- a/dataworkspace/dataworkspace/tests/explorer/test_tags.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tags.py
@@ -1,11 +1,21 @@
-from dataworkspace.apps.explorer.templatetags.explorer_tags import format_duration
+from dataworkspace.apps.explorer.templatetags.explorer_tags import (
+    format_duration,
+    format_duration_short,
+)
 
 
 def test_format_duration():
 
-    assert (
-        format_duration(36061001.3456) == '10 hours 1 minute 1 second 1.35 milliseconds'
-    )
+    assert format_duration(36061001.3456) == '10 hours 1 minute 1 second'
     assert format_duration(1) == '1 millisecond'
-    assert format_duration(3600000) == '1 hour 0 minutes 0 seconds 0 milliseconds'
-    assert format_duration(1000.2) == '1 second 0.2 milliseconds'
+    assert format_duration(1.273) == '1.27 milliseconds'
+    assert format_duration(3600000) == '1 hour 0 minutes 0 seconds'
+    assert format_duration(1000.2) == '1 second 0 milliseconds'
+
+
+def test_format_duration_short():
+    assert format_duration_short(36061001.3456) == '10h 1m 1s'
+    assert format_duration_short(1) == '1ms'
+    assert format_duration_short(1.273) == '1.27ms'
+    assert format_duration_short(3600000) == '1h 0m 0s'
+    assert format_duration_short(1000.2) == '1s 0ms'

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -21,16 +21,6 @@ from dataworkspace.tests.explorer.factories import (
 
 
 class TestQueryListView:
-    def test_headers(self, user, client):
-        SimpleQueryFactory(title='foo - bar1', created_by_user=user)
-        SimpleQueryFactory(title='foo - bar2', created_by_user=user)
-        SimpleQueryFactory(title='foo - bar3', created_by_user=user)
-        SimpleQueryFactory(title='qux - mux', created_by_user=user)
-        resp = client.get(reverse("explorer:list_queries"))
-        assert 'foo (3)' in resp.content.decode(resp.charset)
-        assert 'foo - bar2' in resp.content.decode(resp.charset)
-        assert 'qux - mux' in resp.content.decode(resp.charset)
-
     def test_run_count(self, user, client):
         q = SimpleQueryFactory(title='foo - bar1', created_by_user=user)
         for _ in range(0, 4):

--- a/test/selenium/test_selenium.py
+++ b/test/selenium/test_selenium.py
@@ -128,7 +128,7 @@ class TestDataExplorer:
         assert edit_query_on_home_page.read_result_rows() == [["1", "2", "3"]]
 
         query_log_page = edit_query_on_home_page.click_query_log()
-        assert f"Query {query_detail_page.query_id}" in query_log_page.get_html()
+        assert str(title) in query_log_page.get_html()
         assert "select 1, 2, 3" in query_log_page.get_html()
 
     def test_query_execution_logs(self, _application):
@@ -161,7 +161,7 @@ class TestDataExplorer:
         assert edit_query_on_home_page.read_result_rows() == [["1", "2", "3"]]
 
         query_log_page = edit_query_on_home_page.click_query_log()
-        assert f"Query {query_detail_page.query_id}" in query_log_page.get_html()
+        assert str(title) in query_log_page.get_html()
         assert "select 1, 2, 3" in query_log_page.get_html()
 
     def test_user_can_only_read_from_datasets_they_have_access_to(self, _application):


### PR DESCRIPTION
### Description of change
Minor updates to the Data Explorer saved queries and query log pages in line with new design by Bo.


### Old saved queries
<img width="1034" alt="Screen Shot 2020-10-13 at 10 35 38" src="https://user-images.githubusercontent.com/2920760/95843679-df933780-0d3f-11eb-9c1a-fb566f93362b.png">


### New saved queries
<img width="1035" alt="Screen Shot 2020-10-13 at 10 34 31" src="https://user-images.githubusercontent.com/2920760/95843501-af4b9900-0d3f-11eb-9984-154f5af0a3eb.png">


### Old query logs
<img width="1066" alt="Screen Shot 2020-10-13 at 10 36 05" src="https://user-images.githubusercontent.com/2920760/95843699-e6ba4580-0d3f-11eb-8397-315e381b3050.png">

### New query logs
<img width="1102" alt="Screen Shot 2020-10-13 at 10 34 39" src="https://user-images.githubusercontent.com/2920760/95843519-b377b680-0d3f-11eb-9437-444c28e456b4.png">


### Checklist

* [x] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
