### PR TITLE
Feature/dns rewrite proxy nlb

### DIFF
--- a/dns-rewrite-proxy/nameserver.py
+++ b/dns-rewrite-proxy/nameserver.py
@@ -73,7 +73,10 @@ async def async_main():
 
     async def handle_client(reader, writer):
         logger.info('[Healthcheck] request received')
-    healthcheck_task = await create_task(asyncio.start_server(handle_client, '0.0.0.0', 8888))
+
+    healthcheck_task = await create_task(
+        asyncio.start_server(handle_client, '0.0.0.0', 8888)
+    )
     logger.info('[Healthcheck] server started')
 
     loop = asyncio.get_running_loop()

--- a/dns-rewrite-proxy/set-dhcp.py
+++ b/dns-rewrite-proxy/set-dhcp.py
@@ -101,6 +101,8 @@ aws_ec2_host = os.environ['AWS_EC2_HOST']
 logger.debug('Parsing environment... (aws_ec2_host: %s)', aws_ec2_host)
 vpc_id = os.environ['VPC_ID']
 logger.debug('Parsing environment... (vpc_id: %s)', vpc_id)
+ip_address = os.environ['IP_ADDRESS']
+logger.debug('Parsing environment... (ip_address: %s)', ip_address)
 aws_container_credentials_relative_uri = os.environ[
     'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'
 ]
@@ -109,14 +111,6 @@ logger.debug(
     aws_container_credentials_relative_uri,
 )
 logger.debug('Parsing environment... (done)')
-
-logger.debug('Finding local IP address...')
-with urllib.request.urlopen('http://169.254.170.2/v2/metadata') as ip_response:
-    ip_address = json.loads(ip_response.read().decode('utf-8'))['Containers'][0][
-        'Networks'
-    ][0]['IPv4Addresses'][0]
-logger.debug('Finding local IP address... (ip_address: %s)', ip_address)
-logger.debug('Finding local IP address... (done)')
 
 logger.debug('Finding credentials...')
 with urllib.request.urlopen(

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -98,7 +98,7 @@ resource "aws_ecs_service" "admin" {
   deployment_maximum_percent = 600
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.admin_service.id}"]
   }
 
@@ -178,7 +178,7 @@ resource "aws_ecs_service" "admin_celery" {
   deployment_maximum_percent = 600
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.admin_service.id}"]
   }
 }
@@ -284,7 +284,7 @@ data "aws_iam_policy_document" "admin_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.admin.arn}",
+      "${aws_cloudwatch_log_group.admin.arn}:*",
     ]
   }
 }
@@ -619,7 +619,7 @@ data "aws_iam_policy_document" "admin_task_ecs_tasks_assume_role" {
 
 resource "aws_alb" "admin" {
   name            = "${var.prefix}-admin"
-  subnets         = ["${aws_subnet.public.*.id}"]
+  subnets         = "${aws_subnet.public.*.id}"
   security_groups = ["${aws_security_group.admin_alb.id}"]
 
   access_logs {
@@ -691,7 +691,7 @@ resource "aws_elasticache_cluster" "admin" {
 
 resource "aws_elasticache_subnet_group" "admin" {
   name               = "${var.prefix_short}-admin"
-  subnet_ids         = ["${aws_subnet.private_with_egress.*.id}"]
+  subnet_ids         = "${aws_subnet.private_with_egress.*.id}"
 }
 
 resource "aws_iam_role_policy_attachment" "admin_cloudwatch_logs" {

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -164,10 +164,6 @@
       "value": "8888"
     },
     {
-      "name": "APPLICATION_TEMPLATES__1__SPAWNER_OPTIONS__PORT",
-      "value": "8888"
-    },
-    {
       "name": "APPLICATION_TEMPLATES__1__SPAWNER_OPTIONS__ROLE_PREFIX",
       "value": "${notebook_task_role__role_prefix}"
     },
@@ -424,10 +420,6 @@
       "value": "8888"
     },
     {
-      "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__PORT",
-      "value": "8888"
-    },
-    {
       "name": "APPLICATION_TEMPLATES__5__SPAWNER_OPTIONS__ROLE_PREFIX",
       "value": "${notebook_task_role__role_prefix}"
     },
@@ -502,10 +494,6 @@
     {
       "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__SUBNETS__1",
       "value": "${fargate_spawner__task_subnet}"
-    },
-    {
-      "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__PORT",
-      "value": "8888"
     },
     {
       "name": "APPLICATION_TEMPLATES__6__SPAWNER_OPTIONS__PORT",

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -88,7 +88,7 @@ data "template_file" "dns_rewrite_proxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
 
   vars = {
-    container_image    = "${var.dns_rewrite_proxy_container_image}:feature_dns_rewrite_proxy_nlb"
+    container_image    = "${var.dns_rewrite_proxy_container_image}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
     container_name     = "${local.dns_rewrite_proxy_container_name}"
     container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
     container_memory   = "${local.dns_rewrite_proxy_container_memory}"

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -1,13 +1,59 @@
+resource "aws_lb" "dns_rewrite_proxy" {
+  name                             = "${var.prefix}-dns-rewrite-proxy"
+  load_balancer_type               = "network"
+  enable_cross_zone_load_balancing = "true"
+
+  internal = true
+  
+  subnet_mapping {
+    subnet_id     = "${aws_subnet.private_with_egress.*.id[0]}"
+    # private_ipv4_address = "172.16.12.96"
+  }
+}
+
+resource "aws_lb_listener" "dns_rewrite_proxy" {
+  load_balancer_arn = "${aws_lb.dns_rewrite_proxy.id}"
+  port              = 53
+  protocol          = "UDP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.dns_rewrite_proxy.id}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "dns_rewrite_proxy" {
+  name                 = "${var.prefix}-dns-rewrite-proxy"
+  port                 = 53
+  protocol             = "UDP"
+  vpc_id               = "${aws_vpc.main.id}"
+  target_type          = "ip"
+
+  health_check {
+    protocol            = "TCP"
+    port                = "8888"
+  }
+
+  depends_on = ["aws_lb.dns_rewrite_proxy"]
+}
+
 resource "aws_ecs_service" "dns_rewrite_proxy" {
   name            = "${var.prefix}-dns-rewrite-proxy"
   cluster         = "${aws_ecs_cluster.main_cluster.id}"
   task_definition = "${aws_ecs_task_definition.dns_rewrite_proxy.arn}"
   desired_count   = 1
   launch_type     = "FARGATE"
+  platform_version = "1.4.0"
 
   network_configuration {
     subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
     security_groups = ["${aws_security_group.dns_rewrite_proxy.id}"]
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.dns_rewrite_proxy.id}"
+    container_name = "${local.dns_rewrite_proxy_container_name}"
+    container_port = 53
   }
 }
 
@@ -42,7 +88,7 @@ data "template_file" "dns_rewrite_proxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
 
   vars {
-    container_image    = "${var.dns_rewrite_proxy_container_image}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
+    container_image    = "${var.dns_rewrite_proxy_container_image}:feature_dns_rewrite_proxy_nlb"
     container_name     = "${local.dns_rewrite_proxy_container_name}"
     container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
     container_memory   = "${local.dns_rewrite_proxy_container_memory}"

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -87,7 +87,7 @@ resource "aws_ecs_task_definition" "dns_rewrite_proxy" {
 data "template_file" "dns_rewrite_proxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.dns_rewrite_proxy_container_image}:feature_dns_rewrite_proxy_nlb"
     container_name     = "${local.dns_rewrite_proxy_container_name}"
     container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
@@ -153,7 +153,7 @@ data "aws_iam_policy_document" "dns_rewrite_proxy_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.dns_rewrite_proxy.arn}",
+      "${aws_cloudwatch_log_group.dns_rewrite_proxy.arn}:*",
     ]
   }
 }

--- a/infra/ecs_main_dns_rewrite_proxy_container_definitions.json
+++ b/infra/ecs_main_dns_rewrite_proxy_container_definitions.json
@@ -36,6 +36,9 @@
     }, {
       "name": "VPC_ID",
       "value": "${vpc_id}"
+    }, {
+      "name": "IP_ADDRESS",
+      "value": "${ip_address}"
     }]
   }
 ]

