### PR TITLE
test: add retries to integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ docker-test-unit: docker-build
 
 .PHONY: docker-test-integration
 docker-test-integration: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest test/
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest --reruns 5 test/
 
 
 .PHONY: docker-test

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -17,6 +17,7 @@ pytest-cov==2.10.1
 pytest-mock==3.3.1
 pytest-django==4.1.0
 pytest-timeout==1.4.2
+pytest-rerunfailures==9.1.1
 django-debug-toolbar==3.2
 requests-mock==1.8.0
 pyppeteer

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ aiopg==1.1.0              # via -r requirements-dev.in
 aioredis==1.3.1           # via -r requirements.txt
 amqp==2.6.1               # via -r requirements.txt, kombu
 appdirs==1.4.4            # via black, pyppeteer
+appnope==0.1.2            # via ipython
 asgiref==3.2.10           # via -r requirements.txt, django
 astroid==2.4.2            # via pylint
 async-timeout==3.0.1      # via -r requirements.txt, aiohttp, aioredis
@@ -64,7 +65,7 @@ greenlet==0.4.16          # via -r requirements.txt, gevent
 hawk-server-asyncio==0.0.13  # via -r requirements.txt
 hiredis==1.1.0            # via -r requirements.txt, aioredis
 idna==2.10                # via -r requirements.txt, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements.txt
+importlib-metadata==2.0.0  # via -r requirements.txt, flake8, kombu, markdown, pluggy, pytest
 iniconfig==1.0.1          # via pytest
 ipdb==0.13.4              # via -r requirements-dev.in
 ipython-genutils==0.2.0   # via traitlets
@@ -114,8 +115,9 @@ pyppeteer==0.2.2          # via -r requirements-dev.in
 pytest-cov==2.10.1        # via -r requirements-dev.in
 pytest-django==4.1.0      # via -r requirements-dev.in
 pytest-mock==3.3.1        # via -r requirements-dev.in
+pytest-rerunfailures==9.1.1  # via -r requirements-dev.in
 pytest-timeout==1.4.2     # via -r requirements-dev.in
-pytest==6.1.2             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-mock, pytest-timeout
+pytest==6.1.2             # via -r requirements-dev.in, pytest-cov, pytest-django, pytest-mock, pytest-rerunfailures, pytest-timeout
 python-dateutil==2.8.1    # via -r requirements.txt, botocore, celery-redbeat, faker, freezegun, zenpy
 python-dotenv==0.12.0     # via -r requirements.txt
 pytz==2020.1              # via -r requirements.txt, celery, django, zenpy
@@ -140,8 +142,8 @@ text-unidecode==1.3       # via faker
 toml==0.10.1              # via black, pylint, pytest
 tqdm==4.49.0              # via pyppeteer
 traitlets==5.0.4          # via ipython
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via -r requirements.txt
+typed-ast==1.4.1          # via astroid, black
+typing-extensions==3.7.4.3  # via -r requirements.txt, yarl
 urllib3==1.25.10          # via -r requirements.txt, botocore, elastic-apm, pyppeteer, requests, selenium, sentry-sdk
 vine==1.3.0               # via -r requirements.txt, amqp, celery
 wcwidth==0.2.5            # via prompt-toolkit


### PR DESCRIPTION
### Description of change
Some of our integration tests are flakey at the moment. While we should
address this, quick investigation hasn't yielded results and we'll need
to prioritise spending more time on it. For now, we'll just re-run any
failed integration tests a few times to try to bypass any transient
failures.

### Checklist

* [ ] Have tests been added to cover any changes?
