### PR TITLE
remove celery worker from start.sh

### DIFF
--- a/dataworkspace/start.sh
+++ b/dataworkspace/start.sh
@@ -20,9 +20,8 @@ set -e
     mkdir -p /home/django/logs
 
     # Start nginx, proxy and application
-    echo "Starting nginx, proxy, django application, and celery..."
-    parallel --will-cite --line-buffer --jobs 5 --halt now,done=1 ::: \
-        "celery worker --app dataworkspace.cel.celery_app --pool gevent --concurrency 150" \
+    echo "Starting nginx, proxy, django application, and celery beat..."
+    parallel --will-cite --line-buffer --jobs 4 --halt now,done=1 ::: \
         "celery beat   --app dataworkspace.cel.celery_app --pidfile /home/django/celerybeat.pid -S redbeat.RedBeatScheduler" \
         "python3 -m start" \
         "PROXY_PORT='8001' UPSTREAM_ROOT='http://localhost:8002' python3 -m proxy" \


### PR DESCRIPTION
### Description of change
This PR is the third step of moving celery out of main data workspace instance. This removes celery worker from start.sh so that main instance doesn't spin them any more. They are now part of separate celery instance.

### Checklist

* [ ] Have tests been added to cover any changes?
