### PR TITLE
Revert "fix: use POST not GET for dialog/saving queries"

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -108,7 +108,7 @@
                     </button>
 
                     <button class="govuk-button govuk-button--secondary govuk-!-margin-left-3"
-                            data-module="govuk-button" name="action" value="dialog" formaction="{{ form_save_action }}">
+                            data-module="govuk-button" name="action" value="save">
                       Save
                     </button>
 
@@ -119,7 +119,7 @@
 
                   </div>
 
-                  <input aria-label="Title" type="govuk-visually-hidden" value="{{ form.title.value|default_if_none:"" }}" name="title" hidden/>
+                  <input aria-label="Title" type="govuk-visually-hidden" value="{{ form.title.value|default_if_none:"Playground Query" }}" name="title" hidden/>
                 </div>
               </fieldset>
 

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -6,14 +6,7 @@
 
 {% block back_button %}
   {% if backlink %}
-    {% if query %}
-      {# We can't support backlinks when the query exists due to our POST-based navigation #}
-      {# If it's a pre-existing query, then if the user has edited the query and is now on the "save updates" page #}
-      {# the backlink will only hold a pointer to the current query. If this is clicked, the query from the DB #}
-      {# will be loaded, potentially discarding any changes that the user has made so far. #}
-    {% else %}
-      <a href="{{ backlink }}" class="govuk-back-link">Back</a>
-    {% endif %}
+    <a href="{{ backlink }}" class="govuk-back-link">Back</a>
   {% endif %}
 {% endblock %}
 
@@ -133,7 +126,7 @@
                     <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" type="button" id="unformat_button">
                         Reset format
                     </button>
-                    <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="view" formaction="{% url 'explorer:index' %}{% if query.id %}?query_id={{ query.id }}{% endif %}">
+                    <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="edit">
                         Edit SQL
                     </button>
 

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -170,23 +170,6 @@ class CreateQueryView(CreateView):
     def post(self, request, *args, **kwargs):
         action = request.POST.get('action', '')
 
-        if action == 'dialog':
-            # This represents the 'dialog' box for creating a query when clicking 'save' from the playground.
-            context_data = {}
-
-            sql = self.request.POST.get("sql")
-            if sql:
-                context_data['disable_sql'] = True
-
-            query_params = (('sql', request.POST.get('sql')),)
-            context_data['backlink'] = (
-                reverse("explorer:index") + f"?{urlencode(query_params)}"
-            )
-            context_data['form'] = self.get_form()
-            context_data['form'].errors.clear()
-
-            return render(request, self.template_name, context_data)
-
         if action == 'save':
             ret = super().post(request)
             if self.get_form().is_valid():
@@ -216,6 +199,12 @@ class CreateQueryView(CreateView):
                 )
 
             return ret
+
+        elif action == 'edit':
+            query_params = (('sql', request.POST.get('sql')),)
+            return HttpResponseRedirect(
+                reverse('explorer:index') + f"?{urlencode(query_params)}"
+            )
 
         else:
             return HttpResponse(f"Unknown form action: {action}", 400)
@@ -262,7 +251,6 @@ class PlayQueryView(View):
                 'title': 'Playground',
                 'form': QueryForm(initial={"sql": request.GET.get('sql')}),
                 'form_action': self.get_form_action(request),
-                'form_save_action': self.get_form_save_action(request),
                 'schema': schema,
                 'schema_tables': tables_columns,
             },
@@ -305,13 +293,9 @@ class PlayQueryView(View):
                 reverse('explorer:query_create') + f"?{urlencode(query_params)}"
             )
 
-        elif action in {'view', 'run', 'fetch-page'}:
-            run_query = action != 'view'
-
+        elif action in {'run', 'fetch-page'}:
             query.params = url_get_params(request)
-            response = self.render_with_sql(
-                request, query, run_query=run_query, log=run_query
-            )
+            response = self.render_with_sql(request, query, run_query=True, log=True)
 
             return response
 
@@ -333,27 +317,6 @@ class PlayQueryView(View):
 
         return form_action
 
-    def get_form_save_action(self, request, query=None):
-        form_action_params = urlencode(
-            tuple(
-                (k, v)
-                for k, v in request.GET.items()
-                if k not in {'sql', 'querylog_id'}
-            )
-        )
-
-        if query:
-            form_action = reverse(
-                'explorer:query_detail', kwargs={"query_id": query.id}
-            )
-
-        else:
-            form_action = reverse('explorer:query_create')
-            if form_action_params:
-                form_action += "?" + form_action_params
-
-        return form_action
-
     def render_with_sql(self, request, query, run_query=True, log=False):
         rows = url_get_rows(request)
         page = url_get_page(request)
@@ -366,10 +329,6 @@ class PlayQueryView(View):
         # loading the old saved query SQL, and we do that by passing the new SQL through as a query param.
         if request.method == 'GET' and request.GET.get('sql'):
             form.initial['sql'] = request.GET.get('sql')
-
-        # Remove any validation errors - we aren't interested in these from the playground.
-        # SQL syntax errors are added during `query_viewmodel`.
-        form.errors.clear()
 
         context = query_viewmodel(
             request.user,
@@ -385,9 +344,6 @@ class PlayQueryView(View):
         context['schema'] = schema
         context['schema_tables'] = tables_columns
         context['form_action'] = self.get_form_action(request)
-        context['form_save_action'] = self.get_form_save_action(
-            request, query=query if query.id else None
-        )
         return render(self.request, 'explorer/home.html', context)
 
 
@@ -395,33 +351,25 @@ class QueryView(View):
     def get(self, request, query_id):
         query, form = QueryView.get_instance_and_form(request, query_id)
         query.save()  # updates the modified date
+
+        # Overwrite SQL form field from GET query parameter (sent when saving an existing query from the playground).
+        sql = request.GET.get("sql")
+        if sql:
+            form.initial['sql'] = sql
+
         context = {'form': form, 'query': query}
+        if request.GET.get("from") == "play":
+            query_params = (('sql', form.initial['sql']), ('query_id', query.id))
+            context['backlink'] = (
+                reverse("explorer:index") + f"?{urlencode(query_params)}"
+            )
+
         return render(self.request, 'explorer/query.html', context)
 
     def post(self, request, query_id):
         action = request.POST.get("action", "")
 
-        if action == 'dialog':
-            # This represents the 'dialog' box for updating a query when clicking 'save' from the playground (when
-            # editing a query that has been previously saved).
-            # It shows the user the query but does not save it - they need to click 'save' on this page to persist
-            # the update.
-            show = url_get_show(request)
-            query, form = QueryView.get_instance_and_form(request, query_id)
-            form.errors.clear()
-            vm = query_viewmodel(
-                request.user,
-                query,
-                form=form,
-                run_query=show,
-                rows=url_get_rows(request),
-                page=url_get_page(request),
-            )
-            vm['backlink'] = reverse("explorer:index") + f"?query_id={query.id}"
-            return render(self.request, 'explorer/query.html', vm)
-
-        elif action == 'save':
-            # User has confirmed they want to save the query - commit the updates to DB.
+        if action == 'save':
             show = url_get_show(request)
             query, form = QueryView.get_instance_and_form(request, query_id)
             success = form.is_valid() and form.save()
@@ -437,9 +385,8 @@ class QueryView(View):
             return render(self.request, 'explorer/query.html', vm)
 
         elif action == 'edit':
-            # User wants to run/edit the query again - send them to the "playground"/home page.
             query, form = QueryView.get_instance_and_form(request, query_id)
-            query_params = (('query_id', query.id),)
+            query_params = (('query_id', query.id), ('sql', request.POST.get('sql')))
             return HttpResponseRedirect(
                 reverse('explorer:index') + f"?{urlencode(query_params)}"
             )

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -155,27 +155,16 @@ class TestQueryDetailView:
 
         assert '6872' not in resp.content.decode(resp.charset)
 
-    @pytest.mark.xfail(
-        reason=(
-            "A backlink with the current implementation will cause data loss when an existing query"
-            " has been edited, goes to be saved, and then the backlink is used"
-        )
-    )
     def test_renders_back_link(self, staff_user, staff_client):
         query = SimpleQueryFactory(sql='select 6870+1;', created_by_user=staff_user)
 
-        response = staff_client.post(
+        response = staff_client.get(
             reverse("explorer:query_detail", kwargs={"query_id": query.id}),
-            {
-                "action": "dialog",
-                "sql": query.sql,
-                "title": query.title,
-                "description": query.description,
-            },
+            {"from": "play"},
         )
 
         assert (
-            f'<a href="/data-explorer/?query_id={query.id}" class="govuk-back-link">Back</a>'
+            f'<a href="/data-explorer/?sql=select+6870%2B1%3B&amp;query_id={query.id}" class="govuk-back-link">Back</a>'
             in response.content.decode(response.charset)
         )
 


### PR DESCRIPTION
Reverts uktrade/data-workspace#1023

Going to install a temporary query model so that we:

1) use post-redirect-get to avoid back/forward navigation prompting the user to resubmit the form
2) ensure that SQL is preserved even when using backlinks from the 'save query' dialog page.