### PR TITLE
feat: add data hub link to header

### DIFF
--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -210,3 +210,14 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
 .hidden {
     display: none;
 }
+
+.app-header--suggestion {
+    display: none;
+}
+
+@media (min-width: 48.05em) {
+    .app-header--suggestion {
+        display: block;
+        float: right;
+    }
+}

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -49,7 +49,14 @@
           Data Workspace
         </a>
       </div>
-     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <div class="app-header--suggestion">
+        <p class="govuk-body">
+          <a class="govuk-header__link" href="https://www.datahub.trade.gov.uk/" target="_blank">Switch to Data Hub</a>
+        </p>
+      </div>
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">
+        Menu
+      </button>
       <nav>
         <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
           <li class="govuk-header__navigation-item{% if request.get_full_path == '/' %} govuk-header__navigation-item--active{% endif %}">

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -105,6 +105,7 @@ def test_header_links(request_client):
 
     expected_links = [
         ("Data Workspace", "http://dataworkspace.test:8000/"),
+        ("Switch to Data Hub", "https://www.datahub.trade.gov.uk/"),
         ("Home", "http://dataworkspace.test:8000/"),
         ("Tools", "/tools/"),
         ("About", "/about/"),


### PR DESCRIPTION
### Description of change
<img width="1037" alt="Screen Shot 2020-12-09 at 10 24 14" src="https://user-images.githubusercontent.com/2920760/101617573-b1ad3500-3a08-11eb-9901-d7894208e75d.png">

<img width="882" alt="Screen Shot 2020-12-08 at 17 04 07" src="https://user-images.githubusercontent.com/2920760/101516443-64cd4e00-3977-11eb-8459-b90ddb7c2782.png">
