### PR TITLE
show code snippets for each source table on dataset page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -53,12 +53,11 @@ def dataset_type_to_manage_unpublished_permission_codename(dataset_type: int):
     }[dataset_type]
 
 
-def get_code_snippets(dataset: DataSet):
-    sourcetables = dataset.sourcetable_set.all()
-    if not sourcetables:
+def get_code_snippets(source_table):
+    if not hasattr(source_table, 'schema') or not hasattr(source_table, 'table'):
         return {}
 
-    schema, table_name = sourcetables[0].schema, sourcetables[0].table
+    schema, table_name = source_table.schema, source_table.table
     python_snippet = f"""import os
 import pandas
 import psycopg2

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -549,12 +549,13 @@ class DatasetDetailView(DetailView):
         )
 
         DataLinkWithLinkToggle = namedtuple(
-            'DataLinkWithLinkToggle', ('data_link', 'can_show_link')
+            'DataLinkWithLinkToggle', ('data_link', 'can_show_link', 'code_snippets')
         )
         data_links_with_link_toggle = [
             DataLinkWithLinkToggle(
                 data_link=data_link,
                 can_show_link=data_link.can_show_link_for_user(self.request.user),
+                code_snippets=get_code_snippets(data_link),
             )
             for data_link in data_links
         ]
@@ -585,7 +586,6 @@ class DatasetDetailView(DetailView):
                     not source_link.url.startswith('s3://')
                     for source_link in self.object.sourcelink_set.all()
                 ),
-                'code_snippets': get_code_snippets(self.object),
                 'visualisation_src': dashboard_url,
                 'custom_dataset_query_type': DataLinkType.CUSTOM_QUERY.value,
                 'source_table_type': DataLinkType.SOURCE_TABLE.value,

--- a/dataworkspace/dataworkspace/static/app-copy.js
+++ b/dataworkspace/dataworkspace/static/app-copy.js
@@ -44,8 +44,3 @@ Copy.prototype.init = function () {
     }, 5000)
   });
 };
-
-let $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')
-nodeListForEach($codeBlocks, function ($codeBlock) {
-  new Copy($codeBlock).init()
-});

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -221,3 +221,7 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
         float: right;
     }
 }
+
+.app-table_cell--no-border {
+  border-bottom: none;
+}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -90,7 +90,7 @@
                 </thead>
                 <tbody>
 
-                {% for data_link, can_show_link in data_links_with_link_toggle %}
+                {% for data_link, can_show_link, _ in data_links_with_link_toggle %}
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell">
                             {% if has_access and can_show_link %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -62,20 +62,20 @@
         </thead>
         <tbody>
 
-        {% for data_link, _ in data_links_with_link_toggle %}
+        {% for data_link, _, code_snippets in data_links_with_link_toggle %}
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ data_link.name }}</td>
-            <td class="govuk-table__cell">"{{ data_link.schema }}"."{{ data_link.table }}"</td>
-            <td class="govuk-table__cell">{{ data_link.get_frequency_display }}</td>
-            <td class="govuk-table__cell">{{ data_link.get_data_last_updated_date|default_if_none:"N/A" }}</td>
+            <td class="govuk-table__cell app-table_cell--no-border">{{ data_link.name }}</td>
+            <td class="govuk-table__cell app-table_cell--no-border">"{{ data_link.schema }}"."{{ data_link.table }}"</td>
+            <td class="govuk-table__cell app-table_cell--no-border">{{ data_link.get_frequency_display }}</td>
+            <td class="govuk-table__cell app-table_cell--no-border">{{ data_link.get_data_last_updated_date|default_if_none:"N/A" }}</td>
             {% if user.is_superuser %}
-              <td class="govuk-table__cell">
+              <td class="govuk-table__cell app-table_cell--no-border">
                 {% if data_link.get_google_data_studio_link and data_link.accessible_by_google_data_studio %}
                   <a href="{{ data_link.get_google_data_studio_link }}">Google Data Studio</a>
                 {% endif %}
               </td>
             {% endif %}
-            <td class="govuk-table__cell">
+            <td class="govuk-table__cell app-table_cell--no-border">
               {% if data_link.type == source_table_type %}
                 {% if has_access %}
                   <a class="govuk-link"
@@ -89,6 +89,22 @@
                   No preview available
               {% endif %}
             </td>
+            {% if code_snippets %}
+              <tr class="govuk-table__row">
+                <td colspan="6" class="govuk-table__cell">
+                  <details class="govuk-details-!-margin-bottom-2" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Code snippets <span class="govuk-visually-hidden">for "{{ data_link.schema }}"."{{ data_link.table }}"</span>
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      {% include 'partials/code_snippets.html' with code_snippets=code_snippets data_link=data_link %}
+                    </div>
+                  </details>
+                </td>
+              </tr>
+            {% endif %}
           </tr>
         {% endfor %}
         {% if not data_links_with_link_toggle %}
@@ -103,8 +119,6 @@
       {% endif %}
     </div>
   </div>
-
-  {% include 'partials/code_snippets.html' %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -148,4 +162,10 @@
       {% endif %}
     </div>
   </div>
+  <script nonce="{{ request.csp_nonce }}">
+    let $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')
+    nodeListForEach($codeBlocks, function ($codeBlock) {
+      new Copy($codeBlock).init()
+    });
+  </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -5,45 +5,45 @@
   {% if code_snippets %}
   <link rel="stylesheet" href="{% static 'assets/vendor/highlight/styles/a11y-light.css' %}">
 
-  <h2 class="govuk-heading-l govuk-!-margin-top-8">Code snippets</h2>
+  <h3 class="govuk-heading-l">Code snippets <span class="govuk-visually-hidden">for "{{ data_link.schema }}"."{{ data_link.table }}"</span></h3>
   <div class="govuk-tabs" data-module="govuk-tabs">
     <h2 class="govuk-tabs__title">Contents</h2>
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-        <a class="govuk-tabs__tab" href="#code-snippet-sql">SQL</a>
+        <a class="govuk-tabs__tab" href="#code-snippet-sql-{{ data_link.schema }}-{{ data_link.table }}">SQL</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#code-snippet-python">Python</a>
+        <a class="govuk-tabs__tab" href="#code-snippet-python-{{ data_link.schema }}-{{ data_link.table }}">Python</a>
       </li>
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#code-snippet-r">R</a>
+        <a class="govuk-tabs__tab" href="#code-snippet-r-{{ data_link.schema }}-{{ data_link.table }}">R</a>
       </li>
     </ul>
 
-    <div class="govuk-tabs__panel" id="code-snippet-sql">
+    <div class="govuk-tabs__panel" id="code-snippet-sql-{{ data_link.schema }}-{{ data_link.table }}">
       <h3 class="govuk-heading-m">SQL</h3>
       <div class="app-example__code">
-        <pre data-module="app-copy">
+        <pre data-module="app-copy" style="white-space: pre-wrap;">
           <code class="hljs psql">{{ code_snippets.sql }}</code>
         </pre>
       </div>
 
-      <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}">Open in Data Explorer</a>
+      <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}">Open <span class="govuk-visually-hidden">first 50 rows of "{{ data_link.schema }}"."{{ data_link.table }}" </span>in Data Explorer</a>
     </div>
 
-    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-python">
+    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-python-{{ data_link.schema }}-{{ data_link.table }}">
       <h3 class="govuk-heading-m">Python</h3>
       <div class="app-example__code">
-        <pre data-module="app-copy">
+        <pre data-module="app-copy" style="white-space: pre-wrap;">
           <code class="hljs python">{{ code_snippets.python }}</code>
         </pre>
       </div>
     </div>
 
-    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-r">
+    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-r-{{ data_link.schema }}-{{ data_link.table }}">
       <h3 class="govuk-heading-m">R</h3>
       <div class="app-example__code">
-        <pre data-module="app-copy">
+        <pre data-module="app-copy" style="white-space: pre-wrap;">
           <code class="hljs r">{{ code_snippets.r }}</code>
         </pre>
       </div>

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -29,12 +29,11 @@ def test_dataset_type_to_manage_unpublished_permission_codename():
 @pytest.mark.django_db
 def test_get_code_snippets(metadata_db):
     ds = DataSetFactory.create(type=DataSetType.MASTER.value)
+    sourcetable = SourceTableFactory.create(
+        dataset=ds, schema="public", table="MY_LOVELY_TABLE"
+    )
 
-    assert get_code_snippets(ds) == {}
-
-    SourceTableFactory.create(dataset=ds, schema="public", table="MY_LOVELY_TABLE")
-
-    snippets = get_code_snippets(ds)
+    snippets = get_code_snippets(sourcetable)
     assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['python']
     assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['r']
     assert snippets['sql'] == """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50"""

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1259,7 +1259,7 @@ def test_launch_master_dataset_in_data_explorer(metadata_db):
 
     assert response.status_code == 200
     assert (
-        doc.xpath("//a[normalize-space(text()) = 'Open in Data Explorer']/@href")[0]
+        doc.xpath('//a[@id="launch-data-explorer"]/@href')[0]
         == f'/data-explorer/?sql={expected_sql}'
     )
 


### PR DESCRIPTION
### Description of change
This PR is to show code snippets for each table within dataset page in data workspace.

![image](https://user-images.githubusercontent.com/1433053/105648183-11b94700-5ea2-11eb-8936-cdc9ffba45db.png)


### Checklist

* [ ] Have tests been added to cover any changes?
