### PR TITLE
feat: bump pgAdmin to 4.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2020-10-27
+
+### Changed
+
+- Version of pgAdmin to work when opened in a new tab
+
 ## 2020-10-23
 
 ### Changed

--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -1,4 +1,4 @@
-FROM dpage/pgadmin4:4.8
+FROM dpage/pgadmin4:4.27
 
 ENV \
 	PGADMIN_LISTEN_ADDRESS=0.0.0.0 \
@@ -7,3 +7,9 @@ ENV \
 	PGADMIN_DEFAULT_PASSWORD=test
 
 COPY pgadmin-config.py /pgadmin4/config_local.py
+
+USER root
+RUN \
+	touch /pgadmin4/.pgpass /pgadmin4/servers.json && \
+	chown pgadmin:pgadmin /pgadmin4/.pgpass /pgadmin4/servers.json
+USER pgadmin

--- a/pgadmin/pgadmin-config.py
+++ b/pgadmin/pgadmin-config.py
@@ -117,7 +117,7 @@ env = normalise_environment(os.environ)
 
 servers = {}
 passwords = []
-passfile = '/root/.pgpass'
+passfile = '/pgadmin4/.pgpass'
 
 for i, (name, dsn) in enumerate(env['DATABASE_DSN'].items()):
     user = re.search(r'user=([a-z0-9_]+)', dsn).groups()[0]


### PR DESCRIPTION
### Description of change

This is done to fix the error

> DOMException: Blocked a frame with origin [...] from accessing a cross-origin frame

that prevents pgAdmin from fully loading when started in a new tab.

Suspect it's due to https://github.com/postgres/pgadmin4/blob/REL-4_8/web/pgadmin/browser/static/js/layout.js#L77 which raises an exception when window.opener is present, but from a different domain.

This appears fixed in recent version of pgAdmin, since the code that throws the exception is wrapped in a try/except block
https://github.com/postgres/pgadmin4/blob/80ab5969920b1b258c4bb52020badbc67cf805ab/web/pgadmin/static/js/window.js#L14,

It was investigated to use `rel="noopener"` on the `form` element, but this only works on `a` elements. In a future version, we may be able to use `a` elements that have `rel="noopener"` on them, so have a more consistent tool environment.

### Checklist

* [ ] Have tests been added to cover any changes?
* [x] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
