### PR TITLE
fix: allow more form fields in POST

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -630,3 +630,9 @@ DATAFLOW_API_CONFIG = {
     'DATAFLOW_HAWK_KEY': env.get('DATAFLOW_HAWK_KEY'),
     'DATAFLOW_S3_IMPORT_DAG': env.get('DATAFLOW_S3_IMPORT_DAG'),
 }
+
+# We increase this from the default (1000) because we want some datasets to be able to be granted to thousands of users
+# This is not an ideal solution, but it is a quite one. A better solution might eventually involve groups of users,
+# and granting a single group permissions on a dataset. For our admin dataset permissions, django sends one form field
+# per user granted, rather than a single field with e.g. comma-separated users.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000


### PR DESCRIPTION
### Description of change
Sometimes we want to grant thousands of users access to a dataset.
Django forms end up sending one form field for each user. The default
limit on # form fields submitted per POST is 1000. This means that at
the moment, there's (roughly) an upper limit of 1000 users that can be
granted access to a dataset - existing users must be sent as well, so
it's not as if we can continuously grant 1000 users new access in each
request.

This bumps the limit to 10,000 form fields, which should be more than good
enough for a fair while - ideally until a better solution is available,
e.g. granting datasets to a group that contains multiple users.

We also tweak the quicksight sync code so that it does a bulk refresh
rather than a user-by-user refresh if we're adding/removing a lot of
users at once - this should result in fewer AWS calls and probably
faster refreshes.

### Checklist

* [ ] Have tests been added to cover any changes?
