### PR TITLE
adding table names into autocomplete list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-13
+
+### Added
+- Schema and table name will now be visible in Data Explorer autocomplete list, that the user has access to.
+
 ## 2020-10-12
 
 ### Changed

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -4,6 +4,7 @@
 
 {% block title %}{% if form.errors %}Error: {% endif %}Data Explorer - Home{% endblock %}
 {% block content %}
+{{ schema_tables|json_script:"schema_tables" }}
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full" id="query_area">

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -228,7 +228,7 @@ class PlayQueryView(View):
         )
         tables_columns = ['.'.join(schema_table) for schema_table, _ in schema]
         return schema, tables_columns
-        
+
     def get(self, request):
         if url_get_query_id(request):
             query = get_object_or_404(

--- a/dataworkspace/dataworkspace/static/explorer_query.js
+++ b/dataworkspace/dataworkspace/static/explorer_query.js
@@ -6,10 +6,36 @@ var editor = ace.edit("ace-sql-editor", {
   fontSize: 18,
   showLineNumbers: false,
   showGutter: false,
+  enableBasicAutocompletion: true,
   enableLiveAutocompletion: true,
   showPrintMargin: false,
   readOnly: document.getElementById('ace-sql-editor').dataset.disabled || false,
 });
+
+var table_list = JSON.parse(document.getElementById("schema_tables").textContent);
+
+var staticWordCompleter = {
+  getCompletions: function(editor, session, pos, prefix, callback) {
+      var wordList = table_list
+
+      callback(null, [...wordList.map(function(word) {
+          return {
+              caption: word,
+              value: word,
+              meta: "static"
+          };
+      }), ...session.$mode.$highlightRules.$keywordList.map(function(word) {
+          return {
+              caption: word,
+              value: word,
+              meta: 'keyword',
+          };
+      })
+    ]);
+  }
+}
+
+editor.completers = [staticWordCompleter]
 
 editor.commands.removeCommand(editor.commands.byName.indent);
 editor.commands.removeCommand(editor.commands.byName.outdent);


### PR DESCRIPTION
### Description of change
As part of Firebreak, this is an attempt to update autocomplete to include schema, table names that the user has access to.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
