### PR TITLE
feat: log when users view visualisations

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -45,6 +45,7 @@ from dataworkspace.apps.applications.utils import (
     application_options,
     get_quicksight_dashboard_name_url,
     sync_quicksight_permissions,
+    log_visualisation_view,
 )
 from dataworkspace.apps.applications.spawner import get_spawner
 from dataworkspace.apps.applications.utils import stop_spawner_and_application
@@ -61,6 +62,7 @@ from dataworkspace.apps.datasets.models import (
     VisualisationUserPermission,
     VisualisationLink,
 )
+from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.notify import decrypt_token, send_email
 from dataworkspace.utils import DATA_EXPLORER_FLAG
 from dataworkspace.zendesk import update_zendesk_ticket
@@ -274,8 +276,18 @@ def visualisation_link_html_view(request, link_id):
 
     identifier = visualisation_link.identifier
     if visualisation_link.visualisation_type == 'QUICKSIGHT':
+        log_visualisation_view(
+            visualisation_link,
+            request.user,
+            event_type=EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
+        )
         return _get_embedded_quicksight_dashboard(request, identifier)
     elif visualisation_link.visualisation_type == 'DATASTUDIO':
+        log_visualisation_view(
+            visualisation_link,
+            request.user,
+            event_type=EventLog.TYPE_VIEW_DATASTUDIO_VISUALISATION,
+        )
         return redirect(identifier)
 
     return HttpResponse(

--- a/dataworkspace/dataworkspace/apps/eventlog/models.py
+++ b/dataworkspace/dataworkspace/apps/eventlog/models.py
@@ -23,6 +23,8 @@ class EventLog(models.Model):
     TYPE_GRANTED_VISUALISATION_PERMISSION = 14
     TYPE_REVOKED_VISUALISATION_PERMISSION = 15
     TYPE_SET_DATASET_USER_ACCESS_TYPE = 16
+    TYPE_VIEW_QUICKSIGHT_VISUALISATION = 17
+    TYPE_VIEW_DATASTUDIO_VISUALISATION = 18
 
     _TYPE_CHOICES = (
         (TYPE_DATASET_SOURCE_LINK_DOWNLOAD, 'Dataset source link download'),
@@ -41,6 +43,8 @@ class EventLog(models.Model):
         (TYPE_GRANTED_VISUALISATION_PERMISSION, 'Granted visualisation permission'),
         (TYPE_REVOKED_VISUALISATION_PERMISSION, 'Revoked visualisation permission'),
         (TYPE_SET_DATASET_USER_ACCESS_TYPE, 'Set dataset user access type'),
+        (TYPE_VIEW_QUICKSIGHT_VISUALISATION, 'View AWS QuickSight visualisation'),
+        (TYPE_VIEW_DATASTUDIO_VISUALISATION, 'View Google DataStudio visualisation'),
     )
     user = models.ForeignKey(
         get_user_model(), on_delete=models.DO_NOTHING, related_name='events'


### PR DESCRIPTION
### Description of change
Add entries to our event log when users view (quicksight and datastudio)
visualisations so that we can understand how users are interacting with
our catalogue and which visualisations are popular/not. The eventlog is
automatically scraped by data-flow and returned to workspace as a master
dataset, so no further action needed for this.

### Checklist

* [x] Have tests been added to cover any changes?
