### PR TITLE
fix: pgAdmin not properly starting when in a new tab

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/tool_section.html
+++ b/dataworkspace/dataworkspace/templates/partials/tool_section.html
@@ -36,7 +36,7 @@
           </form>
         </div>
         <div class="govuk-grid-column-one-half">
-          <form action="{{ application_url }}" method="GET" style="display: inline-block" class="govuk-!-width-full" target="_blank">
+          <form action="{{ application_url }}" method="GET" style="display: inline-block" class="govuk-!-width-full" target="_blank" rel="noopener">
             <button class="govuk-button govuk-button--secondary govuk-!-width-full">Open {{ application_name }}</button>
           </form>
         </div>
@@ -44,7 +44,7 @@
     {% else %}
       <div class="govuk-grid-row">
         {% if customisable_instance %}
-          <form action="{{ application_url }}" method="GET" style="display: inline-block" class="govuk-!-width-full" target="_blank">
+          <form action="{{ application_url }}" method="GET" style="display: inline-block" class="govuk-!-width-full" target="_blank" rel="noopener">
             <div class="govuk-grid-column-one-half">
               <div class="govuk-form-group inline-form-group">
                 <select class="govuk-select" id="sort" name="__memory_cpu">
@@ -64,7 +64,7 @@
             <p class="govuk-body"></p>
           </div>
           <div class="govuk-grid-column-one-half">
-            <a class="govuk-button govuk-button--secondary govuk-!-width-full" href="{{ application_url }}" target="_blank">Open {{ application_name }}</a>
+            <a class="govuk-button govuk-button--secondary govuk-!-width-full" href="{{ application_url }}" target="_blank" rel="noopener">Open {{ application_name }}</a>
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
### Description of change

Suspect it's due to https://github.com/postgres/pgadmin4/blob/REL-4_8/web/pgadmin/browser/static/js/layout.js#L77 which raises an exception when window.opener is present, but from a different domain.

> DOMException: Blocked a frame with origin [...] from accessing a cross-origin frame

It looks like it's fixed in more recent versions of pgAdmin, https://github.com/postgres/pgadmin4/blob/80ab5969920b1b258c4bb52020badbc67cf805ab/web/pgadmin/static/js/window.js#L14, but I think better for that to be a last resort since there could be UI changes.

It looks like IE11 doesn't support `rel="noopener"` https://caniuse.com/?search=noopener . However, it looks like window.opener is not set in IE for cross domains, so it doesn't need this fix https://stackoverflow.com/q/18625733/1319998

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
