### PR TITLE
fix: catch IntegrityError when trying to create users from sso

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1130,14 +1130,17 @@ def _do_sync_activity_stream_sso_users():
             emails = obj['dit:emailAddress']
             primary_email = emails[0]
 
-            create_user_from_sso(
-                user_id,
-                primary_email,
-                emails,
-                obj['dit:firstName'],
-                obj['dit:lastName'],
-                check_tools_access_if_user_exists=True,
-            )
+            try:
+                create_user_from_sso(
+                    user_id,
+                    primary_email,
+                    emails,
+                    obj['dit:firstName'],
+                    obj['dit:lastName'],
+                    check_tools_access_if_user_exists=True,
+                )
+            except IntegrityError:
+                logger.exception('Failed to create user record')
 
         last_published_str = records[-1]['_source']['published']
         last_published = datetime.datetime.strptime(


### PR DESCRIPTION
### Description of change

The sync sso task is currently failing to complete due to bad SSO data causing the creation of DW users to fail. This is now caught and logged to sentry instead.

### Checklist

* [ ] Have tests been added to cover any changes?