--- a/infra/ecs_main_dns_rewrite_proxy_container_definitions.json
+++ b/infra/ecs_main_dns_rewrite_proxy_container_definitions.json
@@ -8,9 +8,10 @@
     "portMappings": [{
         "containerPort": 53,
         "protocol": "udp"
-    },{
-        "containerPort": 53,
-        "protocol": "tcp"
+    },
+    {
+      "containerPort": 8888,
+      "protocol": "tcp"
     }],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/infra/ecs_main_healthcheck.tf
+++ b/infra/ecs_main_healthcheck.tf
@@ -7,7 +7,7 @@ resource "aws_ecs_service" "healthcheck" {
   deployment_maximum_percent = 600
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.healthcheck_service.id}"]
   }
 
@@ -75,7 +75,7 @@ resource "aws_ecs_task_definition" "healthcheck" {
 data "template_file" "healthcheck_container_definitions" {
   template = "${file("${path.module}/ecs_main_healthcheck_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image   = "${var.healthcheck_container_image}:${data.external.healthcheck_current_tag.result.tag}"
     container_name    = "${local.healthcheck_container_name}"
     container_port    = "${local.healthcheck_container_port}"
@@ -139,7 +139,7 @@ data "aws_iam_policy_document" "healthcheck_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.healthcheck.arn}",
+      "${aws_cloudwatch_log_group.healthcheck.arn}:*",
     ]
   }
 }
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "healthcheck_task_ecs_tasks_assume_role" {
 
 resource "aws_alb" "healthcheck" {
   name            = "${var.prefix}-hc"
-  subnets         = ["${aws_subnet.public.*.id}"]
+  subnets         = "${aws_subnet.public.*.id}"
   security_groups = ["${aws_security_group.healthcheck_alb.id}"]
 
   access_logs {

--- a/infra/ecs_main_mirrors_sync.tf
+++ b/infra/ecs_main_mirrors_sync.tf
@@ -1,9 +1,9 @@
 resource "aws_ecs_task_definition" "mirrors_sync_conda" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-conda"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_conda.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_conda.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -14,13 +14,13 @@ data "template_file" "mirrors_sync_container_definitions_conda" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.mirrors_sync_container_image}"
     container_name     = "${local.mirrors_sync_container_name}"
     container_cpu      = "${local.mirrors_sync_container_cpu}"
     container_memory   = "${local.mirrors_sync_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_region = "${data.aws_region.aws_region.name}"
@@ -40,9 +40,9 @@ data "template_file" "mirrors_sync_container_definitions_conda" {
 resource "aws_ecs_task_definition" "mirrors_sync_cran" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-cran"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -53,13 +53,13 @@ data "template_file" "mirrors_sync_container_definitions_cran" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.mirrors_sync_container_image}"
     container_name     = "${local.mirrors_sync_container_name}"
     container_cpu      = "${local.mirrors_sync_container_cpu}"
     container_memory   = "${local.mirrors_sync_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_region = "${data.aws_region.aws_region.name}"
@@ -79,9 +79,9 @@ data "template_file" "mirrors_sync_container_definitions_cran" {
 resource "aws_ecs_task_definition" "mirrors_sync_cran_binary" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-cran-binary"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran_binary.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran_binary.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -92,13 +92,13 @@ data "template_file" "mirrors_sync_container_definitions_cran_binary" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_cran_binary_container_definition.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.mirrors_sync_cran_binary_container_image}"
     container_name     = "${local.mirrors_sync_cran_binary_container_name}"
     container_cpu      = "${local.mirrors_sync_cran_binary_container_cpu}"
     container_memory   = "${local.mirrors_sync_cran_binary_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_name = "${var.mirrors_bucket_name}"
@@ -108,9 +108,9 @@ data "template_file" "mirrors_sync_container_definitions_cran_binary" {
 resource "aws_ecs_task_definition" "mirrors_sync_pypi" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-pypi"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_pypi.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_pypi.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -121,13 +121,13 @@ data "template_file" "mirrors_sync_container_definitions_pypi" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.mirrors_sync_container_image}"
     container_name     = "${local.mirrors_sync_container_name}"
     container_cpu      = "${local.mirrors_sync_container_cpu}"
     container_memory   = "${local.mirrors_sync_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_region = "${data.aws_region.aws_region.name}"
@@ -147,9 +147,9 @@ data "template_file" "mirrors_sync_container_definitions_pypi" {
 resource "aws_ecs_task_definition" "mirrors_sync_debian" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-debian"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_debian.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_debian.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -160,13 +160,13 @@ data "template_file" "mirrors_sync_container_definitions_debian" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "quay.io/uktrade/data-workspace-mirrors-sync:master"
     container_name     = "${local.mirrors_sync_container_name}"
     container_cpu      = "${local.mirrors_sync_container_cpu}"
     container_memory   = "${local.mirrors_sync_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_region = "${data.aws_region.aws_region.name}"
@@ -186,9 +186,9 @@ data "template_file" "mirrors_sync_container_definitions_debian" {
 resource "aws_ecs_task_definition" "mirrors_sync_nltk" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-nltk"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_nltk.rendered}"
-  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.arn}"
-  task_role_arn         = "${aws_iam_role.mirrors_sync_task.arn}"
+  container_definitions = "${data.template_file.mirrors_sync_container_definitions_nltk.*.rendered[count.index]}"
+  execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
+  task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
@@ -199,13 +199,13 @@ data "template_file" "mirrors_sync_container_definitions_nltk" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image    = "${var.mirrors_sync_container_image}"
     container_name     = "${local.mirrors_sync_container_name}"
     container_cpu      = "${local.mirrors_sync_container_cpu}"
     container_memory   = "${local.mirrors_sync_container_memory}"
 
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
     log_region = "${data.aws_region.aws_region.name}"
 
     mirrors_bucket_region = "${data.aws_region.aws_region.name}"
@@ -231,7 +231,7 @@ resource "aws_cloudwatch_log_group" "mirrors_sync" {
 resource "aws_cloudwatch_log_subscription_filter" "mirrors_sync" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name            = "jupyterhub-mirrors-sync"
-  log_group_name  = "${aws_cloudwatch_log_group.mirrors_sync.name}"
+  log_group_name  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
   filter_pattern  = ""
   destination_arn = "${var.cloudwatch_destination_arn}"
 }
@@ -240,7 +240,7 @@ resource "aws_iam_role" "mirrors_sync_task_execution" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name               = "mirrors-sync-task-execution"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_task_execution_ecs_tasks_assume_role.json}"
+  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_task_execution_ecs_tasks_assume_role.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_task_execution_ecs_tasks_assume_role" {
@@ -257,15 +257,15 @@ data "aws_iam_policy_document" "mirrors_sync_task_execution_ecs_tasks_assume_rol
 
 resource "aws_iam_role_policy_attachment" "mirrors_sync_task_execution" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  role       = "${aws_iam_role.mirrors_sync_task_execution.name}"
-  policy_arn = "${aws_iam_policy.mirrors_sync_task_execution.arn}"
+  role       = "${aws_iam_role.mirrors_sync_task_execution.*.name[count.index]}"
+  policy_arn = "${aws_iam_policy.mirrors_sync_task_execution.*.arn[count.index]}"
 }
 
 resource "aws_iam_policy" "mirrors_sync_task_execution" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name        = "jupyterhub-mirrors-sync-task-execution"
   path        = "/"
-  policy       = "${data.aws_iam_policy_document.mirrors_sync_task_execution.json}"
+  policy       = "${data.aws_iam_policy_document.mirrors_sync_task_execution.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_task_execution" {
@@ -277,7 +277,7 @@ data "aws_iam_policy_document" "mirrors_sync_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.mirrors_sync.arn}",
+      "${aws_cloudwatch_log_group.mirrors_sync.*.arn[count.index]}",
     ]
   }
 }
@@ -286,7 +286,7 @@ resource "aws_iam_role" "mirrors_sync_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name               = "jupyterhub-mirrors-sync-task"
   path               = "/"
-  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_task_ecs_tasks_assume_role.json}"
+  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_task_ecs_tasks_assume_role.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_task_ecs_tasks_assume_role" {
@@ -303,15 +303,15 @@ data "aws_iam_policy_document" "mirrors_sync_task_ecs_tasks_assume_role" {
 
 resource "aws_iam_role_policy_attachment" "mirrors_sync" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  role       = "${aws_iam_role.mirrors_sync_task.name}"
-  policy_arn = "${aws_iam_policy.mirrors_sync_task.arn}"
+  role       = "${aws_iam_role.mirrors_sync_task.*.name[count.index]}"
+  policy_arn = "${aws_iam_policy.mirrors_sync_task.*.arn[count.index]}"
 }
 
 resource "aws_iam_policy" "mirrors_sync_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name        = "jupyterhub-mirrors-sync-task"
   path        = "/"
-  policy       = "${data.aws_iam_policy_document.mirrors_sync_task.json}"
+  policy       = "${data.aws_iam_policy_document.mirrors_sync_task.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_task" {
@@ -324,7 +324,7 @@ data "aws_iam_policy_document" "mirrors_sync_task" {
     ]
 
     resources = [
-      "${aws_s3_bucket.mirrors.arn}/*",
+      "${aws_s3_bucket.mirrors.*.arn[count.index]}/*",
     ]
   }
   statement {
@@ -333,7 +333,7 @@ data "aws_iam_policy_document" "mirrors_sync_task" {
     ]
 
     resources = [
-      "${aws_s3_bucket.mirrors.arn}",
+      "${aws_s3_bucket.mirrors.*.arn[count.index]}",
     ]
   }
 }
@@ -349,12 +349,12 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_pypi_scheduled_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   target_id = "${var.prefix}-mirror-pypi"
   arn       = "${aws_ecs_cluster.main_cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.name}"
-  role_arn  = "${aws_iam_role.mirrors_sync_events.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.*.name[count.index]}"
+  role_arn  = "${aws_iam_role.mirrors_sync_events.*.arn[count.index]}"
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_pypi.arn}"
+    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_pypi.*.arn[count.index]}"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
@@ -369,12 +369,12 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_conda_scheduled_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   target_id = "${var.prefix}-mirror-conda"
   arn       = "${aws_ecs_cluster.main_cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.name}"
