### PR TITLE
Move signature check to config

### DIFF
--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -38,9 +38,10 @@ RUN \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
     echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+    echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
     until apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'; do sleep 10; done && \
-    apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-    apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         build-essential=12.6 \
         git=1:2.20.1-2+deb10u3 \
         git-man=1:2.20.1-2+deb10u3 \

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -133,11 +133,11 @@ RUN \
     node /opt/conda/lib/python3.7/site-packages/jupyterlab/staging/yarn.js cache clean && \
     echo 'local({' > /opt/conda/lib/R/etc/Rprofile.site && \
     echo '  r = getOption("repos")' >> /opt/conda/lib/R/etc/Rprofile.site && \
-    echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /opt/conda/lib/R/etc/Rprofile.site && \
+    echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/"' >> /opt/conda/lib/R/etc/Rprofile.site && \
+    echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /opt/conda/lib/R/etc/Rprofile.site && \
     echo '  options(repos = r)' >> /opt/conda/lib/R/etc/Rprofile.site && \
     echo '})' >> /opt/conda/lib/R/etc/Rprofile.site && \
-    Rscript -e 'install.packages(c("tidyverse", "xml2", "base64enc", "curl", "httr", "aws.ec2metadata"), clean=TRUE)' && \
-    Rscript -e 'install.packages("aws.s3", repos = c("cloudyr" = "http://cloudyr.github.io/drat"), clean=TRUE)'
+    Rscript -e 'install.packages(c("tidyverse", "xml2", "base64enc", "curl", "httr", "aws.ec2metadata", "aws.s3"), repos="https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/", clean=TRUE)'
 
 COPY jupyter_notebook_config.py /etc/jupyter/jupyter_notebook_config.py
 

--- a/jupyterlab-r/Dockerfile
+++ b/jupyterlab-r/Dockerfile
@@ -38,9 +38,10 @@ RUN \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
     echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+    echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
     until apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'; do sleep 10; done && \
-    apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-    apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         build-essential=12.6 \
         gfortran=4:8.3.0-1 \
         git=1:2.20.1-2+deb10u3 \

--- a/mirrors-sync-cran-binary/Dockerfile
+++ b/mirrors-sync-cran-binary/Dockerfile
@@ -22,10 +22,11 @@ RUN \
 	rm -rf /var/lib/apt/lists/* && \
 	echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
 	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
 	until apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'; do sleep 10; done && \
 	rm -rf /var/lib/apt/lists/* && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
 		gdebi-core=0.9.5.7+nmu3 \
 		gfortran=4:8.3.0-1 \
 		git=1:2.20.1-2+deb10u3 \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -10,8 +10,9 @@ RUN \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian-security/ buster/updates main" >> /etc/apt/sources.list && \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
-	apt-get update -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 && \
-	apt-get install -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 -y --no-install-recommends \
+	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
 		locales=2.28-10 && \
 	echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
 	locale-gen en_US.utf8 && \
@@ -29,8 +30,8 @@ ENV \
 COPY exploretiva /exploretiva
 
 RUN \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
 		ca-certificates \
 		dirmngr \
 		gnupg2 && \
@@ -41,8 +42,8 @@ RUN \
 	apt-get autoclean -y && \
 	rm -rf /tmp/* && \
 	rm -rf /var/lib/apt/lists/* && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
 		gdebi-core=0.9.5.7+nmu3 \
 		gfortran=4:8.3.0-1 \
 		git=1:2.20.1-2+deb10u3 \

--- a/visualisation-base-r/Dockerfile
+++ b/visualisation-base-r/Dockerfile
@@ -22,10 +22,11 @@ RUN \
 	rm -rf /var/lib/apt/lists/* && \
 	echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
 	echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
+	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf && \
 	until apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'; do sleep 10; done && \
 	rm -rf /var/lib/apt/lists/* && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 update && \
-	apt-get -o Acquire::Check-Valid-Until=false -o Acquire::Retries=10 install -y --no-install-recommends \
+	apt-get update && \
+	apt-get install -y --no-install-recommends \
 		r-base=3.6.1-2~bustercran.0 \
 		r-base-dev=3.6.1-2~bustercran.0 \
 		r-recommended=3.6.1-2~bustercran.0 && \

--- a/visualisation-base/Dockerfile
+++ b/visualisation-base/Dockerfile
@@ -21,4 +21,5 @@ RUN \
 		gnupg2 && \
 	rm -rf /var/lib/apt/lists/* && \
 	echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
-	echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list
+	echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
+	echo "Acquire{Check-Valid-Until false; Retries 10;}" >> /etc/apt/apt.conf


### PR DESCRIPTION
### Description of change

As we are using a custom debian mirrror we currently disable the check which verifies expired digital signatures.

This PR moves this option to the apt config rather than setting it every time we call apt-get commands.

The docker images affected were all built successfully on my local machine after making the change.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
