### PR TITLE
fix: GTM expects span around the number of results

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -80,7 +80,7 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-body">
-      {{ datasets.paginator.count }} results
+      <span id="search-results-count">{{ datasets.paginator.count }}</span> results
     </h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     {{ form.sort }}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -231,6 +231,19 @@ def test_find_datasets_with_no_results(client):
     assert b"There are no results for your search" in response.content
 
 
+def test_find_datasets_has_search_result_count_span_for_live_search_and_gtm(client):
+    response = client.get(reverse('datasets:find_datasets'))
+
+    assert response.status_code == 200
+    doc = html.fromstring(response.content.decode(response.charset))
+
+    elem = doc.xpath('//*[@id="search-results-count"]')
+    assert (
+        len(elem) == 1
+    ), "There must be a node with the 'search-results-count' id for live search/GTM to work correctly."
+    assert elem[0].text.isnumeric(), "The contents of the node should be numeric only"
+
+
 def test_find_datasets_combines_results(client):
     factories.DataSetFactory.create(published=False, name='Unpublished search dataset')
     ds = factories.DataSetFactory.create(published=True, name='A search dataset')


### PR DESCRIPTION
### Description of change
If this is removed, GTM breaks and live search also breaks and fails to
push state changes to the window history.

### Checklist

* [ ] Have tests been added to cover any changes?
