### PR TITLE
feat: use shared data infrastructure dev network

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -52,3 +52,7 @@ services:
 
 volumes:
   db-data-dev:
+  
+networks:
+  default:
+    name: data-infrastructure-shared-network


### PR DESCRIPTION
### Description of change
When running Data Workspace through docker-compose-dev, we may want to
be able to connect to other Data Infrastructure services such as
data-flow or data-store-service. Not aware of a current use-case for
this, but there are for other of our services to talk together, so doing
this to be consistent.