### PR TITLE
fix: show validation error for reference datasets if no fields present

### DIFF
--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -374,6 +374,8 @@ class ReferenceDataFieldInlineForm(forms.ModelForm):
 
     def clean(self):
         cleaned = super().clean()
+        if self.errors:
+            return cleaned
         if (
             cleaned['data_type'] != ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
             and self.cleaned_data['linked_reference_dataset_field']


### PR DESCRIPTION
### Description of change

Adding a reference dataset without any fields results in a 500 at the moment. This returns the validation errors if any of the inline forms have errors. 

There is already a unit test for this, not really sure how it was passing but this was tested manually and it works.

### Checklist

* [ ] Have tests been added to cover any changes?
