### PR TITLE
fix: use POST not GET for dialog/saving queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -108,7 +108,7 @@
                     </button>
 
                     <button class="govuk-button govuk-button--secondary govuk-!-margin-left-3"
-                            data-module="govuk-button" name="action" value="save">
+                            data-module="govuk-button" name="action" value="dialog" formaction="{{ form_save_action }}">
                       Save
                     </button>
 
@@ -119,7 +119,7 @@
 
                   </div>
 
-                  <input aria-label="Title" type="govuk-visually-hidden" value="{{ form.title.value|default_if_none:"Playground Query" }}" name="title" hidden/>
+                  <input aria-label="Title" type="govuk-visually-hidden" value="{{ form.title.value|default_if_none:"" }}" name="title" hidden/>
                 </div>
               </fieldset>
 

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -6,7 +6,14 @@
 
 {% block back_button %}
   {% if backlink %}
-    <a href="{{ backlink }}" class="govuk-back-link">Back</a>
+    {% if query %}
+      {# We can't support backlinks when the query exists due to our POST-based navigation #}
+      {# If it's a pre-existing query, then if the user has edited the query and is now on the "save updates" page #}
+      {# the backlink will only hold a pointer to the current query. If this is clicked, the query from the DB #}
+      {# will be loaded, potentially discarding any changes that the user has made so far. #}
+    {% else %}
+      <a href="{{ backlink }}" class="govuk-back-link">Back</a>
+    {% endif %}
   {% endif %}
 {% endblock %}
 

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -126,7 +126,7 @@
                     <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" type="button" id="unformat_button">
                         Reset format
                     </button>
-                    <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="edit">
+                    <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="view" formaction="{% url 'explorer:index' %}{% if query.id %}?query_id={{ query.id }}{% endif %}">
                         Edit SQL
                     </button>
 

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -155,6 +155,12 @@ class TestQueryDetailView:
 
         assert '6872' not in resp.content.decode(resp.charset)
 
+    @pytest.mark.xfail(
+        reason=(
+            "A backlink with the current implementation will cause data loss when an existing query"
+            " has been edited, goes to be saved, and then the backlink is used"
+        )
+    )
     def test_renders_back_link(self, staff_user, staff_client):
         query = SimpleQueryFactory(sql='select 6870+1;', created_by_user=staff_user)
 

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -158,13 +158,18 @@ class TestQueryDetailView:
     def test_renders_back_link(self, staff_user, staff_client):
         query = SimpleQueryFactory(sql='select 6870+1;', created_by_user=staff_user)
 
-        response = staff_client.get(
+        response = staff_client.post(
             reverse("explorer:query_detail", kwargs={"query_id": query.id}),
-            {"from": "play"},
+            {
+                "action": "dialog",
+                "sql": query.sql,
+                "title": query.title,
+                "description": query.description,
+            },
         )
 
         assert (
-            f'<a href="/data-explorer/?sql=select+6870%2B1%3B&amp;query_id={query.id}" class="govuk-back-link">Back</a>'
+            f'<a href="/data-explorer/?query_id={query.id}" class="govuk-back-link">Back</a>'
             in response.content.decode(response.charset)
         )
 


### PR DESCRIPTION
### Description of change
At the moment, in Data Explorer, we pass SQL queries and related data
through query params until the user does a final POST to create a query
object. This presents a couple of problems:

1) Long queries (e.g. over 2000 chars) may be truncated or corrupted by
   some browsers which have low limits on the length of URLs/query
   params.
2) There could potentially be data protection issues with sending
   queries in the URL, as it may contain sensitive information that
   would end up being logged/retained for longer than necessary.

Let's use POST to move SQL query data between pages. This addresses the
above concerns but does introduce a few others:

* Back/forward browser navigation is not as clean - users are likely to
see 'resubmit form'-style warnings if they navigate back, because we're
showing a page directly from a POST rather than redirecting them to a
GET page (because we don't create a query object until they finally
save, so there's nothing for users to GET).
* Slightly more complex form actions, as certain buttons will override
  the main form action and be handled by a different view. This is
  obviously a minor thing.

### Checklist

* [x] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
