### PR TITLE
Celery ECS service

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -22,7 +22,6 @@ locals {
 
     environment = "${var.admin_environment}"
 
-    #notebooks_bucket = "${var.appstream_bucket}"
     uploads_bucket = "${var.uploads_bucket}"
     notebooks_bucket = "${var.notebooks_bucket}"
     mirror_remote_root = "https://s3-${data.aws_region.aws_region.name}.amazonaws.com/${var.mirrors_data_bucket_name != "" ? var.mirrors_data_bucket_name : var.mirrors_bucket_name}/"


### PR DESCRIPTION
### Description of change
Adds a separate ECS service to run celery workers for Data Workspace. **Commit-by-commit review probably easiest.**

This re-uses a lot of resources from the admin service, as it runs the same code and in theory needs almost all of the same access to external resources (e.g. redis, database, gitlab, etc). The notable exception is that the admin service SG allows HTTP/S in, which we theoretically would not want for celery. The celery service receives no public IP and so should not be routable from the Internet. I feel like adding a new security group with separate controls might increase the risk of not keeping the celery workers in sync with the main application in terms of access to external resources, potentially breaking a future release if the security group is only updated for the admin app and not the celery service.

The first commit is a refactor to prevent duplication of the main block of the template variables. There are some minor differences between the two de-duplicated vars for the template, but I think these were inconsequential. It bears close inspection during code review though. 