### PR TITLE
feature: send ping from server to client to keep websocket connection alive

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -690,7 +690,7 @@ async def async_main():
             upstream_ws = await upstream_connection
             _, _, _, with_session_cookie = downstream_request[SESSION_KEY]
             downstream_ws = await with_session_cookie(
-                web.WebSocketResponse(protocols=protocols)
+                web.WebSocketResponse(protocols=protocols, heartbeat=30)
             )
 
             await downstream_ws.prepare(downstream_request)


### PR DESCRIPTION
### Description of change

Shiny visualisation go grey after 1 minute of inactivity and they currently need a workaround in the visualisation R code to keep the connection alive.

This can instead be fixed in the proxy by passing a heartbeat parameter when creating the downsteam websocket which makes the server send a ping request to the client, thereby keeping the connection alive.

Example of a working visualisation: https://hello-shiny.data.trade.staging.uktrade.digital/

https://trello.com/c/RAvdLbwY/510-prevent-shiny-visualisations-from-stopping-after-1-minute-of-idleness

### Checklist

* [ ] Have tests been added to cover any changes?
