### PR TITLE
feat: annotate sentry errors with user info

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -20,6 +20,7 @@ import aioredis
 from elasticapm.contrib.aiohttp import ElasticAPM
 from hawkserver import authenticate_hawk_header
 from multidict import CIMultiDict
+from sentry_sdk import set_user
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from yarl import URL
 from sentry import init_sentry
@@ -1060,6 +1061,8 @@ async def async_main():
                     request_url(request),
                 )
 
+                set_user({"id": me_profile['user_id'], "email": me_profile['email']})
+
                 return await handler(request)
 
             if me_profile:
@@ -1126,6 +1129,8 @@ async def async_main():
 
             request['logger'].info('Basic-authenticated: %s', basic_auth_user)
 
+            set_user({"id": basic_auth_user})
+
             return await handler(request)
 
         return _authenticate_by_basic_auth
@@ -1175,6 +1180,8 @@ async def async_main():
                 return web.Response(status=401)
 
             request['logger'].info('Hawk authenticated: %s', creds['id'])
+
+            set_user({"id": creds['id']})
 
             return await handler(request)
 


### PR DESCRIPTION
### Description of change
Make sentry errors easier to read by using the native user logging
features. This doesn't make any new information available in Sentry, as
this data is already tracked through HTTP headers. It just makes it
easier to read and trace.

### Checklist

* [ ] Have tests been added to cover any changes?
