### PR TITLE
feature: show catalogue item published status for unpublished items

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -195,6 +195,7 @@ def get_datasets_data_for_user_matching_query(
         'source_tag_names',
         'source_tag_ids',
         'purpose',
+        'published',
     ).annotate(has_access=BoolOr('_has_access'))
 
     return datasets.values(
@@ -206,6 +207,7 @@ def get_datasets_data_for_user_matching_query(
         'source_tag_names',
         'source_tag_ids',
         'purpose',
+        'published',
         'has_access',
     )
 
@@ -294,6 +296,7 @@ def get_visualisations_data_for_user_matching_query(
         'source_tag_names',
         'source_tag_ids',
         'purpose',
+        'published',
     ).annotate(has_access=BoolOr('_has_access'))
 
     return visualisations.values(
@@ -305,6 +308,7 @@ def get_visualisations_data_for_user_matching_query(
         'source_tag_names',
         'source_tag_ids',
         'purpose',
+        'published',
         'has_access',
     )
 

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -77,6 +77,13 @@
       <h2 class="govuk-heading-m">
         <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}</a>
       </h2>
+      {% if not dataset.published %}
+        <div class="govuk-!-display-inline-block" style="float: right">
+          <strong class="govuk-tag govuk-tag--grey">
+            Unpublished
+          </strong>
+        </div>
+      {% endif %}
       <p class="govuk-body">{{ dataset.short_description }}</p>
       <p class="govuk-body">
         <span class="govuk-!-font-weight-bold">Purpose:</span> {{ purpose|get_key:dataset.purpose}}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -254,6 +254,7 @@ def test_find_datasets_combines_results(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -265,6 +266,7 @@ def test_find_datasets_combines_results(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
         {
@@ -276,6 +278,7 @@ def test_find_datasets_combines_results(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -313,6 +316,7 @@ def test_find_datasets_filters_by_query(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -324,6 +328,7 @@ def test_find_datasets_filters_by_query(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
         {
@@ -335,6 +340,7 @@ def test_find_datasets_filters_by_query(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -360,6 +366,7 @@ def test_find_datasets_filters_by_use(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -371,6 +378,7 @@ def test_find_datasets_filters_by_use(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -399,6 +407,7 @@ def test_find_datasets_filters_visualisations_by_use(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -410,6 +419,7 @@ def test_find_datasets_filters_visualisations_by_use(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -461,6 +471,7 @@ def test_find_datasets_filters_by_source(client):
             'source_tag_names': MatchUnorderedMembers([source.name, source_2.name]),
             'source_tag_ids': MatchUnorderedMembers([source.id, source_2.id]),
             'purpose': ds.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -472,6 +483,7 @@ def test_find_datasets_filters_by_source(client):
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -717,6 +729,7 @@ def test_find_datasets_filters_by_access():
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': access_granted_master.type,
+            'published': True,
             'has_access': True,
         },
         {
@@ -728,6 +741,7 @@ def test_find_datasets_filters_by_access():
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': public_master.type,
+            'published': True,
             'has_access': True,
         },
         {
@@ -739,6 +753,7 @@ def test_find_datasets_filters_by_access():
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
         {
@@ -750,6 +765,7 @@ def test_find_datasets_filters_by_access():
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
+            'published': True,
             'has_access': True,
         },
         {
@@ -761,6 +777,7 @@ def test_find_datasets_filters_by_access():
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': DataSetType.VISUALISATION.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -804,6 +821,7 @@ def test_find_datasets_filters_by_access_and_use_only_returns_the_dataset_once()
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': access_granted_master.type,
+            'published': True,
             'has_access': True,
         }
     ]
@@ -1196,6 +1214,7 @@ def test_find_datasets_search_by_source_name(client):
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': ds1.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -1207,6 +1226,7 @@ def test_find_datasets_search_by_source_name(client):
             'source_tag_names': [source.name],
             'source_tag_ids': [source.id],
             'purpose': DataSetType.REFERENCE.value,
+            'published': True,
             'has_access': True,
         },
     ]
@@ -1244,6 +1264,7 @@ def test_find_datasets_name_weighting(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds4.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -1255,6 +1276,7 @@ def test_find_datasets_name_weighting(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds1.type,
+            'published': True,
             'has_access': False,
         },
         {
@@ -1266,6 +1288,7 @@ def test_find_datasets_name_weighting(client):
             'source_tag_names': mock.ANY,
             'source_tag_ids': mock.ANY,
             'purpose': ds2.type,
+            'published': True,
             'has_access': False,
         },
     ]


### PR DESCRIPTION
### Description of change

Show catalogue item published status for unpublished items:

<img width="722" alt="Screenshot 2020-11-12 at 15 41 37" src="https://user-images.githubusercontent.com/915598/98961702-c4157b00-24fd-11eb-9d6f-6007fdc1bc2b.png">

https://trello.com/c/yu426OCN/1049-admins-can-identify-unpublished-catalogue-items-in-search-results

### Checklist

* [ ] Have tests been added to cover any changes?
