### PR TITLE
fix: semantic separation between debug and local

### DIFF
--- a/.envs/test.env
+++ b/.envs/test.env
@@ -1,4 +1,5 @@
 # Static: as in Dockerfile
+DEBUG=False
 PYTHONPATH=/dataworkspace
 DJANGO_SETTINGS_MODULE=dataworkspace.settings.base
 # Dynamic=proxy and app settings populated at runtime

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -21,7 +21,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 ENVIRONMENT = env.get("ENVIRONMENT", "Dev")
 SECRET_KEY = env['SECRET_KEY']
-DEBUG = 'dataworkspace.test' in env['ALLOWED_HOSTS']
+LOCAL = 'dataworkspace.test' in env['ALLOWED_HOSTS']
+DEBUG = bool(strtobool(env.get('DEBUG', str(LOCAL))))
 
 
 def aws_fargate_private_ip():
@@ -33,11 +34,11 @@ def aws_fargate_private_ip():
 
 ALLOWED_HOSTS = (
     (env['ALLOWED_HOSTS'])
-    if DEBUG
+    if LOCAL
     else (env['ALLOWED_HOSTS'] + [aws_fargate_private_ip()])
 )
 
-INTERNAL_IPS = ['127.0.0.1'] if DEBUG else []
+INTERNAL_IPS = ['127.0.0.1'] if LOCAL else []
 
 ELASTIC_APM_URL = env.get("ELASTIC_APM_URL")
 ELASTIC_APM_SECRET_TOKEN = env.get("ELASTIC_APM_SECRET_TOKEN")
@@ -47,7 +48,6 @@ ELASTIC_APM = (
         'SECRET_TOKEN': ELASTIC_APM_SECRET_TOKEN,
         'SERVER_URL': ELASTIC_APM_URL,
         'ENVIRONMENT': env.get('ENVIRONMENT', 'development'),
-        # 'DEBUG': True,  # Allow APM to send metrics when Django is in debug mode
     }
     if ELASTIC_APM_SECRET_TOKEN
     else {}
@@ -188,11 +188,11 @@ CACHES = {
 SESSION_COOKIE_NAME = 'data_workspace_session'
 root_domain_no_port, _, _ = env['APPLICATION_ROOT_DOMAIN'].partition(':')
 SESSION_COOKIE_DOMAIN = root_domain_no_port
-SESSION_COOKIE_SECURE = not DEBUG
+SESSION_COOKIE_SECURE = not LOCAL
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 SESSION_CACHE_ALIAS = 'default'
 
-CSRF_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not LOCAL
 CSRF_COOKIE_NAME = 'data_workspace_csrf'
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
@@ -209,7 +209,7 @@ APPLICATION_SPAWNER_OPTIONS = env.get('APPLICATION_SPAWNER_OPTIONS', {})
 # CSP Headers
 CSP_DEFAULT_SRC = [APPLICATION_ROOT_DOMAIN]
 CSP_OBJECT_SRC = ["'none'"]
-CSP_UPGRADE_INSECURE_REQUESTS = not DEBUG
+CSP_UPGRADE_INSECURE_REQUESTS = not LOCAL
 CSP_BASE_URI = [APPLICATION_ROOT_DOMAIN]
 CSP_FONT_SRC = [APPLICATION_ROOT_DOMAIN, 'data:', 'https://fonts.gstatic.com']
 CSP_FORM_ACTION = [APPLICATION_ROOT_DOMAIN, f'*.{APPLICATION_ROOT_DOMAIN}']

--- a/dataworkspace/start.py
+++ b/dataworkspace/start.py
@@ -2,8 +2,6 @@
 # pylint: disable=multiple-statements,wrong-import-position,wrong-import-order
 
 # fmt: off
-import os
-
 from gevent import monkey; monkey.patch_all()  # noqa: E402,E702
 from psycogreen.gevent import patch_psycopg; patch_psycopg()  # noqa: E402,E702
 # fmt: on
@@ -12,6 +10,7 @@ from psycogreen.gevent import patch_psycopg; patch_psycopg()  # noqa: E402,E702
 
 import signal
 
+from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 from django.utils.autoreload import run_with_reloader
 import gevent
@@ -31,7 +30,7 @@ def run_server():
     print('Requests completed. Exiting gracefully.', flush=True)
 
 
-if os.environ.get('DEBUG') == 'True':
+if settings.DEBUG is True and settings.LOCAL is True:
     print('Running in DEBUG mode with hot reloader')
     run_with_reloader(run_server)
 else:


### PR DESCRIPTION
### Description of change
We use the `debug` Django setting to configure Django for running
locally, but it should be possible to run the app not in debug mode when
running it locally. This patch separates out the setting for running in
debug mode from a setting that confirms we're running locally, so that
various settings can be tied to the correct semantic check.
