### PR TITLE
Duplicate related masters fix

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -549,7 +549,7 @@ class DatasetDetailView(DetailView):
                 'visualisation_src': dashboard_url,
                 'custom_dataset_query_type': DataLinkType.CUSTOM_QUERY.value,
                 'source_table_type': DataLinkType.SOURCE_TABLE.value,
-                'related_masters': related_masters,
+                'related_masters': set(related_masters),
             }
         )
         return ctx

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1359,7 +1359,9 @@ class TestCustomQueryRelatedDataView:
         indirect=["request_client"],
     )
     @pytest.mark.django_db
-    def test_related_dataset_duplicate_masters(self, request_client, published, status):
+    def test_related_dataset_does_not_duplicate_masters(
+        self, request_client, published, status
+    ):
         self._setup_new_table()
         master1 = factories.DataSetFactory.create(
             published=published,


### PR DESCRIPTION
### Description of change
This PR fixes a bug where duplicate master datasets may appear in some situations where a datacut is made up of custom sql that queries two tables, and then a master dataset provides both of those two tables.

### Checklist

* [ ] Have tests been added to cover any changes?
