### PR TITLE
fix: match uuids in url paths for catalogue views

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -6,57 +6,57 @@ from dataworkspace.apps.datasets import views
 urlpatterns = [
     path('', login_required(views.find_datasets), name='find_datasets'),
     path(
-        '<str:dataset_uuid>',
+        '<uuid:dataset_uuid>',
         login_required(views.DatasetDetailView.as_view()),
         name='dataset_detail',
     ),
     path(
-        '<str:dataset_uuid>/link/<str:source_link_id>/download',
+        '<uuid:dataset_uuid>/link/<uuid:source_link_id>/download',
         login_required(views.SourceLinkDownloadView.as_view()),
         name='dataset_source_link_download',
     ),
     path(
-        '<str:dataset_uuid>/view/<str:source_id>/download',
+        '<uuid:dataset_uuid>/view/<uuid:source_id>/download',
         login_required(views.SourceViewDownloadView.as_view()),
         name='dataset_source_view_download',
     ),
     path(
-        '<str:dataset_uuid>/query/<int:query_id>/download',
+        '<uuid:dataset_uuid>/query/<int:query_id>/download',
         login_required(views.CustomDatasetQueryDownloadView.as_view()),
         name='dataset_query_download',
     ),
     path(
-        '<str:dataset_uuid>/query/<int:query_id>/preview',
+        '<uuid:dataset_uuid>/query/<int:query_id>/preview',
         login_required(views.CustomDatasetQueryPreviewView.as_view()),
         name='dataset_query_preview',
     ),
     path(
-        '<str:dataset_uuid>/table/<str:table_uuid>/preview',
+        '<uuid:dataset_uuid>/table/<uuid:table_uuid>/preview',
         login_required(views.SourceTablePreviewView.as_view()),
         name='dataset_table_preview',
     ),
     path(
-        '<str:dataset_uuid>/reference/<str:format>/download',
+        '<uuid:dataset_uuid>/reference/<str:format>/download',
         login_required(views.ReferenceDatasetDownloadView.as_view()),
         name='reference_dataset_download',
     ),
     path(
-        '<str:dataset_uuid>/eligibility-criteria',
+        '<uuid:dataset_uuid>/eligibility-criteria',
         login_required(views.eligibility_criteria_view),
         name='eligibility_criteria',
     ),
     path(
-        '<str:dataset_uuid>/eligibility-criteria-not-met',
+        '<uuid:dataset_uuid>/eligibility-criteria-not-met',
         login_required(views.eligibility_criteria_not_met_view),
         name='eligibility_criteria_not_met',
     ),
     path(
-        '<str:dataset_uuid>/request-access',
+        '<uuid:dataset_uuid>/request-access',
         login_required(views.request_access_view),
         name='request_access',
     ),
     path(
-        '<str:dataset_uuid>/request-access-success',
+        '<uuid:dataset_uuid>/request-access-success',
         login_required(views.request_access_success_view),
         name='request_access_success',
     ),

--- a/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
@@ -271,6 +271,11 @@ class TestDatasetViews:
         response = client.get(ds.get_absolute_url())
         assert response.status_code == 404
 
+    @pytest.mark.django_db
+    def test_dataset_detail_view_invalid_uuid(self, client):
+        response = client.get('/datasets/0c2825e1')
+        assert response.status_code == 404
+
     @override_settings(DEBUG=False, GTM_CONTAINER_ID="test")
     @pytest.mark.parametrize(
         'factory',


### PR DESCRIPTION
This fix ensures a 404 is returned if an invalid uuid is provided in a url. Without this fix a validation error is thrown.

E.g. https://sentry.ci.uktrade.digital/dit/data-workspace/issues/27049/activity/