### PR TITLE
Feature/async query polling

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -14,14 +14,14 @@
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full" id="query_area">
-            {% if form.errors %}
+            <div id="error-banner"{% if not form.errors %} class="govuk-!-display-none"{% endif %}>
               <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
                    data-module="govuk-error-summary">
                 <h2 class="govuk-error-summary__title" id="error-summary-title">
                   There is a problem
                 </h2>
                 <div class="govuk-error-summary__body">
-                  <ul class="govuk-list govuk-error-summary__list">
+                  <ul class="govuk-list govuk-error-summary__list" id="error-summary">
                     {% for field, errors in form.errors.items %}
                       {% for error in errors %}
                         <li>
@@ -32,7 +32,7 @@
                   </ul>
                 </div>
               </div>
-            {% endif %}
+            </div>
 
             <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
               Welcome to Data Explorer
@@ -113,13 +113,13 @@
                         </div>
                       </div>
                     </div>
-                    {% if form.sql.errors %}
+                    <div id="inline-error"{% if not form.sql.errors %} class="govuk-!-display-none"{% endif %}>
                       {% for error in form.sql.errors %}
                         <span id="sql-error" class="govuk-error-message">
-                                <span class="govuk-visually-hidden">Error:</span> {{ error|escape }}
-                            </span>
+                          <span class="govuk-visually-hidden">Error:</span> {{ error|escape }}
+                        </span>
                       {% endfor %}
-                    {% endif %}
+                    </div>
                     <div class="govuk-textarea" id="gov-uk-sql-wrapper" rows="10">
                       <div id="ace-sql-editor">{{ form.sql.value|default_if_none:"" }}</div>
                     </div>
@@ -148,6 +148,9 @@
                   </div>
                 </fieldset>
                 <div id="query-results">
+                  {% if query_log.state == 0 %}
+                    {% include 'explorer/partials/query_submitting.html' %}
+                  {% endif %}
                   {% include 'explorer/partials/query_results.html' %}
                 </div>
               </form>
@@ -181,4 +184,12 @@
     document.getElementById('width-toggle-container').classList.remove('govuk-!-display-none');
     window.initSchemaSearch();
   </script>
+  {% if run_queries_async and query_log %}
+    <script nonce="{{ request.csp_nonce }}" src="{% static 'explorer_async.js' %}"></script>
+    <script nonce="{{ request.csp_nonce }}">
+      setTimeout(function() {
+        window.pollForQueryResults({{ query_log.id }}, 500, 250, 5000);
+      })
+    </script>
+  {% endif %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -149,7 +149,7 @@
                 </fieldset>
                 <div id="query-results">
                   {% if query_log.state == 0 %}
-                    {% include 'explorer/partials/query_submitting.html' %}
+                    {% include 'explorer/partials/query_executing.html' %}
                   {% endif %}
                   {% include 'explorer/partials/query_results.html' %}
                 </div>

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
@@ -7,9 +7,9 @@
       </h3>
       <p class="govuk-body">
         {% if rows > total_rows %}
-          Showing {{ total_rows }} rows from a total of {{ total_rows }}
+          Showing {{ total_rows }} row{{ total_rows|pluralize }} from a total of {{ total_rows }}
         {% else %}
-          Showing {{ rows }} rows from a total of {{ total_rows }}
+          Showing {{ rows }} row{{ rows|pluralize }} from a total of {{ total_rows }}
         {% endif %}
       </p>
       <p class="govuk-body">

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_submitting.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_submitting.html
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row" id="async-query-submitting">
+  <div class="govuk-!-margin-bottom-7 loading-spinner"></div>
+  <p class="govuk-heading-m" style="text-align: center;">
+    Your query is being submitted to Data Explorer for execution.
+  </p>
+</div>

--- a/dataworkspace/dataworkspace/apps/explorer/urls.py
+++ b/dataworkspace/dataworkspace/apps/explorer/urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
     ),
     path('logs/', login_required(ListQueryLogView.as_view()), name='explorer_logs'),
     path(
-        'logs/<int:querylog_id>/results-json',
+        'logs/<int:querylog_id>/results-json/',
         login_required(QueryLogResultView.as_view()),
         name='querylog_results',
     ),

