### PR TITLE
feature: chown pgadmin home directory to allow tool to save sql files

### DIFF
--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -11,5 +11,6 @@ COPY pgadmin-config.py /pgadmin4/config_local.py
 USER root
 RUN \
 	touch /pgadmin4/.pgpass /pgadmin4/servers.json && \
-	chown pgadmin:pgadmin /pgadmin4/.pgpass /pgadmin4/servers.json
+	chown pgadmin:pgadmin /pgadmin4/.pgpass /pgadmin4/servers.json && \
+	chown -R pgadmin:pgadmin /home/jovyan
 USER pgadmin


### PR DESCRIPTION
### Description of change

At the moment users are able to open files but not save them. This chowns the home directory to allow the pgadmin user to write to it.

https://trello.com/c/KhaR4dMw/1084-allow-save-of-sql-queries-in-pgadmin

### Checklist

* [ ] Have tests been added to cover any changes?
