### PR TITLE
fix: don't attempt to clear schema cache when adding new user

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -447,7 +447,7 @@ class AppUserAdmin(UserAdmin):
                 update_quicksight_permissions = True
             clear_schema_info_cache = True
 
-        if clear_schema_info_cache:
+        if clear_schema_info_cache and obj.pk:
             clear_schema_info_cache_for_user(obj)
 
         if 'authorized_visualisations' in form.cleaned_data:


### PR DESCRIPTION
The connection_schema_cache_key method relies on a user profile existing and this won't be there when creating a new user in the admin

### Checklist

* [ ] Have tests been added to cover any changes?
