### PR TITLE
Fix permission denied

### DIFF
--- a/dataworkspace/dataworkspace/tests/explorer/factories.py
+++ b/dataworkspace/dataworkspace/tests/explorer/factories.py
@@ -22,6 +22,7 @@ class QueryLogFactory(factory.django.DjangoModelFactory):
     sql = "SELECT 2+2 AS FOUR"
     page = 1
     duration = 1000
+    connection = "my_database"
 
 
 class PlaygroundSQLFactory(factory.django.DjangoModelFactory):

--- a/dataworkspace/start-celery-dev.sh
+++ b/dataworkspace/start-celery-dev.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+(
+    cd "$(dirname "$0")"
+
+    echo "starting celery..."
+    nodemon -e py --watch dataworkspace -x celery worker --app dataworkspace.cel.celery_app --pool gevent --concurrency 150
+)

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -18,12 +18,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: dev
     image: data-workspace
     env_file: .envs/dev.env
     links:
       - "data-workspace-postgres"
       - "data-workspace-redis"
-    command: "/dataworkspace/start-celery.sh"
+    command: "/dataworkspace/start-celery-dev.sh"
     volumes:
       - ./dataworkspace:/dataworkspace
       - db-logs-dev:/var/log/postgres


### PR DESCRIPTION
### Description of change
We are getting errors in Sentry (e.g. https://sentry.ci.uktrade.digital/organizations/dit/issues/34632/?project=144&statsPeriod=14d) when trying to clear up temporary Data Explorer tables with permission denied.

Brucey bonus: update the local dev celery worker to reload automatically on Python file changes.

### Checklist

* [ ] Have tests been added to cover any changes?
