### PR TITLE
fix: move psycopg2 to requirements file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update && \
         python3=3.7.3-1 \
         python3-dev=3.7.3-1 \
         python3-pip=18.1-5 \
-        python3-setuptools=40.8.0-1 \
-        python3-psycopg2=2.7.7-1 && \
+        python3-setuptools=40.8.0-1 && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.utf8 && \
     rm /etc/nginx/nginx.conf && \

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ aiopg==1.0.0              # via -r requirements-dev.in
 aioredis==1.3.1           # via -r requirements.txt
 amqp==2.6.1               # via -r requirements.txt, kombu
 appdirs==1.4.4            # via black, pyppeteer
+appnope==0.1.0            # via ipython
 asgiref==3.2.10           # via -r requirements.txt, django
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements.txt, aiohttp, aioredis
@@ -64,7 +65,7 @@ greenlet==0.4.16          # via -r requirements.txt, gevent
 hawk-server-asyncio==0.0.13  # via -r requirements.txt
 hiredis==1.1.0            # via -r requirements.txt, aioredis
 idna==2.10                # via -r requirements.txt, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements.txt
+importlib-metadata==2.0.0  # via -r requirements.txt, flake8, kombu, markdown, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 ipdb==0.13.4              # via -r requirements-dev.in
 ipython-genutils==0.2.0   # via traitlets
@@ -79,7 +80,7 @@ markdown==3.2.2           # via -r requirements.txt
 markupsafe==1.1.1         # via -r requirements.txt
 mccabe==0.6.1             # via flake8, pylint
 mock==4.0.2               # via -r requirements-dev.in
-mohawk==1.1.0             # via -r requirements-dev.in
+mohawk==1.1.0             # via -r requirements-dev.in, -r requirements.txt
 monotonic==1.5            # via -r requirements.txt, notifications-python-client
 multidict==4.7.6          # via -r requirements.txt, aiohttp, yarl
 notifications-python-client==5.7.0  # via -r requirements.txt
@@ -96,6 +97,7 @@ prompt-toolkit==3.0.7     # via ipython, remote-pdb-client
 psutil==5.7.2             # via -r requirements.txt
 psycogreen==1.0.2         # via -r requirements.txt, django-db-geventpool
 psycopg2-binary==2.8.6    # via aiopg
+psycopg2==2.7.7           # via -r requirements.txt
 ptyprocess==0.6.0         # via pexpect
 py==1.9.0                 # via pytest
 pycodestyle==2.6.0        # via flake8
@@ -139,8 +141,8 @@ text-unidecode==1.3       # via faker
 toml==0.10.1              # via black, pylint, pytest
 tqdm==4.49.0              # via pyppeteer
 traitlets==5.0.4          # via ipython
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via -r requirements.txt
+typed-ast==1.4.1          # via astroid, black
+typing-extensions==3.7.4.3  # via -r requirements.txt, yarl
 urllib3==1.25.10          # via -r requirements.txt, botocore, elastic-apm, pyppeteer, requests, selenium, sentry-sdk
 vine==1.3.0               # via -r requirements.txt, amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit

--- a/requirements.in
+++ b/requirements.in
@@ -31,6 +31,7 @@ notifications-python-client==5.7.0
 paste==3.4.3
 psutil==5.7.2
 psycogreen==1.0.2
+psycopg2==2.7.7
 python-dotenv==0.12.0
 redis==3.5.3
 pyjwt==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,6 +62,7 @@ packaging==20.4           # via bleach
 paste==3.4.3              # via -r requirements.in
 psutil==5.7.2             # via -r requirements.in
 psycogreen==1.0.2         # via -r requirements.in, django-db-geventpool
+psycopg2==2.7.7           # via -r requirements.in
 pycparser==2.20           # via cffi
 pyjwt==1.7.1              # via -r requirements.in, notifications-python-client
 pyparsing==2.4.7          # via packaging


### PR DESCRIPTION
### Description of change
Rather than singling out psycopg2 for installation via the Dockerfile,
add it to our standard requirements.in tracking file for Python
requirements.


### Checklist

* [ ] Have tests been added to cover any changes?
