### PR TITLE
Remove conda

### DIFF
--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -63,7 +63,7 @@ RUN \
     useradd -u 4357 jovyan -g jovyan -m && \
     echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
-    wget -q -O - https://deb.nodesource.com/setup_11.x | bash  && \
+    wget -q -O - https://deb.nodesource.com/setup_14.x | bash  && \
     apt-get install -y nodejs && \
     python -m pip install \
         pip==20.0.2 \

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -65,9 +65,9 @@ RUN \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
     wget -q -O - https://deb.nodesource.com/setup_14.x | bash  && \
     apt-get install -y nodejs && \
-    python -m pip install \
-        pip==20.0.2 \
-        wheel==0.35.1 && \
+    python -m pip install --upgrade \
+        pip \
+        wheel && \
     python -m pip install \
         aiocontextvars==0.2.2 \
         bokeh==0.13.0 \

--- a/jupyterlab-python/Dockerfile
+++ b/jupyterlab-python/Dockerfile
@@ -16,11 +16,7 @@ ENV \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
-    CONDA_DIR=/opt/conda \
     LD_LIBRARY_PATH=/lib
-
-ENV \
-    PATH="$CONDA_DIR/bin:$PATH"
 
 # Allow man pages to be installed: slim has hacks to exclude them, so we
 # hack the hacks https://unix.stackexchange.com/a/480460/361685
@@ -34,7 +30,12 @@ RUN \
         ca-certificates \
         dirmngr \
         gnupg2 \
-        ssh && \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-setuptools \
+        ssh \
+        wget && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
     echo "deb https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster-updates main" >> /etc/apt/sources.list && \
     echo "deb http://cran.ma.imperial.ac.uk/bin/linux/debian buster-cran35/" >> /etc/apt/sources.list && \
@@ -45,62 +46,50 @@ RUN \
         build-essential=12.6 \
         git=1:2.20.1-2+deb10u3 \
         git-man=1:2.20.1-2+deb10u3 \
+        libxext6 \
+        libxrender1 \
         man-db=2.8.5-2 \
+        openssl=1.1.1d-0+deb10u3 \
         openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
         texlive-generic-extra=2018.20190227-2 \
         texlive-fonts-recommended=2018.20190227-2 \
-        wget=1.20.1-1.1 \
-        sudo=1.8.27-1+deb10u2 && \
+        ttf-dejavu \
+        sudo=1.8.27-1+deb10u2 \
+        tini=0.18.0-1 && \
+	update-alternatives --install /usr/bin/python python /usr/bin/python3 2 && \
+	update-alternatives --install /usr/bin/python python /usr/bin/python2 1 && \
     groupadd -g 4356 jovyan && \
     useradd -u 4357 jovyan -g jovyan -m && \
     echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers && \
     echo "jovyan ALL=NOPASSWD:/usr/bin/apt,/usr/bin/apt-get" >> /etc/sudoers && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-py37_4.8.2-Linux-x86_64.sh -O miniconda.sh && \
