### PR TITLE
fix: update the crontab entry for explorer cleanup to run once a day

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -296,7 +296,7 @@ if not strtobool(env.get('DISABLE_CELERY_BEAT_SCHEDULE', '0')):
         },
         'clean-up-old-data-explorer-materialized-views': {
             'task': 'dataworkspace.apps.explorer.tasks.cleanup_temporary_query_tables',
-            'schedule': crontab(hour=0),
+            'schedule': crontab(minute=0, hour=0),
             'args': (),
         },
         'sync-sso-users-from-activity-stream': {


### PR DESCRIPTION
### Description of change

The current crontab is incorrect and is running once a minute between 12am and 1am. It should just be run once.

### Checklist

* [ ] Have tests been added to cover any changes?