-  role_arn  = "${aws_iam_role.mirrors_sync_events.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.*.name[count.index]}"
+  role_arn  = "${aws_iam_role.mirrors_sync_events.*.arn[count.index]}"
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_conda.arn}"
+    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_conda.*.arn[count.index]}"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
@@ -389,12 +389,12 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_cran_scheduled_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   target_id = "${var.prefix}-mirror-cran"
   arn       = "${aws_ecs_cluster.main_cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.name}"
-  role_arn  = "${aws_iam_role.mirrors_sync_events.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.*.name[count.index]}"
+  role_arn  = "${aws_iam_role.mirrors_sync_events.*.arn[count.index]}"
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_cran.arn}"
+    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_cran.*.arn[count.index]}"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
@@ -409,12 +409,12 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_cran_binary_scheduled_task"
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   target_id = "${var.prefix}-mirror-cran-binary"
   arn       = "${aws_ecs_cluster.main_cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.name}"
-  role_arn  = "${aws_iam_role.mirrors_sync_events.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.*.name[count.index]}"
+  role_arn  = "${aws_iam_role.mirrors_sync_events.*.arn[count.index]}"
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_cran_binary.arn}"
+    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_cran_binary.*.arn[count.index]}"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
@@ -429,12 +429,12 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_nltk_scheduled_task" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   target_id = "${var.prefix}-mirror-pypi"
   arn       = "${aws_ecs_cluster.main_cluster.arn}"
-  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.name}"
-  role_arn  = "${aws_iam_role.mirrors_sync_events.arn}"
+  rule      = "${aws_cloudwatch_event_rule.daily_at_four_am.*.name[count.index]}"
+  role_arn  = "${aws_iam_role.mirrors_sync_events.*.arn[count.index]}"
 
   ecs_target {
     task_count          = 1
-    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_nltk.arn}"
+    task_definition_arn = "${aws_ecs_task_definition.mirrors_sync_nltk.*.arn[count.index]}"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
@@ -448,7 +448,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_nltk_scheduled_task" {
 resource "aws_iam_role" "mirrors_sync_events" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name = "${var.prefix_underscore}_mirrors_sync_events"