-    echo "87e77f097f6ebb5127c77662dfc3165e  miniconda.sh" | md5sum -c && \
-    mkdir -p "$CONDA_DIR" && \
-    bash miniconda.sh -f -b -p "$CONDA_DIR" && \
-    rm miniconda.sh && \
-    echo 'channels:' > /opt/conda/.condarc && \
-    echo '  - https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/conda-forge/' >> /opt/conda/.condarc && \
-    echo '  - https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/anaconda/' >> /opt/conda/.condarc && \
-    echo 'allow_other_channels: false' >> /opt/conda/.condarc && \
-    echo 'auto_update_conda: false' >> /opt/conda/.condarc && \
-    echo 'always_yes: true' >> /opt/conda/.condarc && \
-    echo 'show_channel_urls: true' >> /opt/conda/.condarc && \
-    conda install \
-        'bokeh=0.13.0' \
-        'conda=4.8.2' \
-        'font-ttf-dejavu-sans-mono==2.37' \
-        'gensim=3.5.0' \
-        'ipympl=0.5.6' \
-        'ipython-sql=0.3.9' \
-        'ipython=6.5.0' \
-        'ipywidgets=7.5.1' \
-        'jupyterlab=2.0.0' \
-        'matplotlib=3.2.1' \
-        'nltk=3.3.0' \
-        'nodejs=11.14.0' \
-        'notebook=5.7.8' \
-        'numpy=1.17.2' \
-        'openssl=1.0.2p' \
-        'pandas=0.23.4' \
-        'psycopg2=2.7.5' \
-        'scipy=1.3.1' \
-        'scikit-learn=0.21.3' \
-        'seaborn=0.9.0' \
-        'spacy=2.1.8' \
-        'tini=0.18.0' \
-        'tornado=5.1.1' \
-        'xorg-libxext=1.3.3' \
-        'xorg-libxrender=0.9.10' && \
-    conda clean -tipy && \
-    pip install \
-        pip==20.0.2 && \
-    pip install \
+    wget -q -O - https://deb.nodesource.com/setup_11.x | bash  && \
+    apt-get install -y nodejs && \
+    python -m pip install \
+        pip==20.0.2 \
+        wheel==0.35.1 && \
+    python -m pip install \
         aiocontextvars==0.2.2 \
+        bokeh==0.13.0 \
+        gensim==3.5.0 \
+        ipympl==0.5.6 \
+        ipython-sql==0.3.9 \
+        ipython==6.5.0 \
+        ipywidgets==7.5.1 \
+        jupyterlab==2.0.0 \
+        matplotlib==3.2.1 \
+        nltk==3.3.0 \
+        notebook==5.7.8 \
+        numpy==1.17.2 \
+        pandas==0.23.4 \
+        psycopg2==2.7.5 \
+        scipy==1.3.1 \
+        scikit-learn==0.21.3 \
+        seaborn==0.9.0 \
+        spacy==2.1.8 \
+        tornado==5.1.0 \
         sentry-sdk==0.9.0 && \
-    chown -R jovyan $CONDA_DIR && \
+    chown -R jovyan:jovyan /usr/local && \
     python -m spacy download en && \
     python -m nltk.downloader -d /usr/local/share/nltk_data wordnet stopwords gutenberg && \
     apt-get remove --purge -y \
@@ -119,14 +108,13 @@ COPY jupyterlab_database_access /jupyterlab_database_access
 COPY jupyterlab_template_notebooks /jupyterlab_template_notebooks
 
 RUN \
-    pip install jupyterlab_template_notebooks/server/ && \
+    python -m pip install jupyterlab_template_notebooks/server/ && \
     jupyter serverextension enable --system --python jupyterlab_template_notebooks && \
     jupyter labextension install \
         /jupyterlab_database_access \
         /jupyterlab_template_notebooks/browser \
         @jupyter-widgets/jupyterlab-manager@2.0 && \
     npm cache clean --force && \
-    node /opt/conda/lib/python3.7/site-packages/jupyterlab/staging/yarn.js cache clean && \
     echo '[global]' > /etc/pip.conf && \
     echo 'index-url = https://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/pypi/' >> /etc/pip.conf && \
     echo 'no-cache-dir = false' >> /etc/pip.conf

--- a/jupyterlab-python/start.sh
+++ b/jupyterlab-python/start.sh
@@ -5,7 +5,7 @@ chown -R jovyan:jovyan /home/jovyan
 
 set -e
 
-sudo -E -H -u jovyan /opt/conda/bin/jupyter \
+sudo -E -H -u jovyan jupyter \
 	lab \
 	--config=/etc/jupyter/jupyter_notebook_config.py \
 	--NotebookApp.token='' \


### PR DESCRIPTION
### Description of change
Remove Conda from JupyterLab-Python in order to have a simpler and faster build that is more consistent with our other tools.

Leaving JupyterLab-R for now, as we intend to retire that shortly given the limited uptake and the availability of an alternative tool, RStudio.

### Checklist

* [ ] Have tests been added to cover any changes?
