### PR TITLE
fix: chown pgadmin home directory in start.sh and not Dockerfile

### DIFF
--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -7,10 +7,12 @@ ENV \
 	PGADMIN_DEFAULT_PASSWORD=test
 
 COPY pgadmin-config.py /pgadmin4/config_local.py
+COPY start.sh /
 
 USER root
 RUN \
 	touch /pgadmin4/.pgpass /pgadmin4/servers.json && \
 	chown pgadmin:pgadmin /pgadmin4/.pgpass /pgadmin4/servers.json && \
-	chown -R pgadmin:pgadmin /home/jovyan
-USER pgadmin
+	chmod +x /start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/pgadmin/start.sh
+++ b/pgadmin/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+chown -R pgadmin:pgadmin /home/jovyan
+
+set -e
+
+sudo -E -H -u pgadmin /entrypoint.sh
+


### PR DESCRIPTION
Saving files in pgadmin requires write access to the home directory, but the /home/jovyan directory doesn't exist when the Docker image is built (it is created by terraform) so it needs to be chowned when the tool is started.

### Checklist

* [ ] Have tests been added to cover any changes?
