### PR TITLE
Adding sort feature to dataset browser

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -38,6 +38,22 @@ class FilterWidget(forms.widgets.CheckboxSelectMultiple):
         js = ('app-filter-show-more-v2.js',)
 
 
+class SortSelectWidget(forms.widgets.Select):
+    template_name = 'datasets/select.html'
+    option_template_name = 'datasets/select_option.html'
+
+    def __init__(
+        self, label, *args, **kwargs,  # pylint: disable=keyword-arg-before-vararg
+    ):
+        super().__init__(*args, **kwargs)
+        self._label = label
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context['widget']['label'] = self._label
+        return context
+
+
 class RequestAccessForm(forms.Form):
     email = forms.CharField(widget=forms.TextInput, required=True)
     goal = forms.CharField(widget=forms.Textarea, required=True)
@@ -82,6 +98,24 @@ class DatasetSearchForm(forms.Form):
             show_more_label="Show more sources",
         ),
     )
+
+    sort = forms.ChoiceField(
+        required=False,
+        choices=[
+            ('-search_rank,name', 'Relevance'),
+            ('-published_at', 'Latest published'),
+            ('published_at', 'Oldest published'),
+            ('name', 'Alphabetical'),
+        ],
+        widget=SortSelectWidget(label='Sort by'),
+    )
+
+    def clean_sort(self):
+        data = self.cleaned_data['sort']
+        if not data:
+            data = '-search_rank,name'
+
+        return data
 
     class Media:
         js = ('app-filter-show-more-v2.js',)

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -40,7 +40,7 @@
     this.saveState();
 
     this.$form.on(
-      'change', 'input[type=checkbox], input[type=search]',
+      'change', 'input[type=checkbox], input[type=search], select',
       this.formChange.bind(this)
     );
     $(window).on('popstate', this.popState.bind(this));
@@ -59,6 +59,13 @@
           this.formChange();
           e.preventDefault();
         }
+      }.bind(this)
+    );
+
+    this.$form.find('select').change(
+      function(e){
+        this.formChange();
+        e.preventDefault();
       }.bind(this)
     );
   }
@@ -80,6 +87,7 @@
 
     this.restoreBooleans();
     this.restoreSearchInputs();
+    this.restoreSortSelect();
     this.updateResults();
   };
 
