### PR TITLE
fix: log events explicitly

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/models.py
+++ b/dataworkspace/dataworkspace/apps/explorer/models.py
@@ -6,15 +6,13 @@ from time import time
 
 from dynamic_models.models import AbstractFieldSchema, AbstractModelSchema  # noqa: I202
 from django.conf import settings
-from django.db import DatabaseError, models, transaction
+from django.db import DatabaseError, models
 
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse
 
-from dataworkspace.apps.eventlog.models import EventLog
-from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.apps.explorer.utils import (
     extract_params,
     get_params_for_url,
@@ -135,24 +133,6 @@ class Query(models.Model):
         )
         ql.save()
         return ql
-
-    @transaction.atomic
-    def save(
-        self, force_insert=False, force_update=False, using=None, update_fields=None
-    ):
-        super().save(
-            force_insert=force_insert,
-            force_update=force_update,
-            using=using,
-            update_fields=update_fields,
-        )
-
-        log_event(
-            self.created_by_user,
-            EventLog.TYPE_DATA_EXPLORER_SAVED_QUERY,
-            related_object=self,
-            extra={"sql": self.sql},
-        )
 
 
 class QueryLog(models.Model):

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -17,6 +17,8 @@ from django.views.generic import ListView
 from django.views.generic.base import View
 from django.views.generic.edit import CreateView, DeleteView
 
+from dataworkspace.apps.eventlog.models import EventLog
+from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.apps.explorer.exporters import get_exporter_class
 from dataworkspace.apps.explorer.forms import QueryForm
 from dataworkspace.apps.explorer.models import Query, QueryLog, PlaygroundSQL
@@ -215,6 +217,12 @@ class CreateQueryView(CreateView):
                     return render(request, self.template_name, vm)
 
                 messages.success(request, "Your query has been saved.")
+                log_event(
+                    request.user,
+                    EventLog.TYPE_DATA_EXPLORER_SAVED_QUERY,
+                    related_object=query,
+                    extra={"sql": query.sql},
+                )
                 return HttpResponseRedirect(
                     reverse_lazy(
                         'explorer:query_detail', kwargs={'query_id': self.object.id}
@@ -418,6 +426,12 @@ class QueryView(View):
             )
             if success:
                 messages.success(request, "Your query has been updated.")
+                log_event(
+                    request.user,
+                    EventLog.TYPE_DATA_EXPLORER_SAVED_QUERY,
+                    related_object=query,
+                    extra={"sql": query.sql},
+                )
                 return redirect(
                     reverse('explorer:query_detail', kwargs={"query_id": query.id})
                 )


### PR DESCRIPTION
Creating and saving a query results in multiple calls to `save`, which
ends up logging multiple events for a single query save. Instead of
hooking into that method, let's explicitly log events at specific points
in the request.