### PR TITLE
feat: allow sql query box to grow in height

### DIFF
--- a/dataworkspace/dataworkspace/static/explorer_query.js
+++ b/dataworkspace/dataworkspace/static/explorer_query.js
@@ -1,7 +1,7 @@
 var editor = ace.edit("ace-sql-editor", {
   mode: "ace/mode/sql",
   theme: "ace/theme/chrome",
-  maxLines: 10,
+  maxLines: 75,
   minLines: 10,
   fontSize: 18,
   showLineNumbers: false,


### PR DESCRIPTION
### Description of change
At the moment the SQL box of the Data Explorer is limited strictly to 10
rows. Let's allow this to grow dynamically as user's type in longer
queries - up to 75 lines max - as the limited height of the box has been
raised as a pain point by some of our current users.

### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
