### PR TITLE
fix: install latest chromium and chromium-driver apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         gcc=4:8.3.0-1 \
         musl-dev=1.1.21-2 \
-        chromium=87.0.4280.88-0.4~deb10u1 \
-        chromium-driver=87.0.4280.88-0.4~deb10u1 \
+        chromium \
+        chromium-driver \
         libxml2-dev=2.9.4+dfsg1-7+deb10u1 \
         libxslt1-dev=1.1.32-2.2~deb10u1 && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \


### PR DESCRIPTION
### Description of change

The Dockerfile build is failing because the chromium and chromium-driver versions have been retired in Debian. As this has already been upgraded in the past it's probably best to stop pinning a specific version and always install the latest

### Checklist

* [ ] Have tests been added to cover any changes?
