### PR TITLE
Persist git settings for GitLab

### DIFF
--- a/gitlab/start.sh
+++ b/gitlab/start.sh
@@ -15,4 +15,20 @@ mkdir -p /etc/gitlab/
 chmod 600 /etc/gitlab/*_key
 chmod 600 /etc/gitlab/gitlab-secrets.json
 
+# Tweak git settings to support checking out large repos without corruption
+cat << EOF > /etc/gitlab/post-reconfigure.sh
+echo "Applying custom git config for Data Workspace ..."
+
+git config --system pack.windowMemory "100m"
+git config --system pack.SizeLimit "100m"
+git config --system pack.threads "1"
+git config --system pack.window "0"
+
+echo "Done applying custom git config for Data Workspace"
+EOF
+
+chmod +x /etc/gitlab/post-reconfigure.sh
+
+export GITLAB_POST_RECONFIGURE_SCRIPT=/etc/gitlab/post-reconfigure.sh
+
 /assets/wrapper

--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "shared" {
+  key_name = "${var.prefix}"
+  public_key = "${var.shared_keypair_public_key}"
+}

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -422,7 +422,7 @@ resource "aws_instance" "gitlab" {
 
   vpc_security_group_ids      = ["${aws_security_group.gitlab-ec2.id}"]
   associate_public_ip_address = "false"
-  key_name                    = "${var.gitlab_key}"
+  key_name                    = "${aws_key_pair.shared.key_name}"
 
   subnet_id                   = "${aws_subnet.private_with_egress.*.id[0]}"
   user_data                   = <<EOF
@@ -514,7 +514,7 @@ resource "aws_launch_configuration" "gitlab_runner" {
   instance_type   = "${var.gitlab_runner_instance_type}"
   iam_instance_profile = "${aws_iam_instance_profile.gitlab_runner.name}"
   security_groups = ["${aws_security_group.gitlab_runner.id}"]
-  key_name        = "${var.gitlab_runner_key}"
+  key_name        = "${aws_key_pair.shared.key_name}"
 
   associate_public_ip_address = false
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -128,9 +128,6 @@ variable gitlab_sso_id {}
 variable gitlab_sso_secret {}
 variable gitlab_sso_domain {}
 
-variable gitlab_key {}
-variable gitlab_runner_key {}
-
 variable superset_multiuser_admin_users {}
 variable superset_multiuser_db_instance_class {}
 variable superset_multiuser_container_image {}
@@ -157,6 +154,8 @@ variable dataset_subnets_availability_zones {
 variable quicksight_security_group_name {}
 variable quicksight_security_group_description {}
 variable quicksight_subnet_availability_zone {}
+
+variable shared_keypair_public_key {}
 
 locals {
   registry_container_name    = "jupyterhub-registry"


### PR DESCRIPTION
### Description of change
Users have previously reported issues checking out larger git repos from GitLab, and investigation by Michal led to a number of git config settings that alleviated the issue. These were previously issued as one-off commands on the instance, but now we should persist them so they can be applied to any future releases of the gitlab instance.

As part of this change we're moving from an individual's SSH key on the gitlab core instances to a shared one that has been stored in passman. TF PR is separate.

### Checklist

* [ ] Have tests been added to cover any changes?
