### PR TITLE
Data explorer: ignore sql validation when saving

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
@@ -18,7 +18,6 @@
 	<tr class="govuk-table__row">
 	  <th scope="col" class="govuk-table__header">Query title</th>
 	  <th scope="col" class="govuk-table__header" style="width: 25%">Date and time run</th>
-	  <th scope="col" class="govuk-table__header" style="width: 20%">Action</th>
 	</tr>
       </thead>
       <tbody class="govuk-table__body">
@@ -30,11 +29,6 @@
 	    </a>
 	  </td>
 	  <td class="govuk-table__cell">{{ object.run_at|date:"SHORT_DATETIME_FORMAT" }}</td>
-	  <td class="govuk-table__cell">
-	    <a class="govuk-link" href="{% url 'explorer:download_query' object.query_id %}">
-	      Download result (CSV)
-	    </a>
-	  </td>
 	</tr>
 	{% endfor %}
       </tbody>
@@ -50,8 +44,8 @@
       <thead class="govuk-table__head">
 	<tr class="govuk-table__row">
 	  <th scope="col" class="govuk-table__header" style="width: 30%">Query title</th>
-	  <th scope="col" class="govuk-table__header" style="width: 15%">Date created</th>
-	  <th scope="col" class="govuk-table__header" style="width: 15%">Run count</th>
+	  <th scope="col" class="govuk-table__header" style="width: 25%">Date created</th>
+	  <th scope="col" class="govuk-table__header" style="width: 25%">Run count</th>
 	  <th scope="col" class="govuk-table__header">Actions</th>
 	</tr>
       </thead>
@@ -72,9 +66,6 @@
         <td class="govuk-table__cell">
           <a class="govuk-link govuk-!-margin-right-4 govuk-!-display-inline-block" href="{% url 'explorer:index' %}?query_id={{ object.id }}">Run</a>
           <a class="govuk-link govuk-!-margin-right-4 govuk-!-display-inline-block" href="{% url 'explorer:query_delete' object.id %}">Delete</a>
-          <a class="govuk-link govuk-!-display-inline-block" href="{% url 'explorer:download_query' object.id %}">
-            Download result (CSV)
-          </a>
         </td>
 	</tr>
 	{% endfor %}

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -113,7 +113,7 @@ class ListQueryView(ListView):
         return ret
 
     def get_context_data(self, **kwargs):
-        context = super(ListQueryView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['object_list'] = self.object_list
         context['recent_queries'] = self.recently_viewed()
         return context
@@ -190,7 +190,6 @@ class CreateQueryView(CreateView):
         if action == 'save':
             ret = super().post(request)
             if self.get_form().is_valid():
-                show = url_get_show(request)
                 query, form = QueryView.get_instance_and_form(
                     request, self.object.id, play_sql=play_sql
                 )
@@ -202,7 +201,7 @@ class CreateQueryView(CreateView):
                     request.user,
                     query,
                     form=form,
-                    run_query=show,
+                    run_query=False,
                     rows=url_get_rows(request),
                     page=url_get_page(request),
                     message=None,

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -52,7 +52,7 @@ class TestQueryCreateView:
 
         assert Query.objects.all()[0].sql == 'SELECT 1;'
 
-    def test_invalid_query(self, staff_user, staff_client):
+    def test_invalid_query_saved(self, staff_user, staff_client):
         query = SimpleQueryFactory.build(
             sql='SELECT foo; DELETE FROM foo;', created_by_user=staff_user
         )
@@ -61,10 +61,9 @@ class TestQueryCreateView:
         del data['id']
         del data['created_by_user']
 
-        response = staff_client.post(reverse("explorer:query_create"), data)
+        staff_client.post(reverse("explorer:query_create"), data)
 
-        assert response.status_code == 200
-        assert len(Query.objects.all()) == 0
+        assert Query.objects.all()[0].sql == 'SELECT foo; DELETE FROM foo;'
 
     @pytest.mark.django_db(transaction=True)
     def test_renders_back_link(self, staff_user, staff_client):


### PR DESCRIPTION
### Description of change
This PR is to help ignore SQL validation when saving queries in Data Explorer. This will help users to work with queries in parts, they don't have to be fully validated while they are still working on it.

This also removes `Download CSV` link in `Saved queries` section of Data Explorer. As we can't run queries confidently. And with this link you can only download first 1000 rows, if you have more. So it was decided that we should remove this link.

![image](https://user-images.githubusercontent.com/1433053/100734270-4c819000-33c7-11eb-86ff-8590d37e3356.png)

### Checklist

* [x] Have tests been added to cover any changes?