@@ -183,6 +191,14 @@
   LiveSearch.prototype.restoreSearchInputs = function restoreSearchInputs(){
     var that = this;
     this.$form.find('input[type=search]').each(function(i, el){
+      var $el = $(el);
+      $el.val(that.getTextInputValue($el.attr('name')));
+    });
+  };
+
+  LiveSearch.prototype.restoreSortSelect = function restoreSortSelect(){
+    var that = this;
+    this.$form.find('select').each(function(i, el){
       var $el = $(el);
       $el.val(that.getTextInputValue($el.attr('name')));
     });

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -72,6 +72,7 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body"><span id="search-results-count">{{ datasets.paginator.count }}</span> results</p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    {{ form.sort }}
     {% for dataset in datasets %}
     <div class="search-result">
       <h2 class="govuk-heading-m">
@@ -152,7 +153,6 @@
   </div>
 </div>
 </form>
-
 {% endblock %}
 
 {% block footer_scripts %}

--- a/dataworkspace/dataworkspace/templates/datasets/select.html
+++ b/dataworkspace/dataworkspace/templates/datasets/select.html
@@ -1,0 +1,20 @@
+{% with id=widget.attrs.id %}
+<div class="govuk-form-group">
+  <span class="govuk-label">
+    {{ widget.label }}
+    <select class="govuk-select" name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
+      {% for group_name, group_choices, group_index in widget.optgroups %}
+        {% if group_name %}
+          <optgroup label="{{ group_name }}">
+        {% endif %}
+        {% for option in group_choices %}
+          {% include option.template_name with widget=option %}
+        {% endfor %}
+        {% if group_name %}
+          </optgroup>
+        {% endif %}
+      {% endfor %}
+    </select>
+  </span>
+</div>
+{% endwith %}

--- a/dataworkspace/dataworkspace/templates/datasets/select_option.html
+++ b/dataworkspace/dataworkspace/templates/datasets/select_option.html
@@ -1,0 +1,1 @@
+<option value="{{ widget.value|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}>{{ widget.label }}</option>

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1,3 +1,4 @@
+from datetime import timedelta, date
 import random
 from urllib.parse import quote_plus
 from uuid import uuid4
@@ -251,6 +252,7 @@ def test_find_datasets_combines_results(client):
             'slug': ds.slug,
             'search_rank': mock.ANY,
             'short_description': ds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
@@ -263,6 +265,7 @@ def test_find_datasets_combines_results(client):
             'slug': rds.slug,
             'search_rank': mock.ANY,
             'short_description': rds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
@@ -275,6 +278,7 @@ def test_find_datasets_combines_results(client):
             'slug': vis.slug,
             'search_rank': mock.ANY,
             'short_description': vis.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
@@ -313,6 +317,7 @@ def test_find_datasets_filters_by_query(client):
             'slug': ds.slug,
             'search_rank': mock.ANY,
             'short_description': ds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
@@ -325,6 +330,7 @@ def test_find_datasets_filters_by_query(client):
             'slug': rds.slug,
             'search_rank': mock.ANY,
             'short_description': rds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
@@ -337,6 +343,7 @@ def test_find_datasets_filters_by_query(client):
             'slug': vis.slug,
             'search_rank': mock.ANY,
             'short_description': vis.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
@@ -363,6 +370,7 @@ def test_find_datasets_filters_by_use(client):
             'slug': ds.slug,
             'search_rank': mock.ANY,
             'short_description': ds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
@@ -375,6 +383,7 @@ def test_find_datasets_filters_by_use(client):
             'slug': rds.slug,
             'search_rank': mock.ANY,
             'short_description': rds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
@@ -404,6 +413,7 @@ def test_find_datasets_filters_visualisations_by_use(client):
             'slug': ds.slug,
             'search_rank': mock.ANY,
             'short_description': ds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
@@ -416,6 +426,7 @@ def test_find_datasets_filters_visualisations_by_use(client):
             'slug': vis.slug,
             'search_rank': mock.ANY,
             'short_description': vis.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
@@ -468,6 +479,7 @@ def test_find_datasets_filters_by_source(client):
             'slug': ds.slug,
             'search_rank': 0.0,
             'short_description': ds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': MatchUnorderedMembers([source.name, source_2.name]),
             'source_tag_ids': MatchUnorderedMembers([source.id, source_2.id]),
             'purpose': ds.type,
@@ -480,6 +492,7 @@ def test_find_datasets_filters_by_source(client):
             'slug': rds.slug,
             'search_rank': 0.0,
             'short_description': rds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': DataSetType.REFERENCE.value,
@@ -489,6 +502,169 @@ def test_find_datasets_filters_by_source(client):
     ]
 
     assert len(list(response.context["form"].fields['source'].choices)) == 3
+
+
+def test_find_datasets_order_by_name_asc(client):
+    ds1 = factories.DataSetFactory.create(name='a dataset')
+    rds = factories.ReferenceDatasetFactory.create(name='b reference dataset')
+    vis = factories.VisualisationCatalogueItemFactory.create(name='c visualisation')
+
+    response = client.get(reverse('datasets:find_datasets'), {"sort": "name"})
+
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == [
+        {
+            'id': ds1.id,
+            'name': ds1.name,
+            'slug': ds1.slug,
+            'search_rank': mock.ANY,
+            'short_description': ds1.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ds1.type,
+            'has_access': False,
+        },
+        {
+            'id': rds.uuid,
+            'name': rds.name,
+            'slug': rds.slug,
+            'search_rank': mock.ANY,
+            'short_description': rds.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': DataSetType.REFERENCE.value,
+            'has_access': True,
+        },
+        {
+            'id': vis.id,
+            'name': vis.name,
+            'slug': vis.slug,
+            'search_rank': mock.ANY,
+            'short_description': vis.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': DataSetType.VISUALISATION.value,
+            'has_access': True,
+        },
+    ]
+
+
+def test_find_datasets_order_by_newest_first(client):
+    ads1 = factories.DataSetFactory.create(published_at=date.today())
+    ads2 = factories.DataSetFactory.create(
+        published_at=date.today() - timedelta(days=3)
+    )
+    ads3 = factories.DataSetFactory.create(
+        published_at=date.today() - timedelta(days=4)
+    )
+
+    response = client.get(reverse('datasets:find_datasets'), {"sort": "-published_at"})
+
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == [
+        {
+            'id': ads1.id,
+            'name': ads1.name,
+            'slug': ads1.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads1.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads1.type,
+            'has_access': False,
+        },
+        {
+            'id': ads2.id,
+            'name': ads2.name,
+            'slug': ads2.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads2.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads2.type,
+            'has_access': False,
+        },
+        {
+            'id': ads3.id,
+            'name': ads3.name,
+            'slug': ads3.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads3.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads3.type,
+            'has_access': False,
+        },
+    ]
+
+
+def test_find_datasets_order_by_oldest_first(client):
+    ads1 = factories.DataSetFactory.create(
+        published_at=date.today() - timedelta(days=1)
+    )
+    ads2 = factories.DataSetFactory.create(
+        published_at=date.today() - timedelta(days=2)
+    )
+    ads3 = factories.DataSetFactory.create(
+        published_at=date.today() - timedelta(days=3)
+    )
+
+    response = client.get(reverse('datasets:find_datasets'), {"sort": "published_at"})
+
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == [
+        {
+            'id': ads3.id,
+            'name': ads3.name,
+            'slug': ads3.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads3.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads3.type,
+            'has_access': False,
+        },
+        {
+            'id': ads2.id,
+            'name': ads2.name,
+            'slug': ads2.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads2.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads2.type,
+            'has_access': False,
+        },
+        {
+            'id': ads1.id,
+            'name': ads1.name,
+            'slug': ads1.slug,
+            'search_rank': mock.ANY,
+            'short_description': ads1.short_description,
+            'published': True,
+            'published_at': mock.ANY,
+            'source_tag_names': mock.ANY,
+            'source_tag_ids': mock.ANY,
+            'purpose': ads1.type,
+            'has_access': False,
+        },
+    ]
 
 
 def test_datasets_and_visualisations_doesnt_return_duplicate_results(staff_client,):
