### PR TITLE
fix: scrub `database_data` from sentry event

### DIFF
--- a/dataworkspace/sentry.py
+++ b/dataworkspace/sentry.py
@@ -19,6 +19,19 @@ def before_send(event, hint):
     elif isinstance(exception, ServerDisconnectedError):
         event['fingerprint'] = ['server-disconnected-error', '{{ module }}']
 
+    # Remove references to database_data from stack traces
+    if event.get('exception'):
+        for value in event['exception'].get('values', []):
+            for frame in value['stacktrace']['frames']:
+                if 'database_data' in frame['vars']:
+                    frame['vars']['database_data'] = '[Database credentials scrubbed]'
+                for idx, pre_context in enumerate(frame['pre_context']):
+                    if 'password' in pre_context.lower():
+                        frame['pre_context'][idx] = '[Password scrubbed]'
+                for idx, post_context in enumerate(frame['post_context']):
+                    if 'password' in post_context.lower():
+                        frame['post_context'][idx] = '[Password scrubbed]'
+
     return event
 
 


### PR DESCRIPTION
### Description of change

Remove any reference to database_data/password before sending to sentry

