### PR TITLE
feat: update vis header to match new design

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -241,7 +241,7 @@ def tools_html_POST(request):
     frame_src=settings.QUICKSIGHT_DASHBOARD_HOST,
     frame_ancestors=settings.VISUALISATION_EMBED_DOMAINS,
 )
-def _get_embedded_quicksight_dashboard(request, dashboard_id):
+def _get_embedded_quicksight_dashboard(request, dashboard_id, catalogue_item):
     dashboard_name, dashboard_url = get_quicksight_dashboard_name_url(
         dashboard_id, request.user
     )
@@ -254,6 +254,7 @@ def _get_embedded_quicksight_dashboard(request, dashboard_id):
         'visualisation_src': f'{dashboard_url}&{extra_params}',
         'nice_name': dashboard_name,
         'wrap': 'IFRAME_WITH_VISUALISATIONS_HEADER',
+        'catalogue_item': catalogue_item,
     }
 
     return render(request, 'running.html', context, status=200)
@@ -291,7 +292,9 @@ def visualisation_link_html_view(request, link_id):
             request.user,
             event_type=EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
         )
-        return _get_embedded_quicksight_dashboard(request, identifier)
+        return _get_embedded_quicksight_dashboard(
+            request, identifier, visualisation_link.visualisation_catalogue_item
+        )
     elif visualisation_link.visualisation_type == 'DATASTUDIO':
         log_visualisation_view(
             visualisation_link,

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -100,15 +100,7 @@
   </header>
 
   <div class="govuk-width-container">
-    <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
-        <span class="govuk-phase-banner__text">
-          This is a new service – your <a class="govuk-link" href="{% url 'support' %}">feedback</a> will help us to improve it.
-        </span>
-      </p>
-    </div>
-
+    {% include 'partials/alpha_banner.html' %}
     {% block breadcrumbs %}{% endblock %}
     {% block go_back %}{% endblock %}
 

--- a/dataworkspace/dataworkspace/templates/partials/alpha_banner.html
+++ b/dataworkspace/dataworkspace/templates/partials/alpha_banner.html
@@ -1,0 +1,8 @@
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" href="{% url 'support' %}">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>

--- a/dataworkspace/dataworkspace/templates/running.html
+++ b/dataworkspace/dataworkspace/templates/running.html
@@ -20,121 +20,100 @@
   <link rel="apple-touch-icon" sizes="152x152" href="{% static 'assets/images/govuk-apple-touch-icon-152x152.png' %}">
   <link rel="apple-touch-icon" href="{% static 'assets/images/govuk-apple-touch-icon.png' %}">
 
-  {% if wrap == 'IFRAME_WITH_VISUALISATIONS_HEADER' %}
-  <link rel="stylesheet" href="{% static 'govuk-frontend-including-fonts-3.8.1.min-v1.css' %}">
   <style>
-    .vis-template {
+    html, body {
       height: 100%;
-    }
-    .vis__body {
-      margin: 0;
-      height: 100%;
-      background-color: #ffffff;
-    }
-    .vis {
-      display: block;
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-
-    /* Horizontal styles of header */
-    .govuk-width-container {
-      max-width: none;
-    }
-    @media (min-width: 40.0625em) {
-      .govuk-header__container {
-        margin: 0 30px;
-      }
-    }
-
-    /* Vertical styles of header, and that it + the iframe are 100% height */
-    .govuk-header {
-      height: 39px;
-      overflow: hidden;
-      /* Not strictly part of the design, but gives a bit of separation between
-         the header and the visualisation, especially on those with non-white
-         backgrounds and when scrolling down */
-      border-bottom: 1px solid white;
-    }
-    .govuk-header__container {
-      border-bottom: none;
-      margin-bottom: 0;
-      padding-bottom: 10px;
-    }
-    .vis {
-      height: calc(100% - 40px);
-    }
-    @media (min-width: 40.0625em) {
-      .govuk-header {
-        height: 49px;
-      }
-      .vis {
-        height: calc(100% - 50px);
-      }
-    }
-
-    /* Not show the tagline at all when it would wrap to the next line */
-    .vis-header__tagline {
-      display: none;
-    }
-    @media (min-width: 45em) {
-      .vis-header__tagline {
-        display: block;
-        float: right;
-        font-weight: normal;
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 32px;
-      }
-    }
-    .vis-header__tagline__link {
-      text-decoration: underline;
     }
   </style>
+
+  {% if wrap == 'IFRAME_WITH_VISUALISATIONS_HEADER' %}
+    <link rel="stylesheet" href="{% static 'govuk-frontend-including-fonts-3.8.1.min-v1.css' %}">
+    <style>
+      body {
+        display: flex;
+        flex-flow: column;
+      }
+      .header-wrap {
+        flex: 0 1 auto;
+      }
+      .visualisation-wrap {
+        flex: 1 1 auto;
+        display: flex;
+      }
+      iframe {
+        flex: 1;
+      }
+    </style>
   {% endif %}
 
   {% if wrap == 'FULL_HEIGHT_IFRAME' %}
-  <style>
-    .vis-template {
-      height: 100%;
-    }
-    .vis__body {
-      margin: 0;
-      height: 100%;
-      background-color: #ffffff;
-    }
-    .vis {
-      display: block;
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-  </style>
+    <style>
+      .visualisation-wrap {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        background-color: #ffffff;
+      }
+      .visualisation {
+        display: block;
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+      iframe {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   {% endif %}
-
   {% include 'partials/gtm_head.html' %}
 </head>
-
-<body class="vis__body">
+<body class="govuk-template__body">
   {% include 'partials/gtm_body.html' %}
-
   {% if wrap == 'IFRAME_WITH_VISUALISATIONS_HEADER' %}
-  <header class="govuk-header" role="banner">
-    <div class="govuk-header__container govuk-width-container">
-      <div class="govuk-header__logotype">
-        <a href="{{ root_href }}" class="govuk-header__link govuk-header__link--service-name">
-          Data Visualisations
-        </a>
-      </div>
-      <div class="govuk-header__link--service-name vis-header__tagline">
-        Created by tools and data on <a href="{{ root_href }}" class="govuk-header__link vis-header__tagline__link">Data Workspace</a>
+    <div class="header-wrap">
+      <header class="govuk-header" role="banner" data-module="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+          <div class="govuk-header__logotype">
+            <a href="{{ root_href }}" class="govuk-header__link govuk-header__link--service-name">
+              Data Workspace
+            </a>
+          </div>
+        </div>
+      </header>
+      <div class="govuk-width-container">
+        {% include 'partials/alpha_banner.html' %}
+        <div class="govuk-breadcrumbs">
+            <ol class="govuk-breadcrumbs__list">
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="{{ root_href }}">Home</a>
+                </li>
+              {%  if catalogue_item %}
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="{{ catalogue_item.get_absolute_url }}">
+                      {{ catalogue_item.name }}
+                    </a>
+                </li>
+                <li class="govuk-breadcrumbs__list-item">
+                    Visualisation Dashboard
+                </li>
+              {% else %}
+                <li class="govuk-breadcrumbs__list-item">
+                    <a class="govuk-breadcrumbs__link" href="{% url 'applications:tools' %}">
+                      Tools
+                    </a>
+                </li>
+                <li class="govuk-breadcrumbs__list-item">
+                  {{ nice_name }}
+                </li>
+              {% endif %}
+            </ol>
+        </div>
       </div>
     </div>
-  </header>
   {% endif %}
-
-  <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="vis">
+  <div class="visualisation-wrap">
+    <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="visualisation" />
+  </div>
 </body>
-
 </html>


### PR DESCRIPTION
### Description of change

Update the visualisation header to match the design provided https://9f0gap.axshare.com/#id=kqc7tc&p=data_page-header_and_footer_for_preview_page-dit_w_1.

**Before**
![vis-before](https://user-images.githubusercontent.com/594496/105379765-13b2aa00-5c05-11eb-88e2-20be0b3e6bf0.png)


**After**
![vis-after](https://user-images.githubusercontent.com/594496/105379782-16ad9a80-5c05-11eb-811b-12c5ee73c382.png)