@@ -726,6 +902,7 @@ def test_find_datasets_filters_by_access():
             'slug': access_granted_master.slug,
             'search_rank': mock.ANY,
             'short_description': access_granted_master.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': access_granted_master.type,
@@ -738,6 +915,7 @@ def test_find_datasets_filters_by_access():
             'slug': public_master.slug,
             'search_rank': mock.ANY,
             'short_description': public_master.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': public_master.type,
@@ -750,6 +928,7 @@ def test_find_datasets_filters_by_access():
             'slug': public_reference.slug,
             'search_rank': mock.ANY,
             'short_description': public_reference.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
@@ -762,6 +941,7 @@ def test_find_datasets_filters_by_access():
             'slug': access_vis.slug,
             'search_rank': mock.ANY,
             'short_description': access_vis.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
@@ -774,6 +954,7 @@ def test_find_datasets_filters_by_access():
             'slug': public_vis.slug,
             'search_rank': mock.ANY,
             'short_description': public_vis.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
@@ -818,6 +999,7 @@ def test_find_datasets_filters_by_access_and_use_only_returns_the_dataset_once()
             'slug': access_granted_master.slug,
             'search_rank': mock.ANY,
             'short_description': access_granted_master.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': access_granted_master.type,
@@ -1211,6 +1393,7 @@ def test_find_datasets_search_by_source_name(client):
             'slug': ds1.slug,
             'search_rank': 0.243171,
             'short_description': ds1.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': ds1.type,
@@ -1223,6 +1406,7 @@ def test_find_datasets_search_by_source_name(client):
             'slug': rds.slug,
             'search_rank': 0.243171,
             'short_description': rds.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': DataSetType.REFERENCE.value,
@@ -1261,6 +1445,7 @@ def test_find_datasets_name_weighting(client):
             'slug': ds4.slug,
             'search_rank': 0.759909,
             'short_description': ds4.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds4.type,
@@ -1273,6 +1458,7 @@ def test_find_datasets_name_weighting(client):
             'slug': ds1.slug,
             'search_rank': 0.607927,
             'short_description': ds1.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds1.type,
@@ -1285,6 +1471,7 @@ def test_find_datasets_name_weighting(client):
             'slug': ds2.slug,
             'search_rank': 0.243171,
             'short_description': ds2.short_description,
+            'published_at': mock.ANY,
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds2.type,


### PR DESCRIPTION
### Description of change

This PR adds datasets search/filter page, the capability to sort by the following:
            - `Relevance`: '-search_rank,name', 
            - `Newest first`: '-published_at',
            - `Oldest first`: 'published_at',
            - `Alphabetical (A to Z)`: 'name'

![image](https://user-images.githubusercontent.com/1433053/98743592-36744700-23a8-11eb-8fa9-f9a704da7e05.png)

### Checklist

* [x] Have tests been added to cover any changes?
