### PR TITLE
fix: expect uk date format when uploading ref data

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1536,6 +1536,14 @@ class ReferenceDatasetField(TimeStampedUserModel):
         field_data = {'label': self.name}
         if self.data_type == self.DATA_TYPE_DATE:
             field_data['widget'] = forms.DateInput(attrs={'type': 'date'})
+            field_data['input_formats'] = (
+                '%Y-%m-%d',
+                '%d-%m-%Y',
+                '%y-%m-%d',
+                '%d-%m-%y',
+                '%d/%m/%Y',
+                '%d/%m/%y',
+            )
         elif self.data_type == self.DATA_TYPE_TIME:
             field_data['widget'] = forms.DateInput(attrs={'type': 'time'})
         elif self.data_type == self.DATA_TYPE_FOREIGN_KEY:


### PR DESCRIPTION
As it was the refernece dataset uploader was expecting dates in the
format %m-%d-%Y so uploads were failing. This allows some common formats
for what is seemingly a very seldom use data type.