-  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_events_assume_role_policy.json}"
+  assume_role_policy = "${data.aws_iam_policy_document.mirrors_sync_events_assume_role_policy.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_events_assume_role_policy" {
@@ -465,8 +465,8 @@ data "aws_iam_policy_document" "mirrors_sync_events_assume_role_policy" {
 resource "aws_iam_role_policy" "mirrors_sync_events_run_mirror" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   name = "${var.prefix_underscore}_mirrors_sync_events_run_mirror"
-  role = "${aws_iam_role.mirrors_sync_events.id}"
-  policy = "${data.aws_iam_policy_document.mirrors_sync_events_run_tasks.json}"
+  role = "${aws_iam_role.mirrors_sync_events.*.id[count.index]}"
+  policy = "${data.aws_iam_policy_document.mirrors_sync_events_run_tasks.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors_sync_events_run_tasks" {
@@ -477,11 +477,11 @@ data "aws_iam_policy_document" "mirrors_sync_events_run_tasks" {
     ]
 
     resources = [
-      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_cran.family}:*",
-      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_cran_binary.family}:*",
-      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_conda.family}:*",
-      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_pypi.family}:*",
-      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_nltk.family}:*",
+      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_cran.*.family[count.index]}:*",
+      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_cran_binary.*.family[count.index]}:*",
+      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_conda.*.family[count.index]}:*",
+      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_pypi.*.family[count.index]}:*",
+      "arn:aws:ecs:*:${data.aws_caller_identity.aws_caller_identity.account_id}:task-definition/${aws_ecs_task_definition.mirrors_sync_nltk.*.family[count.index]}:*",
     ]
   }
 
@@ -490,8 +490,8 @@ data "aws_iam_policy_document" "mirrors_sync_events_run_tasks" {
       "iam:PassRole"
     ]
     resources = [
-      "${aws_iam_role.mirrors_sync_task.arn}",
-      "${aws_iam_role.mirrors_sync_task_execution.arn}",
+      "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}",
+      "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}",
     ]
     condition {
       test = "StringLike"

--- a/infra/ecs_main_mirrors_sync.tf
+++ b/infra/ecs_main_mirrors_sync.tf
@@ -277,7 +277,7 @@ data "aws_iam_policy_document" "mirrors_sync_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.mirrors_sync.*.arn[count.index]}",
+      "${aws_cloudwatch_log_group.mirrors_sync.*.arn[count.index]}:*",
     ]
   }
 }
@@ -358,7 +358,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_pypi_scheduled_task" {
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
-      subnets =["${aws_subnet.public.*.id}"]
+      subnets = "${aws_subnet.public.*.id}"
       security_groups = ["${aws_security_group.mirrors_sync.id}"]
       assign_public_ip = true
     }
@@ -378,7 +378,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_conda_scheduled_task" {
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
-      subnets =["${aws_subnet.public.*.id}"]
+      subnets = "${aws_subnet.public.*.id}"
       security_groups = ["${aws_security_group.mirrors_sync.id}"]
       assign_public_ip = true
     }
@@ -398,7 +398,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_cran_scheduled_task" {
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
-      subnets =["${aws_subnet.public.*.id}"]
+      subnets = "${aws_subnet.public.*.id}"
       security_groups = ["${aws_security_group.mirrors_sync.id}"]
       assign_public_ip = true
     }
@@ -418,7 +418,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_cran_binary_scheduled_task"
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
-      subnets =["${aws_subnet.public.*.id}"]
+      subnets = "${aws_subnet.public.*.id}"
       security_groups = ["${aws_security_group.mirrors_sync.id}"]
       assign_public_ip = true
     }
@@ -438,7 +438,7 @@ resource "aws_cloudwatch_event_target" "mirrors_sync_nltk_scheduled_task" {
     launch_type = "FARGATE"
     network_configuration {
       # In a public subnet to KISS and minimise costs. NAT traffic is more expensive
-      subnets =["${aws_subnet.public.*.id}"]
+      subnets = "${aws_subnet.public.*.id}"
       security_groups = ["${aws_security_group.mirrors_sync.id}"]
       assign_public_ip = true
     }

--- a/infra/ecs_main_prometheus.tf
+++ b/infra/ecs_main_prometheus.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "prometheus" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.prometheus_service.id}"]
   }
 
@@ -74,7 +74,7 @@ resource "aws_ecs_task_definition" "prometheus" {
 data "template_file" "prometheus_container_definitions" {
   template = "${file("${path.module}/ecs_main_prometheus_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image   = "${var.prometheus_container_image}:${data.external.prometheus_current_tag.result.tag}"
     container_name    = "${local.prometheus_container_name}"
     container_port    = "${local.prometheus_container_port}"
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "prometheus_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.prometheus.arn}",
+      "${aws_cloudwatch_log_group.prometheus.arn}:*",
     ]
   }
 }
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "prometheus_task_ecs_tasks_assume_role" {
 
 resource "aws_alb" "prometheus" {
   name            = "${var.prefix}-pm"
-  subnets         = ["${aws_subnet.public.*.id}"]
+  subnets         = "${aws_subnet.public.*.id}"
   security_groups = ["${aws_security_group.prometheus_alb.id}"]
 
   access_logs {

--- a/infra/ecs_main_registry.tf
+++ b/infra/ecs_main_registry.tf
@@ -8,7 +8,7 @@ resource "aws_ecs_service" "registry" {
   platform_version = "1.4.0"
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.registry_service.id}"]
   }
 
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "registry" {
 data "template_file" "registry_container_definitions" {
   template = "${file("${path.module}/ecs_main_registry_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.registry_container_image}:${data.external.registry_current_tag.result.tag}"
     container_name   = "${local.registry_container_name}"
     container_port   = "${local.registry_container_port}"
@@ -119,7 +119,7 @@ data "aws_iam_policy_document" "registry_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.registry.arn}",
+      "${aws_cloudwatch_log_group.registry.arn}:*",
     ]
   }
 }
@@ -143,7 +143,7 @@ data "aws_iam_policy_document" "registry_task_ecs_tasks_assume_role" {
 
 resource "aws_alb" "registry" {
   name            = "${var.prefix}-registry"
-  subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+  subnets         = "${aws_subnet.private_with_egress.*.id}"
   security_groups = ["${aws_security_group.registry_alb.id}"]
   internal        = true
 

--- a/infra/ecs_main_sentryproxy.tf
+++ b/infra/ecs_main_sentryproxy.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_service" "sentryproxy" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id}"]
+    subnets         = "${aws_subnet.private_with_egress.*.id}"
     security_groups = ["${aws_security_group.sentryproxy_service.id}"]
   }
 
@@ -64,7 +64,7 @@ resource "aws_ecs_task_definition" "sentryproxy" {
 data "template_file" "sentryproxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_sentryproxy_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.sentryproxy_container_image}:${data.external.sentryproxy_current_tag.result.tag}"
     container_name   = "${local.sentryproxy_container_name}"
     container_cpu    = "${local.sentryproxy_container_cpu}"
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "sentryproxy_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.sentryproxy.arn}",
+      "${aws_cloudwatch_log_group.sentryproxy.arn}:*",
     ]
   }
 }

--- a/infra/ecs_main_superset_multiuser.tf
+++ b/infra/ecs_main_superset_multiuser.tf
@@ -44,7 +44,7 @@ resource "aws_ecs_task_definition" "superset_multiuser" {
 data "template_file" "superset_multiuser_container_definitions" {
   template = "${file("${path.module}/ecs_main_superset_multiuser_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image = "${var.superset_multiuser_container_image}"
     container_name  = "superset-multiuser"
     log_group       = "${aws_cloudwatch_log_group.superset_multiuser.name}"
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "superset_multiuser_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.superset_multiuser.arn}",
+      "${aws_cloudwatch_log_group.superset_multiuser.arn}:*",
     ]
   }
 }
