### PR TITLE
Related data custom queries

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -148,6 +148,30 @@
         </div>
     </div>
 
+    {% if related_tables %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">Related data</h2>        
+            <div class="govuk-grid-row">
+                {% for master in related_masters %}
+                    <div class="govuk-grid-column-{% if related_tables|length == 1 %}two-thirds{% else %}one-third{% endif %}">
+                        <div class="govuk-body">
+                            <span class="govuk-caption-m">Master dataset</span>
+                            <h3 class="govuk-heading-m">{{ master.name }}</h3>
+                            <p>{{ master.short_description | truncatechars:225 }}</p>
+                            <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=master.id %}#{{ master.slug }}">Visit page</a>
+                        </div>
+                    </div>
+                    {% if forloop.counter|divisibleby:3 %}
+                        </div>
+                        <div class="govuk-grid-row">
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    
     {% if visualisation_src %}
     <h2 class="govuk-heading-l govuk-!-margin-top-8">Visualisation</h2>
       <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="vis" ></iframe>


### PR DESCRIPTION
### Description of change
This PR enables the catalogue page to show related master datasets for a given datacut. Custom queries are the only datacuts dealt with for the moment. Source views, Source tables and Source links need a different implementation and will be dealt with in subsequent tasks.

If there is one master dataset, it will be shown in two-thirds format. 
![image](https://user-images.githubusercontent.com/1433053/97453581-cb4d5e00-192d-11eb-8d6f-b8ef8ae0df4f.png)

If there are more, then 3 are shown in each row.
![image](https://user-images.githubusercontent.com/1433053/97453708-e8822c80-192d-11eb-83d1-91655b5a63e6.png)


### Checklist

* [ ] Have tests been added to cover any changes?
* [ ] Has the [CHANGELOG](https://github.com/uktrade/data-workspace/blob/master/CHANGELOG.md) been updated?
