### PR TITLE
feat: remove alpha banner from running visualisation

### DIFF
--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -91,7 +91,6 @@
         </header>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-full">
-            {% include 'partials/alpha_banner.html' %}
             <div class="govuk-breadcrumbs">
               <ol class="govuk-breadcrumbs__list">
                   <li class="govuk-breadcrumbs__list-item">


### PR DESCRIPTION
### Description of change

Removed alpha banner due to user complaints about screen real estate for visualisations.

### Checklist

* [ ] Have tests been added to cover any changes?
