### PR TITLE
fix: don't use query params for download SQL

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -210,17 +210,9 @@
                         </div>
                       </div>
 
-                      <button class="govuk-button govuk-button--secondary" data-module="govuk-button" name="action" value="download-csv">
-                        Download CSV
-                      </button>
-
-                      <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="download-excel">
-                        Download Excel
-                      </button>
-
-                      <button class="govuk-button govuk-button--secondary govuk-!-margin-left-4" data-module="govuk-button" name="action" value="download-json">
-                        Download JSON
-                      </button>
+                      <a class="govuk-button govuk-button--secondary" href="{% url 'explorer:download_querylog' query_log.id %}?format=csv">Download CSV</a>
+                      <a class="govuk-button govuk-button--secondary govuk-!-margin-left-4" href="{% url 'explorer:download_querylog' query_log.id %}?format=excel">Download Excel</a>
+                      <a class="govuk-button govuk-button--secondary govuk-!-margin-left-4" href="{% url 'explorer:download_querylog' query_log.id %}?format=json">Download JSON</a>
                     </div>
                   </div>
                 {% endif %}

--- a/dataworkspace/dataworkspace/apps/explorer/urls.py
+++ b/dataworkspace/dataworkspace/apps/explorer/urls.py
@@ -5,7 +5,7 @@ from dataworkspace.apps.accounts.utils import login_required
 from dataworkspace.apps.explorer.views import (
     CreateQueryView,
     DeleteQueryView,
-    DownloadFromSqlView,
+    DownloadFromQuerylogView,
     ListQueryLogView,
     ListQueryView,
     PlayQueryView,
@@ -15,7 +15,9 @@ from dataworkspace.apps.explorer.views import (
 urlpatterns = [
     path('', login_required(PlayQueryView.as_view()), name='index'),
     path(
-        'download/', login_required(DownloadFromSqlView.as_view()), name='download_sql'
+        'download/<int:querylog_id>',
+        login_required(DownloadFromQuerylogView.as_view()),
+        name='download_querylog',
     ),
     path('queries/', login_required(ListQueryView.as_view()), name='list_queries'),
     path(

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -216,7 +216,16 @@ def remove_data_explorer_user_cached_credentials(user):
 
 class QueryResult:
     def __init__(
-        self, sql, page, limit, timeout, duration, description, data, row_count
+        self,
+        sql,
+        page,
+        limit,
+        timeout,
+        duration,
+        description,
+        data,
+        row_count,
+        query_log,
     ):
         self.sql = sql
         self.page = page
@@ -226,6 +235,7 @@ class QueryResult:
         self.description = description
         self.data = data
         self.row_count = row_count
+        self.query_log = query_log
 
     @property
     def header_strings(self):
@@ -346,5 +356,13 @@ def execute_query(query, user, page, limit, timeout):
         row_count = cursor.fetchone()[0]
 
     return QueryResult(
-        query.final_sql(), page, limit, timeout, duration, description, data, row_count
+        query.final_sql(),
+        page,
+        limit,
+        timeout,
+        duration,
+        description,
+        data,
+        row_count,
+        query_log,
     )

--- a/dataworkspace/dataworkspace/tests/explorer/test_models.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_models.py
@@ -23,8 +23,6 @@ from dataworkspace.tests.explorer.factories import SimpleQueryFactory
 
 @pytest.mark.django_db(transaction=True)
 class TestQueryModel:
-    databases = ['default', 'my_database']
-
     def test_params_get_merged(self):
         q = SimpleQueryFactory(sql="select '$$foo$$';")
         q.params = {'foo': 'bar', 'mux': 'qux'}

--- a/dataworkspace/dataworkspace/tests/explorer/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_utils.py
@@ -2,7 +2,6 @@ import json
 from datetime import date, datetime
 from unittest.mock import call, MagicMock, Mock, patch
 
-from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.test import TestCase
 
@@ -47,15 +46,12 @@ class TestGetTotalPages(TestCase):
 
 @pytest.mark.django_db(transaction=True)
 class TestQueryResults:
-    connection_name = settings.EXPLORER_DEFAULT_CONNECTION
-    databases = ['default', 'my_database']
-
     query = "select 1 as foo, 'qux' as mux;"
 
     @pytest.fixture(scope='function', autouse=True)
     def create_query_result(self):
         self.qr = QueryResult(  # pylint: disable=attribute-defined-outside-init
-            self.query, 1, 1000, 10000, None, None, None, None
+            self.query, 1, 1000, 10000, None, None, None, None, None
         )
 
     def test_column_access(self):

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -80,8 +80,6 @@ class TestQueryCreateView:
 
 
 class TestQueryDetailView:
-    databases = ['my_database', 'test_external_db']
-
     def test_query_with_bad_sql_fails_on_save(self, staff_user, staff_client):
         query = SimpleQueryFactory(sql="select 1;", created_by_user=staff_user)
 
@@ -220,20 +218,18 @@ class TestQueryDetailView:
 
 @pytest.mark.django_db(transaction=True)
 class TestHomePage:
-    databases = ['my_database', 'test_external_db']
-
     @pytest.fixture(scope='function', autouse=True)
     def setUp(self, staff_user_data):
         suffix = stable_identification_suffix(
             staff_user_data["HTTP_SSO_PROFILE_USER_ID"], short=True
         )
         schema_and_user_name = f'{USER_SCHEMA_STEM}{suffix}'
-        for alias in self.databases:
-            with connections[alias].cursor() as cursor:
-                cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
-                cursor.execute(
-                    f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
-                )
+
+        with connections['my_database'].cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
+            cursor.execute(
+                f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
+            )
 
     def test_empty_playground_renders(self, staff_client):
         resp = staff_client.get(reverse("explorer:index"))
@@ -349,24 +345,24 @@ class TestHomePage:
 
 
 class TestCSVFromSQL:
-    databases = ['my_database']
-
     @pytest.fixture(scope='function', autouse=True)
     def setUp(self, staff_user_data):
         suffix = stable_identification_suffix(
             staff_user_data["HTTP_SSO_PROFILE_USER_ID"], short=True
         )
         schema_and_user_name = f'{USER_SCHEMA_STEM}{suffix}'
-        for alias in self.databases:
-            with connections[alias].cursor() as cursor:
-                cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
-                cursor.execute(
-                    f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
-                )
+
+        with connections['my_database'].cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
+            cursor.execute(
+                f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
+            )
 
     def test_downloading_from_playground(self, staff_user, staff_client):
-        sql = "select 1;"
-        resp = staff_client.post(reverse("explorer:download_sql"), {'sql': sql})
+        querylog = QueryLogFactory.create(sql="select 1", run_by_user=staff_user)
+        resp = staff_client.get(
+            reverse("explorer:download_querylog", kwargs=dict(querylog_id=querylog.id)),
+        )
 
         assert 'attachment' in resp['Content-Disposition']
         assert 'text/csv' in resp['content-type']
@@ -374,63 +370,104 @@ class TestCSVFromSQL:
 
 
 class TestSQLDownloadViews:
-    databases = ['my_database']
-
     @pytest.fixture(scope='function', autouse=True)
     def setUp(self, staff_user_data):
         suffix = stable_identification_suffix(
             staff_user_data["HTTP_SSO_PROFILE_USER_ID"], short=True
         )
         schema_and_user_name = f'{USER_SCHEMA_STEM}{suffix}'
-        for alias in self.databases:
-            with connections[alias].cursor() as cursor:
-                cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
-                cursor.execute(
-                    f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
-                )
 
-    def test_sql_download_csv(self, staff_client):
-        url = reverse("explorer:download_sql") + '?format=csv'
+        with connections['my_database'].cursor() as cursor:
+            cursor.execute(f'CREATE SCHEMA IF NOT EXISTS {schema_and_user_name}')
+            cursor.execute(
+                f'GRANT ALL ON SCHEMA {schema_and_user_name} TO {schema_and_user_name}'
+            )
 
-        response = staff_client.post(url, {'sql': 'select 1;'})
+    def test_sql_download_csv(self, staff_user, staff_client):
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=staff_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=csv'
+        )
+
+        response = staff_client.get(url)
 
         assert response.status_code == 200
         assert response['content-type'] == 'text/csv'
 
-    def test_sql_download_csv_with_custom_delim(self, staff_client):
-        url = reverse("explorer:download_sql") + '?format=csv&delim=|'
+    def test_sql_download_csv_with_custom_delim(self, staff_user, staff_client):
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=staff_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=csv&delim=|'
+        )
 
-        response = staff_client.post(url, {'sql': 'select 1,2;'})
+        response = staff_client.get(url)
 
         assert response.status_code == 200
         assert response['content-type'] == 'text/csv'
         assert response.content.decode('utf-8') == '?column?|?column?\r\n1|2\r\n'
 
-    def test_sql_download_csv_with_tab_delim(self, staff_client):
-        url = reverse("explorer:download_sql") + '?format=csv&delim=tab'
+    def test_sql_download_csv_with_tab_delim(self, staff_user, staff_client):
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=staff_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=csv&delim=tab'
+        )
 
-        response = staff_client.post(url, {'sql': 'select 1,2;'})
+        response = staff_client.get(url)
 
         assert response.status_code == 200
         assert response['content-type'] == 'text/csv'
         assert response.content.decode('utf-8') == '?column?\t?column?\r\n1\t2\r\n'
 
-    def test_sql_download_csv_with_bad_delim(self, staff_client):
-        url = reverse("explorer:download_sql") + '?format=csv&delim=foo'
+    def test_sql_download_csv_with_bad_delim(self, staff_user, staff_client):
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=staff_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=csv&delim=foo'
+        )
 
