### PR TITLE
fix: allow configuration of ALB dereg delay

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -664,6 +664,7 @@ resource "aws_alb_target_group" "admin" {
   protocol    = "HTTP"
   vpc_id      = "${aws_vpc.main.id}"
   target_type = "ip"
+  deregistration_delay = "${var.admin_deregistration_delay}"
 
   health_check {
     path = "/healthcheck"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -40,6 +40,10 @@ variable admin_authbroker_client_id {}
 variable admin_authbroker_client_secret {}
 variable admin_authbroker_url {}
 variable admin_environment {}
+variable admin_deregistration_delay {
+  type = number
+  default = 300
+}
 
 variable uploads_bucket {}
 variable appstream_bucket {}


### PR DESCRIPTION
### Description of change

At the moment we allow 300 seconds in all environments for ALB targets
to be deregistered. This allows in-flight requests to complete safely
before the targets are killed, but also increases deployment time
significantly as we have to wait for both dev and staging to have this
300s dereg delay each. It would be nice to have a lower (or nil)
deregistration delay in these environments so that deployments from
build to prod can be faster. There are often few/no requests in
dev+staging, and even if they are, it's probably OK for AWS to kill them
after a much shorter delay as they're only for testing.


### Checklist

* [ ] Have tests been added to cover any changes?
