### PR TITLE
fix: not being able to save files in pgAdmin, and fix exiting after start

### DIFF
--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -64,6 +64,6 @@ data "template_file" "pgadmin_container_definitions" {
     metrics_container_image = "${var.metrics_container_image}:${data.external.pgadmin_metrics_current_tag.result.tag}"
     s3sync_container_image = "${var.s3sync_container_image}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
 
-    home_directory = "/home/jovyan"
+    home_directory = "/home/pgadmin"
   }
 }

--- a/pgadmin/Dockerfile
+++ b/pgadmin/Dockerfile
@@ -11,8 +11,8 @@ COPY start.sh /
 
 USER root
 RUN \
-	touch /pgadmin4/.pgpass /pgadmin4/servers.json && \
-	chown pgadmin:pgadmin /pgadmin4/.pgpass /pgadmin4/servers.json && \
+	usermod -u 4356 pgadmin && \
+	groupmod -g 4357 pgadmin && \
 	chmod +x /start.sh
 
 ENTRYPOINT ["/start.sh"]

--- a/pgadmin/start.sh
+++ b/pgadmin/start.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 
-chown -R pgadmin:pgadmin /home/jovyan
+chown -R pgadmin:pgadmin /home/pgadmin
 
 set -e
 
-sudo -E -H -u pgadmin /entrypoint.sh
+# Typically, we use set the owner of files/folders (not in the home directory)
+# in the Dockerfile. However, we've changed the ID of the pgadmin user,
+# and changing to the same owner but a different ID doesn't seem to get
+# properly saved when done from the Dockerfile. So, we do it here.
+touch /pgadmin4/.pgpass /pgadmin4/servers.json
+chown -R pgadmin:pgadmin \
+	/pgadmin4/config_distro.py \
+	/pgadmin4/.pgpass \
+	/pgadmin4/servers.json \
+	/var/lib/pgadmin \
+	/var/log/pgadmin
 
+sudo -E -H -u pgadmin /entrypoint.sh


### PR DESCRIPTION
### Description of change

The pgAdmin user has to have the same ID as the user in s3sync, 4536, for the syncing to work properly (and the group ID is just for consistency)

Before this, if the pgAdmin users has a different ID to that in s3sync, there is a race condition between the s3sync container, and pgAdmin. If pgAdmin starts first, chowns the shared directory, then s3sync will exit shortly after launch since it won't have enough permissions to create files. Since S3 sync is essential, pgAdmin will also then exit. If s3sync starts first, pgAdmin will start and stay running fine (albeit without permission to save files).

The change to make the shared directory /home/pgadmin is not vital, but it means that the correct directory is chosen by the UI in pgAdmin by default.

### Checklist

* [ ] Have tests been added to cover any changes?
