### PR TITLE
fix: set the cran mirror repos in Rprofile.site

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -88,7 +88,12 @@ RUN \
 	echo 'www-port=8888' >> /etc/rstudio/rserver.conf && \
 	echo 'auth-none=1' >> /etc/rstudio/rserver.conf && \
 	echo 'server-daemonize=0' >> /etc/rstudio/rserver.conf && \
-	rm /usr/lib/R/etc/Rprofile.site && \
+	echo 'local({' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  r = getOption("repos")' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  r["CRAN"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/"' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  r["CRAN_1"] = "https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/"' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '  options(repos = r)' >> /usr/lib/R/etc/Rprofile.site && \
+	echo '})' >> /usr/lib/R/etc/Rprofile.site && \
 	echo 'CRAN=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran-binary/' >> /etc/rstudio/repos.conf && \
 	echo 'CRAN_1=https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/cran/' >> /etc/rstudio/repos.conf && \
 	Rscript -e 'install.packages("/exploretiva", repos=NULL, type="source")' && \


### PR DESCRIPTION
This needs to be set in Rprofile.site in addition to setting it in repos.conf to support both RStudio environment sessions and normal sessions

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
