### PR TITLE
fix: return total row count of original query in data explorer

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -352,7 +352,7 @@ def execute_query(query, user, page, limit, timeout):
         query_log.duration = duration
         query_log.save()
 
-        cursor.execute(f'SELECT COUNT(*) FROM {table_name}')
+        cursor.execute(f'SELECT COUNT(*) FROM ({sql}) sq')
         row_count = cursor.fetchone()[0]
 
     return QueryResult(

--- a/dataworkspace/dataworkspace/tests/explorer/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_utils.py
@@ -108,9 +108,7 @@ class TestExecuteQuery:
             call(
                 f'SELECT * FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
             ),
-            call(
-                f'SELECT COUNT(*) FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
-            ),
+            call('SELECT COUNT(*) FROM (select * from foo) sq'),
         ]
         self.mock_cursor.execute.assert_has_calls(expected_calls)
 
@@ -141,9 +139,7 @@ class TestExecuteQuery:
             call(
                 f'SELECT * FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
             ),
-            call(
-                f'SELECT COUNT(*) FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
-            ),
+            call('SELECT COUNT(*) FROM (select * from foo) sq'),
         ]
         self.mock_cursor.execute.assert_has_calls(expected_calls)
 
@@ -175,9 +171,7 @@ class TestExecuteQuery:
             call(
                 f'SELECT * FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
             ),
-            call(
-                f'SELECT COUNT(*) FROM _user_12b9377c._data_explorer_tmp_query_{query_log_id}'
-            ),
+            call('SELECT COUNT(*) FROM (select * from foo) sq'),
         ]
         self.mock_cursor.execute.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
### Description of change

Fix bug in total row count introduced after storing query results in table and fetching from there

### Checklist

* [ ] Have tests been added to cover any changes?
