### PR TITLE
fix: REASSIGN requires privileges on both source and target

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -621,9 +621,24 @@ def _do_delete_unused_datasets_users():
                             )
                             # This reassigns the ownership of all the database objects owned by
                             # the temporary role, however it does not handle privileges so these
-                            # need to be revoked in the next command
+                            # need to be revoked in the next command.
+                            #
+                            # REASSIGN OWNED requires privileges on both the source role(s) and
+                            # the target role so these are granted first.
                             cur.execute(
-                                sql.SQL('REASSIGN OWNED BY {} to {};').format(
+                                sql.SQL('GRANT {} TO {};').format(
+                                    sql.Identifier(usename),
+                                    sql.Identifier(conn.info.user),
+                                )
+                            )
+                            cur.execute(
+                                sql.SQL('GRANT {} TO {};').format(
+                                    sql.Identifier(persistent_db_role),
+                                    sql.Identifier(conn.info.user),
+                                )
+                            )
+                            cur.execute(
+                                sql.SQL('REASSIGN OWNED BY {} TO {};').format(
                                     sql.Identifier(usename),
                                     sql.Identifier(persistent_db_role),
                                 )


### PR DESCRIPTION
### Description of change

REASSIGN OWNED requires privileges on both the source role(s) and the target role. Related to https://github.com/uktrade/data-workspace/pull/1167 

### Checklist

* [ ] Have tests been added to cover any changes?