@@ -138,7 +138,7 @@ resource "aws_lb" "superset_multiuser" {
   load_balancer_type = "application"
   internal           = true
   security_groups    = ["${aws_security_group.superset_multiuser_lb.id}"]
-  subnets            = ["${aws_subnet.private_without_egress.*.id}"]
+  subnets            = "${aws_subnet.private_without_egress.*.id}"
 }
 
 resource "aws_lb_listener" "superset_multiuser_443" {
@@ -179,7 +179,7 @@ resource "aws_lb_target_group" "superset_multiuser_8000" {
 resource "aws_rds_cluster" "superset_multiuser" {
   cluster_identifier      = "${var.prefix}-superset-multiuser"
   engine                  = "aurora-postgresql"
-  availability_zones      = ["${var.aws_availability_zones}"]
+  availability_zones      = "${var.aws_availability_zones}"
   database_name           = "${var.prefix_underscore}_superset_multiuser"
   master_username         = "${var.prefix_underscore}_superset_multiuser_master"
   master_password         = "${random_string.aws_db_instance_superset_multiuser_password.result}"
@@ -204,9 +204,9 @@ resource "aws_rds_cluster_instance" "superset_multiuser" {
 
 resource "aws_db_subnet_group" "superset_multiuser" {
   name       = "${var.prefix}-superset-multiuser"
-  subnet_ids = ["${aws_subnet.private_without_egress.*.id}"]
+  subnet_ids = "${aws_subnet.private_without_egress.*.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-superset-multiuser"
   }
 

--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -49,7 +49,7 @@ data "external" "jupyterlabpython_s3sync_current_tag" {
 data "template_file" "jupyterlabpython_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.jupyterlab_python_container_image}:${data.external.jupyterlabpython_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_notebooks_jupyterlab_r.tf
+++ b/infra/ecs_notebooks_jupyterlab_r.tf
@@ -49,7 +49,7 @@ data "external" "jupyterlabr_s3sync_current_tag" {
 data "template_file" "jupyterlabr_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.jupyterlab_r_container_image}:${data.external.jupyterlabr_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -49,7 +49,7 @@ data "external" "notebook_s3sync_current_tag" {
 data "template_file" "notebook_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.notebook_container_image}:${data.external.notebook_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "notebook_task_execution" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.notebook.arn}",
+      "${aws_cloudwatch_log_group.notebook.arn}:*",
     ]
   }
 

--- a/infra/ecs_notebooks_pgweb.tf
+++ b/infra/ecs_notebooks_pgweb.tf
@@ -49,7 +49,7 @@ data "external" "pgweb_s3sync_current_tag" {
 data "template_file" "pgweb_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.pgweb_container_image}:pgweb-spike"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -48,7 +48,7 @@ data "external" "remotedesktop_s3sync_current_tag" {
 data "template_file" "remotedesktop_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.remotedesktop_container_image}:${data.external.remotedesktop_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -48,7 +48,7 @@ data "external" "superset_s3sync_current_tag" {
 data "template_file" "superset_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.superset_container_image}:master"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -48,7 +48,7 @@ data "external" "theia_s3sync_current_tag" {
 data "template_file" "theia_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.theia_container_image}:master"
     container_name   = "${local.notebook_container_name}"
 

--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -49,7 +49,7 @@ data "external" "pgadmin_s3sync_current_tag" {
 data "template_file" "pgadmin_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.pgadmin_container_image}:${data.external.pgadmin_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
     container_cpu    = "${local.notebook_container_cpu}"

--- a/infra/ecs_rstudio.tf
+++ b/infra/ecs_rstudio.tf
@@ -49,7 +49,7 @@ data "external" "rstudio_s3sync_current_tag" {
 data "template_file" "rstudio_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_image  = "${var.rstudio_container_image}:${data.external.rstudio_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
     container_cpu    = "${local.notebook_container_cpu}"

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -27,7 +27,7 @@ data "external" "user_provided_metrics_current_tag" {
 data "template_file" "user_provided_container_definitions" {
   template = "${file("${path.module}/ecs_user_provided_container_definitions.json")}"
 
-  vars {
+  vars = {
     container_name   = "${local.user_provided_container_name}"
     container_cpu    = "${local.user_provided_container_cpu}"
     container_memory = "${local.user_provided_container_memory}"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -145,6 +145,13 @@ variable dataset_subnets_availability_zones {
 variable quicksight_security_group_name {}
 variable quicksight_security_group_description {}
 variable quicksight_subnet_availability_zone {}
+variable route_53_assume_role {
+  type    = bool
+  default = false
+}
+variable route_53_assume_role_arn {
+  default = ""
+}
 
 locals {
   registry_container_name    = "jupyterhub-registry"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,6 +1,14 @@
 data "aws_region" "aws_region" {}
 data "aws_caller_identity" "aws_caller_identity" {}
 
+provider "aws" {}
+provider "aws" {
+  alias = "route53"
+}
+provider "aws" {
+  alias = "mirror"
+}
+
 variable aws_availability_zones {
  type = "list"
 }
@@ -145,13 +153,6 @@ variable dataset_subnets_availability_zones {
 variable quicksight_security_group_name {}
 variable quicksight_security_group_description {}
 variable quicksight_subnet_availability_zone {}
-variable route_53_assume_role {
-  type    = bool
-  default = false
-}
-variable route_53_assume_role_arn {
-  default = ""
-}
 
 locals {
   registry_container_name    = "jupyterhub-registry"

--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -31,9 +31,9 @@ resource "aws_db_instance" "admin" {
 
 resource "aws_db_subnet_group" "admin" {
   name       = "${var.prefix}-admin"
-  subnet_ids = ["${aws_subnet.private_with_egress.*.id}"]
+  subnet_ids = "${aws_subnet.private_with_egress.*.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin"
   }
 }

--- a/infra/rds_datasets.tf
+++ b/infra/rds_datasets.tf
@@ -1,5 +1,5 @@
 resource "aws_rds_cluster" "datasets" {
-  availability_zones            = ["${var.aws_availability_zones}"]
+  availability_zones            = "${var.aws_availability_zones}"
   backup_retention_period       = "${var.datasets_rds_cluster_backup_retention_period}"
   cluster_identifier            = "${var.datasets_rds_cluster_cluster_identifier}"
   database_name                 = "${var.datasets_rds_cluster_database_name}"
@@ -35,9 +35,9 @@ resource "aws_rds_cluster_instance" "datasets" {
 
 resource "aws_db_subnet_group" "datasets" {
   name       = "${var.prefix}-datasets"
-  subnet_ids = ["${aws_subnet.datasets.*.id}"]
+  subnet_ids = "${aws_subnet.datasets.*.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets"
   }
 }
@@ -48,6 +48,6 @@ resource "random_string" "aws_rds_cluster_instance_datasets_password" {
   special = false
 
   lifecycle {
-    ignore_changes = "*"
+    ignore_changes = all
   }
 }

--- a/infra/rds_jupyterhub.tf
+++ b/infra/rds_jupyterhub.tf
@@ -24,9 +24,9 @@
 
 resource "aws_db_subnet_group" "jupyterhub" {
   name       = "${var.prefix}"
-  subnet_ids = ["${aws_subnet.private_with_egress.*.id}"]
+  subnet_ids = "${aws_subnet.private_with_egress.*.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -1,10 +1,25 @@
+provider "aws" {
+  region  = "eu-west-2"
+  profile = "jupyterhub"
+  alias   = "route53"
+  version = "~> 3.2.0"
+
+  dynamic "assume_role" {
+    for_each = var.route_53_assume_role ? [1] : [0]
+    content {
+      role_arn = "${var.route_53_assume_role_arn}"
+    }
+  }
+
+}
+
 data "aws_route53_zone" "aws_route53_zone" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   name = "${var.aws_route53_zone}"
 }
 
 resource "aws_route53_record" "registry" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.registry_internal_domain}"
   type    = "A"
@@ -34,7 +49,7 @@ resource "aws_acm_certificate_validation" "registry" {
 }
 
 resource "aws_route53_record" "admin" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.admin_domain}"
   type    = "A"
@@ -51,7 +66,7 @@ resource "aws_route53_record" "admin" {
 }
 
 resource "aws_route53_record" "applications" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "*.${var.admin_domain}"
   type    = "A"
@@ -82,7 +97,7 @@ resource "aws_acm_certificate_validation" "admin" {
 }
 
 resource "aws_route53_record" "healthcheck" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.healthcheck_domain}"
   type    = "A"
@@ -112,7 +127,7 @@ resource "aws_acm_certificate_validation" "healthcheck" {
 }
 
 resource "aws_route53_record" "prometheus" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.prometheus_domain}"
   type    = "A"
@@ -142,7 +157,7 @@ resource "aws_acm_certificate_validation" "prometheus" {
 }
 
 resource "aws_route53_record" "gitlab" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id  = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name     = "${var.gitlab_domain}"
   type     = "A"
@@ -159,7 +174,7 @@ resource "aws_route53_record" "gitlab" {
 }
 
 resource "aws_route53_record" "superset_multiuser_internal" {
-  # provider = "aws.route53"
+  provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.superset_internal_domain}"
   type    = "A"

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -1,10 +1,10 @@
 data "aws_route53_zone" "aws_route53_zone" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   name = "${var.aws_route53_zone}"
 }
 
 resource "aws_route53_record" "registry" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.registry_internal_domain}"
   type    = "A"
@@ -34,7 +34,7 @@ resource "aws_acm_certificate_validation" "registry" {
 }
 
 resource "aws_route53_record" "admin" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.admin_domain}"
   type    = "A"
@@ -51,7 +51,7 @@ resource "aws_route53_record" "admin" {
 }
 
 resource "aws_route53_record" "applications" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "*.${var.admin_domain}"
   type    = "A"
@@ -82,7 +82,7 @@ resource "aws_acm_certificate_validation" "admin" {
 }
 
 resource "aws_route53_record" "healthcheck" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.healthcheck_domain}"
   type    = "A"
@@ -112,7 +112,7 @@ resource "aws_acm_certificate_validation" "healthcheck" {
 }
 
 resource "aws_route53_record" "prometheus" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.prometheus_domain}"
   type    = "A"
@@ -142,7 +142,7 @@ resource "aws_acm_certificate_validation" "prometheus" {
 }
 
 resource "aws_route53_record" "gitlab" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id  = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name     = "${var.gitlab_domain}"
   type     = "A"
@@ -159,7 +159,7 @@ resource "aws_route53_record" "gitlab" {
 }
 
 resource "aws_route53_record" "superset_multiuser_internal" {
-  provider = "aws.route53"
+  # provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.superset_internal_domain}"
   type    = "A"

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -1,18 +1,3 @@
-provider "aws" {
-  region  = "eu-west-2"
-  profile = "jupyterhub"
-  alias   = "route53"
-  version = "~> 3.2.0"
-
-  dynamic "assume_role" {
-    for_each = var.route_53_assume_role ? [1] : [0]
-    content {
-      role_arn = "${var.route_53_assume_role_arn}"
-    }
-  }
-
-}
-
 data "aws_route53_zone" "aws_route53_zone" {
   provider = "aws.route53"
   name = "${var.aws_route53_zone}"

--- a/infra/s3_mirrors.tf
+++ b/infra/s3_mirrors.tf
@@ -14,13 +14,13 @@ resource "aws_s3_bucket" "mirrors" {
 data "aws_s3_bucket" "mirrors" {
   count = "${var.mirrors_data_bucket_name != "" ? 1 : 0}"
   bucket = "${var.mirrors_data_bucket_name}"
-  provider = "aws.mirror"
+  # provider = "aws.mirror"
 }
 
 resource "aws_s3_bucket_policy" "mirrors" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  bucket = "${aws_s3_bucket.mirrors.id}"
-  policy = "${data.aws_iam_policy_document.mirrors.json}"
+  bucket = "${aws_s3_bucket.mirrors.*.id[count.index]}"
+  policy = "${data.aws_iam_policy_document.mirrors.*.json[count.index]}"
 }
 
 data "aws_iam_policy_document" "mirrors" {
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "mirrors" {
     ]
 
     resources = [
-      "${aws_s3_bucket.mirrors.arn}/*",
+      "${aws_s3_bucket.mirrors.*.arn[count.index]}/*",
     ]
   }
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "dns_rewrite_proxy" {
   description = "${var.prefix}-dns-rewrite-proxy"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-dns-rewrite-proxy"
   }
 
@@ -51,7 +51,7 @@ resource "aws_security_group" "sentryproxy_service" {
   description = "${var.prefix}-sentryproxy"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-sentryproxy"
   }
 
@@ -89,7 +89,7 @@ resource "aws_security_group" "registry_alb" {
   description = "${var.prefix}-registry-alb"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-registry-alb"
   }
 
@@ -151,7 +151,7 @@ resource "aws_security_group" "registry_service" {
   description = "${var.prefix}-registry-service"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-registry-service"
   }
 
@@ -190,7 +190,7 @@ resource "aws_security_group" "admin_alb" {
   description = "${var.prefix}-admin-alb"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin-alb"
   }
 
@@ -203,7 +203,7 @@ resource "aws_security_group_rule" "admin_alb_ingress_https_from_whitelist" {
   description = "ingress-https-from-whitelist"
 
   security_group_id = "${aws_security_group.admin_alb.id}"
-  cidr_blocks       = ["${var.ip_whitelist}", "${aws_eip.nat_gateway.public_ip}/32"]
+  cidr_blocks       = concat("${var.ip_whitelist}", ["${aws_eip.nat_gateway.public_ip}/32"])
 
   type       = "ingress"
   from_port  = "443"
@@ -215,7 +215,7 @@ resource "aws_security_group_rule" "admin_alb_ingress_http_from_whitelist" {
   description = "ingress-http-from-whitelist"
 
   security_group_id = "${aws_security_group.admin_alb.id}"
-  cidr_blocks       = ["${var.ip_whitelist}"]
+  cidr_blocks       = "${var.ip_whitelist}"
 
   type       = "ingress"
   from_port  = "80"
@@ -227,7 +227,7 @@ resource "aws_security_group_rule" "admin_alb_ingress_icmp_host_unreachable_for_
   description = "ingress-icmp-host-unreachable-for-mtu-discovery-from-whitelist"
 
   security_group_id = "${aws_security_group.admin_alb.id}"
-  cidr_blocks       = ["${var.ip_whitelist}"]
+  cidr_blocks       = "${var.ip_whitelist}"
 
   type      = "ingress"
   from_port = 3
@@ -264,7 +264,7 @@ resource "aws_security_group" "admin_redis" {
   description = "${var.prefix}-admin-redis"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin-redis"
   }
 
@@ -302,7 +302,7 @@ resource "aws_security_group" "admin_service" {
   description = "${var.prefix}-admin-service"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin-service"
   }
 
@@ -449,7 +449,7 @@ resource "aws_security_group" "admin_db" {
   description = "${var.prefix}-admin-db"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin-db"
   }
 
@@ -475,7 +475,7 @@ resource "aws_security_group" "notebooks" {
   description = "${var.prefix}-notebooks"
   vpc_id      = "${aws_vpc.notebooks.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-notebooks"
   }
 
@@ -598,7 +598,7 @@ resource "aws_security_group" "cloudwatch" {
   description = "${var.prefix}-cloudwatch"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-cloudwatch"
   }
 
@@ -612,7 +612,7 @@ resource "aws_security_group" "ecr_dkr" {
   description = "${var.prefix}-ecr-dkr"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-ecr-dkr"
   }
 
@@ -626,7 +626,7 @@ resource "aws_security_group" "ecr_api" {
   description = "${var.prefix}-ecr-api"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-ecr-api"
   }
 
@@ -700,7 +700,7 @@ resource "aws_security_group" "mirrors_sync" {
   description = "${var.prefix}-mirrors-sync"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-mirrors-sync"
   }
 
@@ -726,7 +726,7 @@ resource "aws_security_group" "healthcheck_alb" {
   description = "${var.prefix}-healthcheck-alb"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-healthcheck-alb"
   }
 
@@ -776,7 +776,7 @@ resource "aws_security_group" "healthcheck_service" {
   description = "${var.prefix}-healthcheck_service"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-healthcheck_service"
   }
 
@@ -826,7 +826,7 @@ resource "aws_security_group" "prometheus_alb" {
   description = "${var.prefix}-prometheus-alb"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-prometheus-alb"
   }
 
@@ -851,7 +851,7 @@ resource "aws_security_group_rule" "prometheus_alb_ingress_https_from_whitelist"
   description = "ingress-https-from-all"
 
   security_group_id = "${aws_security_group.prometheus_alb.id}"
-  cidr_blocks       = ["${var.prometheus_whitelist}", "${aws_eip.nat_gateway.public_ip}/32"]
+  cidr_blocks       = concat("${var.prometheus_whitelist}", ["${aws_eip.nat_gateway.public_ip}/32"])
 
   type       = "ingress"
   from_port  = "443"
@@ -876,7 +876,7 @@ resource "aws_security_group" "prometheus_service" {
   description = "${var.prefix}-prometheus_service"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-prometheus_service"
   }
 
@@ -926,7 +926,7 @@ resource "aws_security_group" "gitlab_service" {
   description = "${var.prefix}-gitlab-service"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-gitlab-service"
   }
 
@@ -1036,7 +1036,7 @@ resource "aws_security_group" "gitlab_redis" {
   description = "${var.prefix}-gitlab-redis"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-admin-gitlab"
   }
 
@@ -1062,7 +1062,7 @@ resource "aws_security_group" "gitlab_db" {
   description = "${var.prefix}-gitlab-db"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-gitlab-db"
   }
 
@@ -1088,7 +1088,7 @@ resource "aws_security_group" "gitlab-ec2" {
   description = "${var.prefix}-gitlab-ec2"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-gitlab-ec2"
   }
 
@@ -1126,7 +1126,7 @@ resource "aws_security_group" "gitlab_runner" {
   description = "${var.prefix}-gitlab-runner"
   vpc_id      = "${aws_vpc.notebooks.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-gitlab-runner"
   }
 
@@ -1190,7 +1190,7 @@ resource "aws_security_group" "superset_multiuser_db" {
   description = "${var.prefix}-superset-multiuser-db"
   vpc_id      = "${aws_vpc.notebooks.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-superset-multiuser-db"
   }
 
@@ -1216,7 +1216,7 @@ resource "aws_security_group" "superset_multiuser_service" {
   description = "${var.prefix}-superset-multiuser-service"
   vpc_id      = "${aws_vpc.notebooks.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-superset-multiuser-service"
   }
 
@@ -1290,7 +1290,7 @@ resource "aws_security_group" "superset_multiuser_lb" {
   description = "${var.prefix}-superset-multiuser-lb"
   vpc_id      = "${aws_vpc.notebooks.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-superset-multiuser-lb"
   }
 
@@ -1328,7 +1328,7 @@ resource "aws_security_group" "efs_notebooks" {
   description = "${var.prefix}-efs-notebooks"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-efs-notebooks"
   }
 
@@ -1342,7 +1342,7 @@ resource "aws_security_group" "efs_mount_target_notebooks" {
   description = "${var.prefix}-efs-mount-target-notebooks"
   vpc_id      = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-efs-mount-target-notebooks"
   }
 
@@ -1369,7 +1369,7 @@ resource "aws_security_group" "quicksight" {
   description = "${var.quicksight_security_group_description}"
   vpc_id      = "${aws_vpc.datasets.id}"
 
-  tags {
+  tags = {
     Name = "${var.quicksight_security_group_name}"
   }
 
@@ -1407,7 +1407,7 @@ resource "aws_security_group" "datasets" {
   description = "${var.prefix}-datasets"
   vpc_id      = "${aws_vpc.datasets.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets"
   }
 

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -32,7 +32,7 @@ resource "aws_vpc" "notebooks" {
 }
 
 resource "aws_flow_log" "notebooks" {
-  log_group_name = "${aws_cloudwatch_log_group.vpc_main_flow_log.name}"
+  log_destination = "${aws_cloudwatch_log_group.vpc_main_flow_log.name}"
   iam_role_arn   = "${aws_iam_role.vpc_notebooks_flow_log.arn}"
   vpc_id         = "${aws_vpc.notebooks.id}"
   traffic_type   = "ALL"
@@ -88,7 +88,7 @@ resource "aws_vpc_dhcp_options_association" "main" {
 }
 
 resource "aws_flow_log" "main" {
-  log_group_name = "${aws_cloudwatch_log_group.vpc_main_flow_log.name}"
+  log_destination = "${aws_cloudwatch_log_group.vpc_main_flow_log.name}"
   iam_role_arn   = "${aws_iam_role.vpc_main_flow_log.arn}"
   vpc_id         = "${aws_vpc.main.id}"
   traffic_type   = "ALL"

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -22,7 +22,7 @@ resource "aws_vpc" "notebooks" {
   enable_dns_support   = false
   enable_dns_hostnames = false
 
-  tags {
+  tags = {
     Name = "${var.prefix}-notebooks"
   }
 
@@ -64,7 +64,7 @@ resource "aws_vpc" "main" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 
@@ -77,7 +77,7 @@ resource "aws_vpc_dhcp_options" "main" {
   domain_name_servers = ["AmazonProvidedDNS"]
   domain_name = "eu-west-2.compute.internal"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }
@@ -130,7 +130,7 @@ data "aws_iam_policy_document" "vpc_main_flow_log" {
     ]
 
     resources = [
-      "${aws_cloudwatch_log_group.vpc_main_flow_log.arn}",
+      "${aws_cloudwatch_log_group.vpc_main_flow_log.arn}:*",
     ]
   }
 }
@@ -142,7 +142,7 @@ resource "aws_subnet" "public" {
 
   availability_zone = "${var.aws_availability_zones[count.index]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-public-${var.aws_availability_zones_short[count.index]}"
   }
 
@@ -158,7 +158,7 @@ resource "aws_subnet" "private_with_egress" {
 
   availability_zone = "${var.aws_availability_zones[count.index]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-private-with-egress-${var.aws_availability_zones_short[count.index]}"
   }
 
@@ -174,7 +174,7 @@ resource "aws_subnet" "public_whitelisted_ingress" {
 
   availability_zone = "${var.aws_availability_zones[count.index]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-public-whitelisted-ingress-${var.aws_availability_zones_short[count.index]}"
   }
 
@@ -191,9 +191,9 @@ resource "aws_route_table_association" "public_whitelisted_ingress" {
 
 resource "aws_network_acl" "public_whitelisted_ingress" {
   vpc_id     = "${aws_vpc.main.id}"
-  subnet_ids = ["${aws_subnet.public_whitelisted_ingress.*.id}"]
+  subnet_ids = "${aws_subnet.public_whitelisted_ingress.*.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-public-whitelisted-ingress"
   }
 }
@@ -243,7 +243,7 @@ resource "aws_network_acl_rule" "public_whitelisted_ingress_vpc_ingress" {
 
   egress      = false
   protocol    = "tcp"
-  rule_number = "${length(var.gitlab_ip_whitelist) * 4 + count.index + 1}"
+  rule_number = "${length(var.gitlab_ip_whitelist) * 4 + 1}"
   rule_action = "allow"
   cidr_block  = "${aws_vpc.main.cidr_block}"
   from_port   = 0
@@ -254,7 +254,7 @@ resource "aws_network_acl_rule" "public_whitelisted_ingress_vpc_egress" {
 
   egress      = true
   protocol    = "tcp"
-  rule_number = "${length(var.gitlab_ip_whitelist) * 4 + count.index + 2}"
+  rule_number = "${length(var.gitlab_ip_whitelist) * 4 + 2}"
   rule_action = "allow"
   cidr_block  = "${aws_vpc.main.cidr_block}"
   from_port   = 0
@@ -268,7 +268,7 @@ resource "aws_subnet" "private_without_egress" {
 
   availability_zone = "${var.aws_availability_zones[count.index]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-private-without-egress-${var.aws_availability_zones_short[count.index]}"
   }
 
@@ -279,7 +279,7 @@ resource "aws_subnet" "private_without_egress" {
 
 resource "aws_route_table" "public" {
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "${var.prefix}-public"
   }
 }
@@ -298,7 +298,7 @@ resource "aws_route" "public_internet_gateway_ipv4" {
 
 resource "aws_route_table" "private_with_egress" {
   vpc_id = "${aws_vpc.main.id}"
-  tags {
+  tags = {
     Name = "${var.prefix}-private-with-egress"
   }
 }
@@ -326,7 +326,7 @@ resource "aws_route" "private_with_egress_nat_gateway_ipv4" {
 resource "aws_internet_gateway" "main" {
   vpc_id = "${aws_vpc.main.id}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }
@@ -335,7 +335,7 @@ resource "aws_nat_gateway" "main" {
   allocation_id = "${aws_eip.nat_gateway.id}"
   subnet_id     = "${aws_subnet.public.*.id[0]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}"
   }
 }
@@ -346,7 +346,7 @@ resource "aws_eip" "nat_gateway" {
 
 resource "aws_route_table" "private_without_egress" {
   vpc_id = "${aws_vpc.notebooks.id}"
-  tags {
+  tags = {
     Name = "${var.prefix}-private-without-egress"
   }
 }
@@ -377,7 +377,7 @@ resource "aws_vpc" "datasets" {
   enable_dns_support   = true
   enable_dns_hostnames = false
 
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets"
   }
 
@@ -441,7 +441,7 @@ resource "aws_vpc_peering_connection" "datasets_to_notebooks" {
 
 resource "aws_route_table" "datasets" {
   vpc_id = "${aws_vpc.datasets.id}"
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets"
   }
 }
@@ -489,7 +489,7 @@ resource "aws_subnet" "datasets" {
 
   availability_zone = "${var.dataset_subnets_availability_zones[count.index]}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets-${var.aws_availability_zones_short[count.index]}"
   }
 
@@ -510,7 +510,7 @@ resource "aws_subnet" "datasets_quicksight" {
 
   availability_zone = "${var.quicksight_subnet_availability_zone}"
 
-  tags {
+  tags = {
     Name = "${var.prefix}-datasets-quicksight"
   }
 


### PR DESCRIPTION
### Description of change

This creates an NLB to sit in front of the dns-rewrite-proxy ECS service. The NLB has a fixed ip address attached to it in its subnet_mapping meaning that tools should always be able to reach a nameserver. Previously the nameserver was set to the ECS task's ip address meaning that a forced redeployment of the service would result in the tool's dns resolution failing.

This also removes the TCP 53 container port as the ECS loadbalancer block doesn't work with multiple protocols for the same port and it turns out the dns-rewrite-proxy doesn't actually listen on TCP anyway.

Setting the NLB's ip address required an upgrade of the aws provider to version 3.2.0 which required an upgrade to terraform v0.12 in order for it to be compatible. The terraform upgrade required quite a lot of syntax changes and was done as a seperate commit. The accompanying terraform-data-workspace changes can be seen in this PR: https://gitlab.ci.uktrade.digital/data-infrastructure/terraform-data-workspace/-/merge_requests/12

This PR has been tested on catalogue-dev and works. Once both PRs are merged anyone running a terraform command will need to download v0.12 and run a `terraform init`.

https://trello.com/c/icYVH6Hh/821-dns-resolver-ha-with-fixed-private-ip-address-to-avoid-rebooting-breaking-tools
### Checklist

* [ ] Have tests been added to cover any changes?