--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -482,10 +482,13 @@ def query_viewmodel(
     log=True,
 ):
     error = None
+    query_log = None
     if run_query:
         try:
             if flag_is_active(request, DATA_EXPLORER_ASYNC_QUERIES_FLAG):
-                query_log_id = execute_query_async.delay(
+                headers = None
+                data = None
+                query_log = execute_query_async(
                     query.final_sql(),
                     query.connection,
                     query.id,
@@ -493,8 +496,7 @@ def query_viewmodel(
                     page,
                     rows,
                     timeout,
-                ).get()
-                headers, data, query_log = fetch_query_results(query_log_id)
+                )
             else:
                 headers, data, query_log = execute_query_sync(
                     query.final_sql(),
@@ -524,7 +526,8 @@ def query_viewmodel(
         'total_rows': query_log.rows if has_valid_results else None,
         'duration': query_log.duration if has_valid_results else None,
         'unsafe_rendering': settings.EXPLORER_UNSAFE_RENDERING,
-        'query_log': query_log if has_valid_results else None,
+        'run_queries_async': flag_is_active(request, DATA_EXPLORER_ASYNC_QUERIES_FLAG),
+        'query_log': query_log,
     }
     ret['total_pages'] = get_total_pages(ret['total_rows'], rows)
 

--- a/dataworkspace/dataworkspace/static/explorer_async.js
+++ b/dataworkspace/dataworkspace/static/explorer_async.js
@@ -1,22 +1,26 @@
+var QUERY_STATE_RUNNING = 0;
+var QUERY_STATE_FAILED = 1;
+
 function pollForQueryResults(queryLogId, delay, delayStep, maxDelay) {
-  var resultsContainer = document.getElementById('query-results');
   var xhr = new XMLHttpRequest();
   xhr.open('GET', '/data-explorer/logs/' + queryLogId + '/results-json/');
   xhr.onreadystatechange = function() {
     if (this.readyState === XMLHttpRequest.DONE) {
       var resp = JSON.parse(xhr.responseText);
-      resultsContainer.innerHTML = resp.html;
-      if (resp.state === 0) {
+      if (resp.state === QUERY_STATE_RUNNING) {
         setTimeout(function () {
           pollForQueryResults(queryLogId, Math.min(delay + delayStep, maxDelay), delayStep, maxDelay)
         }, delay)
       }
-      else if (resp.state === 1) {
+      else if (resp.state === QUERY_STATE_FAILED) {
         document.getElementById('error-summary').innerHTML = resp.error;
         document.getElementById('error-banner').classList.remove('govuk-!-display-none');
         document.getElementById('id_sql').classList.add('govuk-form-group--error');
         document.getElementById('inline-error').innerHTML = '<span id="sql-error" class="govuk-error-message">' + resp.error + '</span>'
         document.getElementById('inline-error').classList.remove('govuk-!-display-none');
+      }
+      else {
+        document.getElementById('query-results').innerHTML = resp.html;
       }
     }
   }

--- a/dataworkspace/dataworkspace/static/explorer_async.js
+++ b/dataworkspace/dataworkspace/static/explorer_async.js
@@ -1,0 +1,25 @@
+function pollForQueryResults(queryLogId, delay, delayStep, maxDelay) {
+  var resultsContainer = document.getElementById('query-results');
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '/data-explorer/logs/' + queryLogId + '/results-json/');
+  xhr.onreadystatechange = function() {
+    if (this.readyState === XMLHttpRequest.DONE) {
+      var resp = JSON.parse(xhr.responseText);
+      resultsContainer.innerHTML = resp.html;
+      if (resp.state === 0) {
+        setTimeout(function () {
+          pollForQueryResults(queryLogId, Math.min(delay + delayStep, maxDelay), delayStep, maxDelay)
+        }, delay)
+      }
+      else if (resp.state === 1) {
+        document.getElementById('error-summary').innerHTML = resp.error;
+        document.getElementById('error-banner').classList.remove('govuk-!-display-none');
+        document.getElementById('id_sql').classList.add('govuk-form-group--error');
+        document.getElementById('inline-error').innerHTML = '<span id="sql-error" class="govuk-error-message">' + resp.error + '</span>'
+        document.getElementById('inline-error').classList.remove('govuk-!-display-none');
+      }
+    }
+  }
+  xhr.send()
+}
+window.pollForQueryResults = pollForQueryResults;

--- a/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_tasks.py
@@ -17,6 +17,7 @@ from dataworkspace.apps.explorer.exporters import (
 )
 from dataworkspace.apps.explorer.models import PlaygroundSQL, QueryLog
 from dataworkspace.apps.explorer.tasks import (
+    _run_querylog_query_async,
     truncate_querylogs,
     cleanup_playground_sql_table,
     cleanup_temporary_query_tables,
@@ -197,20 +198,15 @@ class TestExecuteQuery:
         self.mock_cursor.execute.assert_has_calls(expected_calls)
 
     def test_cant_query_with_unregistered_connection_async(self):
-        query = SimpleQueryFactory(
-            sql="select '$$foo:bar$$', '$$qux$$';", connection='not_registered'
+        query = QueryLogFactory(
+            sql="select '$$foo:bar$$', '$$qux$$';", connection='not_registered',
         )
         with pytest.raises(InvalidExplorerConnectionException):
-            execute_query_async(
-                query.final_sql(),
-                query.connection,
-                query.id,
-                self.user.id,
-                1,
-                100,
-                10000,
+            _run_querylog_query_async(
+                query.id, 1, 100, 10000,
             )
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)
@@ -228,6 +224,7 @@ class TestExecuteQuery:
         res = CSVExporter(request=self.request, query=SimpleQueryFactory()).get_output()
         assert res == 'a,b\r\n1,\r\nJenét,1\r\n'
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)
@@ -247,6 +244,7 @@ class TestExecuteQuery:
         )
         assert res == '?column?|?column?\r\n1|2\r\n'
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)
@@ -266,6 +264,7 @@ class TestExecuteQuery:
         ).get_output()
         assert res == json.dumps([{'a': 1, 'b': None}, {'a': 'Jenét', 'b': '1'}])
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)
@@ -281,6 +280,7 @@ class TestExecuteQuery:
         ).get_output()
         assert res == json.dumps([{'a': 1, 'b': date.today()}], cls=DjangoJSONEncoder)
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)
@@ -300,6 +300,7 @@ class TestExecuteQuery:
         ).get_output()
         assert res[:2] == six.b('PK')
 
+    @pytest.mark.skip(reason="Async downloads are still a WIP")
     @patch('dataworkspace.apps.explorer.tasks.get_user_explorer_connection_settings')
     @patch('dataworkspace.apps.explorer.exporters.fetch_query_results')
     @override_flag(DATA_EXPLORER_ASYNC_QUERIES_FLAG, active=True)

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -342,7 +342,7 @@ class TestHomePage:
                 {'title': 'test', 'sql': 'select 1+3400;', "action": "run"},
             )
             assert (
-                'Your query is being submitted to Data Explorer for execution.'
+                'Your query is currently being executed by Data Explorer'
                 in resp.content.decode(resp.charset)
             )
 


### PR DESCRIPTION
- On query submit create the show a "query submitting" page and start polling for results
    - Polling starts at 0.5 seconds and ramps up to a max of 5
- Updates `execute_query_sync` to create a query log before running the query asynchronously
- Reverts async download as it's covered by a separate ticket.
- Skip async download tests as that feature is still in development (in a separate ticket)
- Configurable via the `RUN_ASYNC_QUERIES` waffle flag

You can use pg_sleep to test locally: `select 123 as a_col from (select pg_sleep(10)) a;`