### PR TITLE
fix: refresh results when clearing search input

### DIFF
--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -43,6 +43,10 @@
       'change', 'input[type=checkbox], input[type=search], select',
       this.formChange.bind(this)
     );
+    this.$form.on(
+      'search', 'input[type=search]',
+      this.formChange.bind(this)
+    );
     $(window).on('popstate', this.popState.bind(this));
 
     this.$form.find('input[type=submit]').click(


### PR DESCRIPTION
### Description of change
HTML5 inputs with a 'search' type get a little "x" automatically added
in some browsers. Clicking this clears the search input but doesn't
refresh the results on Data Workspace's search page. We can hook into
this by recognising a form change on the 'search' event.

![2021-02-05 15 12 40](https://user-images.githubusercontent.com/2920760/107051682-a423e980-67c4-11eb-94bb-0cd17e532e73.gif)


### Checklist

* [ ] Have tests been added to cover any changes?
