### PR TITLE
Tweak Data Explorer query detail page

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -32,14 +32,20 @@
                     </div>
                 </div>
             {% endif %}
-            <h1 class="govuk-heading-m govuk-!-margin-bottom-2">
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
                 {% if query %}
                     {{ query.title }}
-                    <a class="govuk-link" href="{% url 'explorer:explorer_logs' %}?query_id={{ query.id }}">History</a>
                 {% else %}
                     New Query
                 {% endif %}
             </h1>
+
+            {% if not backlink %}
+            <p class="govuk-body">
+                <a class="govuk-link" href="{% url 'explorer:explorer_logs' %}?query_id={{ query.id }}">View logs for this query</a>
+            </p>
+            {% endif %}
+
             <fieldset class="govuk-fieldset">
                 {% if message %}
                     <div class="govuk-warning-text">


### PR DESCRIPTION
* only show 'query logs' link when viewing a query (not when
  editing/saving an update to a query).
* move the query logs link onto it's own line and give it slightly
  clearer content.
* increase the size of the title on the query detail page
* don't show backlink on query detail page