### PR TITLE
reset data explorer creds when changing master dataset permissions

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -29,6 +29,7 @@ from dataworkspace.apps.applications.utils import (
 )
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_permission_change
+from dataworkspace.apps.explorer.schema import clear_schema_info_cache_for_user
 
 
 class AppUserCreationForm(forms.ModelForm):
@@ -430,6 +431,7 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
+            clear_schema_info_cache_for_user(obj)
 
         for dataset in current_datasets - authorized_datasets:
             DataSetUserPermission.objects.filter(dataset=dataset, user=obj).delete()
@@ -442,6 +444,7 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
+            clear_schema_info_cache_for_user(obj)
 
         if 'authorized_visualisations' in form.cleaned_data:
             current_visualisations = VisualisationCatalogueItem.objects.filter(

--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -420,6 +420,7 @@ class AppUserAdmin(UserAdmin):
         )
 
         update_quicksight_permissions = False
+        clear_schema_info_cache = False
         for dataset in authorized_datasets - current_datasets:
             DataSetUserPermission.objects.create(dataset=dataset, user=obj)
             log_permission_change(
@@ -431,7 +432,7 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
-            clear_schema_info_cache_for_user(obj)
+            clear_schema_info_cache = True
 
         for dataset in current_datasets - authorized_datasets:
             DataSetUserPermission.objects.filter(dataset=dataset, user=obj).delete()
@@ -444,6 +445,9 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
+            clear_schema_info_cache = True
+
+        if clear_schema_info_cache:
             clear_schema_info_cache_for_user(obj)
 
         if 'authorized_visualisations' in form.cleaned_data:

--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -47,6 +47,7 @@ from dataworkspace.apps.dw_admin.forms import (
 )
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_permission_change
+from dataworkspace.apps.explorer.schema import clear_schema_info_cache_for_user
 
 logger = logging.getLogger('app')
 
@@ -296,6 +297,7 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Added dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
+            clear_schema_info_cache_for_user(user)
 
         for user in current_authorized_users - authorized_users:
             DataSetUserPermission.objects.filter(dataset=obj, user=user).delete()
@@ -307,6 +309,7 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Removed dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
+            clear_schema_info_cache_for_user(user)
 
         if original_user_access_type != obj.user_access_type:
             log_permission_change(

--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -287,6 +287,7 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
 
         changed_user_sso_ids = set()
 
+        clear_schema_info_cache = False
         for user in authorized_users - current_authorized_users:
             DataSetUserPermission.objects.create(dataset=obj, user=user)
             log_permission_change(
@@ -297,7 +298,7 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Added dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
-            clear_schema_info_cache_for_user(user)
+            clear_schema_info_cache = True
 
         for user in current_authorized_users - authorized_users:
             DataSetUserPermission.objects.filter(dataset=obj, user=user).delete()
@@ -309,6 +310,9 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Removed dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
+            clear_schema_info_cache = True
+
+        if clear_schema_info_cache:
             clear_schema_info_cache_for_user(user)
 
         if original_user_access_type != obj.user_access_type:

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -3130,9 +3130,10 @@ class TestDatasetAdminPytest:
         assert mock_sync.delay.call_args_list == [mock.call()]
 
     @mock.patch("dataworkspace.apps.datasets.admin.sync_quicksight_permissions")
+    @mock.patch("dataworkspace.apps.datasets.admin.clear_schema_info_cache_for_user")
     @pytest.mark.django_db
-    def test_master_dataset_authorized_user_changes_calls_sync_job(
-        self, mock_sync, staff_client
+    def test_master_dataset_authorized_user_changes_calls_sync_job_and_clears_explorer_cache(
+        self, mock_clear_cache, mock_sync, staff_client
     ):
         user = factories.UserFactory()
         dataset = factories.MasterDataSetFactory.create(
@@ -3175,3 +3176,4 @@ class TestDatasetAdminPytest:
         assert mock_sync.delay.call_args_list == [
             mock.call(user_sso_ids_to_update=(str(user.profile.sso_id),))
         ]
+        assert mock_clear_cache.call_args_list == [mock.call(user)]


### PR DESCRIPTION
### Description of change
This PR is to reset user credentials that are cached when master dataset permissions are changed.

### Checklist

* [ ] Have tests been added to cover any changes?
