### PR TITLE
test: check no migrations are missing in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ jobs:
       - <<: *prepare-docker-cache
       - <<: *save-docker-cache
       - run:
+          name: Check all migrations have been generated
+          command: make docker-check-migrations
+      - run:
           name: Run test
           command: |
             touch .envs/dev.env

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ docker-clean:
 check-flake8:
 	flake8 .
 
+.PHONY: docker-check-migrations
+docker-check-migrations:
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test sh -c "sleep 5 && django-admin makemigrations --check --dry-run"
+
 .PHONY: check-black
 check-black:
 	black --exclude=venv --skip-string-normalization --check .


### PR DESCRIPTION
### Description of change
Sometimes developers (or at least, me) forget to run `django-admin
makemigrations` for minor model changes. Let's use our CI to check that
there aren't any pending model migrations that need to be generated so
that this is less likely to get merged into master.