-        response = staff_client.post(url, {'sql': 'select 1,2;'})
+        response = staff_client.get(url)
 
         assert response.status_code == 200
         assert response['content-type'] == 'text/csv'
         assert response.content.decode('utf-8') == '?column?,?column?\r\n1,2\r\n'
 
-    def test_sql_download_json(self, staff_client):
-        url = reverse("explorer:download_sql") + '?format=json'
+    def test_sql_download_json(self, staff_user, staff_client):
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=staff_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=json'
+        )
 
-        response = staff_client.post(url, {'sql': 'select 1;'})
+        response = staff_client.get(url)
 
         assert response.status_code == 200
         assert response['content-type'] == 'application/json'
+
+    def test_cannot_download_someone_elses_querylog(self, staff_user, staff_client):
+        other_user = UserFactory(email='foo@bar.net')
+        my_querylog = QueryLogFactory(sql="select 1,2", run_by_user=other_user)
+        url = (
+            reverse(
+                "explorer:download_querylog", kwargs=dict(querylog_id=my_querylog.id)
+            )
+            + '?format=json'
+        )
+
+        response = staff_client.get(url)
+        assert response.status_code == 404
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
### Description of change
Users sometimes write very long queries, which they shoule be able to
download. Our Data Workspace proxy, using aiohttp, only supports quite
short HTTP headers/params and often 500s if a very long query is
submitted using GET parameters. Let's switch to using much shorter URLs,
taking advantage of our query logging, to fetch the desired SQL from the
database rather than from the client.

### Checklist

* [ ] Have tests been added to cover any changes?
