### PR TITLE
feat: create table validate -> ingest -> success

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -53,6 +53,10 @@ def dataset_type_to_manage_unpublished_permission_codename(dataset_type: int):
     }[dataset_type]
 
 
+def get_sql_snippet(schema, table_name, limit=50):
+    return f"""SELECT * FROM "{schema}"."{table_name}" LIMIT {limit}"""
+
+
 def get_code_snippets(source_table):
     if not hasattr(source_table, 'schema') or not hasattr(source_table, 'table'):
         return {}
@@ -88,6 +92,8 @@ while (!dbHasCompleted(res)) {{
     print(chunk)
 }}"""
 
-    sql_snippet = f"""SELECT * FROM "{schema}"."{table_name}" LIMIT 50"""
-
-    return {"python": python_snippet, "r": r_snippet, "sql": sql_snippet}
+    return {
+        "python": python_snippet,
+        "r": r_snippet,
+        "sql": get_sql_snippet(schema, table_name),
+    }

--- a/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
+++ b/dataworkspace/dataworkspace/apps/explorer/templatetags/explorer_tags.py
@@ -1,4 +1,9 @@
+from urllib.parse import quote
+
 from django import template
+from django.urls import reverse
+
+from dataworkspace.apps.datasets.utils import get_sql_snippet
 
 register = template.Library()
 
@@ -40,3 +45,8 @@ def format_duration(milli_seconds, short=False):
 @register.filter
 def format_duration_short(milli_seconds):
     return format_duration(milli_seconds, short=True)
+
+
+@register.simple_tag
+def query_table_in_explorer_link(schema, table, *args, **kwargs):
+    return f"{reverse('explorer:index')}?sql={quote(get_sql_snippet(schema, table))}"

--- a/dataworkspace/dataworkspace/apps/your_files/urls.py
+++ b/dataworkspace/dataworkspace/apps/your_files/urls.py
@@ -1,11 +1,44 @@
 from django.urls import path
 
 from dataworkspace.apps.accounts.utils import login_required
-from dataworkspace.apps.your_files.views import CreateTableView, file_browser_html_view
+from dataworkspace.apps.your_files.views import (
+    CreateTableDAGStatusView,
+    CreateTableFailedView,
+    CreateTableIngestingView,
+    CreateTableSuccessView,
+    CreateTableValidatingView,
+    CreateTableView,
+    file_browser_html_view,
+)
 
 urlpatterns = [
     path('', login_required(file_browser_html_view), name='files'),
     path(
         'create-table', login_required(CreateTableView.as_view()), name='create-table'
+    ),
+    path(
+        'create-table/validating',
+        login_required(CreateTableValidatingView.as_view()),
+        name='create-table-validating',
+    ),
+    path(
+        'create-table/ingesting',
+        login_required(CreateTableIngestingView.as_view()),
+        name='create-table-ingesting',
+    ),
+    path(
+        'create-table/success',
+        login_required(CreateTableSuccessView.as_view()),
+        name='create-table-success',
+    ),
+    path(
+        'create-table/failed',
+        login_required(CreateTableFailedView.as_view()),
+        name='create-table-failed',
+    ),
+    path(
+        'create-table/status/<str:execution_date>',
+        login_required(CreateTableDAGStatusView.as_view()),
+        name='create-table-status',
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/your_files/views.py
+++ b/dataworkspace/dataworkspace/apps/your_files/views.py
@@ -1,12 +1,18 @@
 from datetime import datetime
+from urllib.parse import urlencode
 
 from csp.decorators import csp_update
 from django.conf import settings
-from django.contrib import messages
-from django.http import HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import (
+    HttpResponse,
+    HttpResponseRedirect,
+    HttpResponseBadRequest,
+    JsonResponse,
+)
 from django.shortcuts import render
 from django.urls import reverse
-from django.views.generic import FormView
+from django.views import View
+from django.views.generic import FormView, TemplateView
 from requests import HTTPError
 
 from waffle.mixins import WaffleFlagMixin
@@ -19,6 +25,7 @@ from dataworkspace.apps.core.utils import (
 from dataworkspace.apps.your_files.forms import CreateTableForm
 from dataworkspace.apps.your_files.utils import (
     copy_file_to_uploads_bucket,
+    get_dataflow_dag_status,
     get_s3_csv_column_types,
     clean_db_identifier,
     trigger_dataflow_dag,
@@ -41,7 +48,7 @@ def file_browser_html_GET(request):
 
     return render(
         request,
-        'files.html',
+        'your_files/files.html',
         {
             'prefix': prefix,
             'bucket': settings.NOTEBOOKS_BUCKET,
@@ -58,14 +65,16 @@ class CreateTableView(WaffleFlagMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context['path'] = self.request.GET['path']
+        context['filename'] = context['path'].split('/')[-1]
+        return context
+
+    def get(self, request, *args, **kwargs):
         if 'path' not in self.request.GET:
             return HttpResponseBadRequest(
                 "Expected a `path` parameter for the CSV file"
             )
-
-        context['path'] = self.request.GET['path']
-        context['filename'] = context['path'].split('/')[-1]
-        return context
+        return super().get(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -83,14 +92,97 @@ class CreateTableView(WaffleFlagMixin, FormView):
         copy_file_to_uploads_bucket(path, import_path)
         dag_run_id = f'{schema}-{table_name}-{datetime.now().isoformat()}'
         try:
-            trigger_dataflow_dag(
+            response = trigger_dataflow_dag(
                 import_path, schema, table_name, column_definitions, dag_run_id
             )
         except HTTPError:
             return self.form_invalid(form)
-        messages.success(self.request, 'Table created')
-        return HttpResponseRedirect(reverse('your-files:files'))
+        params = {
+            'filename': path.split('/')[-1],
+            'schema': schema,
+            'table_name': table_name,
+            'execution_date': response['execution_date'],
+        }
+        return HttpResponseRedirect(
+            f'{reverse("your-files:create-table-validating")}?{urlencode(params)}'
+        )
 
     def form_invalid(self, form):
-        messages.error(self.request, 'An error occurred while processing your file')
-        return HttpResponseRedirect(reverse('your-files:files'))
+        filename = form.data['path'].split('/')[-1]
+        return HttpResponseRedirect(
+            f'{reverse("your-files:create-table-failed")}?filename={filename}'
+        )
+
+
+class BaseCreateTableTemplateView(WaffleFlagMixin, TemplateView):
+    waffle_flag = settings.YOUR_FILES_CREATE_TABLE_FLAG
+    required_parameters = [
+        'filename',
+        'schema',
+        'table_name',
+        'execution_date',
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {param: self.request.GET.get(param) for param in self.required_parameters}
+        )
+        return context
+
+    def get(self, request, *args, **kwargs):
+        for param in self.required_parameters:
+            if param not in self.request.GET:
+                return HttpResponseBadRequest(
+                    f'Expected a `{param}` parameter for the CSV file'
+                )
+        return super().get(request, *args, **kwargs)
+
+
+class CreateTableValidatingView(BaseCreateTableTemplateView):
+    template_name = 'your_files/create-table-validating.html'
+
+
+class CreateTableIngestingView(BaseCreateTableTemplateView):
+    template_name = 'your_files/create-table-ingesting.html'
+
+
+class CreateTableSuccessView(BaseCreateTableTemplateView):
+    template_name = 'your_files/create-table-success.html'
+
+
+class CreateTableFailedView(WaffleFlagMixin, TemplateView):
+    waffle_flag = settings.YOUR_FILES_CREATE_TABLE_FLAG
+    template_name = 'your_files/create-table-failed.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['filename'] = self.request.GET['filename']
+        return context
+
+    def get(self, request, *args, **kwargs):
+        if 'filename' not in self.request.GET:
+            return HttpResponseBadRequest(
+                "Expected a `filename` parameter for the CSV file"
+            )
+        return super().get(request, *args, **kwargs)
+
+
+class CreateTableDAGStatusView(View):
+    """
+    Check on the status of a DAG that has been run via the create table flow.
+
+    Airflow 1 requires calling with the execution date which is not ideal. Once
+    we have upgraded to Airflow 2 we can update this to call with the unique dag run id.
+
+    Airflow 2 will also return more info, including the config we called the API with
+    to trigger the DAG. Once we have this available we can then check if the file
+    path in the response matches the s3 path prefix for the current user - as an extra
+    step to check the current user actually created this dag run themselves.
+    """
+
+    def get(self, request, execution_date):
+        try:
+            return JsonResponse(get_dataflow_dag_status(execution_date))
+        except HTTPError as e:
+            return JsonResponse({}, status=e.response.status_code)

--- a/dataworkspace/dataworkspace/static/your-files-create-table.js
+++ b/dataworkspace/dataworkspace/static/your-files-create-table.js
@@ -1,0 +1,36 @@
+var DELAY_STEP = 250;
+var MAX_DELAY = 5000;
+
+function pollForDagStateChange(executionDate, successStates, successRedirectUrl, failureRedirectUrl, pollDelay) {
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', '/files/create-table/status/' + executionDate);
+  xhr.onreadystatechange = function() {
+    if (this.readyState === XMLHttpRequest.DONE) {
+      if (this.status === 200) {
+        var resp = JSON.parse(xhr.responseText);
+        if (successStates.includes(resp.state)) {
+          window.location.href = successRedirectUrl;
+        }
+        else if (resp.state === "failed") {
+          window.location.href = failureRedirectUrl;
+        }
+        else {
+          setTimeout(function () {
+            pollForDagStateChange(
+                executionDate,
+                successStates,
+                successRedirectUrl,
+                failureRedirectUrl,
+                Math.min(pollDelay + DELAY_STEP, MAX_DELAY),
+            )
+          }, pollDelay);
+        }
+      }
+      else {
+        window.location.href = failureRedirectUrl;
+      }
+    }
+  }
+  xhr.send()
+}
+window.pollForDagStateChange = pollForDagStateChange;

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-base.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-base.html
@@ -1,9 +1,5 @@
 {% extends '_main.html' %}
 {% load static %}
-{% block head %}
-  {{ block.super }}
-  <script nonce="{{ request.csp_nonce }}" src="{% static 'your-files-create-table.js' %}"></script>
-{% endblock %}
 {% block breadcrumbs %}
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
@@ -17,3 +13,7 @@
     </ol>
   </div>
 {% endblock breadcrumbs %}
+{% block footer_scripts %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}" src="{% static 'your-files-create-table.js' %}"></script>
+{% endblock footer_scripts %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-base.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-base.html
@@ -1,0 +1,19 @@
+{% extends '_main.html' %}
+{% load static %}
+{% block head %}
+  {{ block.super }}
+  <script nonce="{{ request.csp_nonce }}" src="{% static 'your-files-create-table.js' %}"></script>
+{% endblock %}
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{% url 'root' %}">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{% url 'applications:tools' %}">Tools</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">Your files</li>
+    </ol>
+  </div>
+{% endblock breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
-        We can't process your CSV file
+        We can’t process your CSV file
       </h1>
       <p class="govuk-body">
         Your file, {{ filename }}, cannot be processed. Please check the following before you try again.

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
@@ -1,0 +1,24 @@
+{% extends 'your_files/create-table-base.html' %}
+{% block page_title %}Table creation failed{% endblock page_title %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        We can't process your CSV file
+      </h1>
+      <p class="govuk-body">
+        Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
+      </p>
+      <div class="govuk-inset-text">
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Make sure the file uploaded is a CSV file</li>
+          <li>All rows in your file must have the same number of columns</li>
+          <li>Column names must be unique</li>
+        </ul>
+      </div>
+      <p class="govuk-body">
+        <a href="{% url 'your_files:files' %}" class="govuk-link">Return to your files</a>
+      </p>
+    </div>
+  </div>
+{% endblock content %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-ingesting.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-ingesting.html
@@ -1,0 +1,27 @@
+{% extends 'your_files/create-table-base.html' %}
+
+{% block page_title %}Ingesting data{% endblock page_title %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 id="pipeline_header" class="govuk-panel__title">Importing {{ filename }}</h1>
+        <div id="spinner" class="govuk-!-margin-bottom-7 loading-spinner"></div>
+        <div id="pipeline_info" class="govuk-panel__body govuk-!-font-size-24">
+          Your data is being uploaded to Data Workspace and stored privately for you.
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}
+{% block footer_scripts %}
+  <script nonce="{{ request.csp_nonce }}">
+    window.pollForDagStateChange(
+        "{{ execution_date }}",
+        ["success"],
+        "{% url 'your-files:create-table-success' %}?{{ request.GET.urlencode }}",
+        "{% url 'your-files:create-table-failed' %}?{{ request.GET.urlencode }}",
+        500
+    );
+  </script>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-ingesting.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-ingesting.html
@@ -15,6 +15,7 @@
   </div>
 {% endblock content %}
 {% block footer_scripts %}
+  {{ block.super }}
   <script nonce="{{ request.csp_nonce }}">
     window.pollForDagStateChange(
         "{{ execution_date }}",

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-success.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-success.html
@@ -1,0 +1,24 @@
+{% extends 'your_files/create-table-base.html' %}
+
+{% block page_title %}Table created{% endblock page_title %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 id="pipeline_header" class="govuk-panel__title">Table created</h1>
+      </div>
+    </div>
+  </div>
+  <div class="govuk-grid-row" id="upload_complete">
+    <div class="govuk-grid-column-full">
+      <h2 class="govuk-heading-m">What next?</h2>
+      <p class="govuk-body">You can immediately access your data in tools at <strong>"{{ schema }}"."{{ table_name }}"</strong>.</p>
+      <a class="govuk-button govuk-button--primary" target="_blank" href="{% url 'explorer:index' %}?sql=SELECT+%2A+FROM+%22{{ schema }}%22.%22{{ table_name }}%22+LIMIT+50">
+        Open in Data Explorer
+      </a>
+      <p class="govuk-body">
+        <a href="{% url 'your_files:files' %}" class="govuk-link">Return to your files</a>
+      </p>
+    </div>
+  </div>
+{% endblock content %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-success.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-success.html
@@ -1,5 +1,5 @@
 {% extends 'your_files/create-table-base.html' %}
-
+{% load explorer_tags %}
 {% block page_title %}Table created{% endblock page_title %}
 {% block content %}
   <div class="govuk-grid-row">
@@ -13,7 +13,7 @@
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">What next?</h2>
       <p class="govuk-body">You can immediately access your data in tools at <strong>"{{ schema }}"."{{ table_name }}"</strong>.</p>
-      <a class="govuk-button govuk-button--primary" target="_blank" href="{% url 'explorer:index' %}?sql=SELECT+%2A+FROM+%22{{ schema }}%22.%22{{ table_name }}%22+LIMIT+50">
+      <a class="govuk-button govuk-button--primary" target="_blank" href="{% query_table_in_explorer_link schema table_name %}">
         Open in Data Explorer
       </a>
       <p class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-validating.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-validating.html
@@ -14,6 +14,7 @@
   </div>
 {% endblock content %}
 {% block footer_scripts %}
+  {{ block.super }}
   <script nonce="{{ request.csp_nonce }}">
     window.pollForDagStateChange(
         "{{ execution_date }}",

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-validating.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-validating.html
@@ -1,0 +1,26 @@
+{% extends 'your_files/create-table-base.html' %}
+{% block page_title %}Validating data{% endblock page_title %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 id="pipeline_header" class="govuk-panel__title">Validating {{ filename }}</h1>
+        <div id="spinner" class="govuk-!-margin-bottom-7 loading-spinner"></div>
+        <div id="pipeline_info" class="govuk-panel__body govuk-!-font-size-24">
+          Your CSV file is being validated against your chosen columns and data types.
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock content %}
+{% block footer_scripts %}
+  <script nonce="{{ request.csp_nonce }}">
+    window.pollForDagStateChange(
+        "{{ execution_date }}",
+        ["success", "running"],
+        "{% url 'your-files:create-table-ingesting' %}?{{ request.GET.urlencode }}",
+        "{% url 'your-files:create-table-failed' %}?{{ request.GET.urlencode }}",
+        500
+    );
+  </script>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/your_files/files.html
+++ b/dataworkspace/dataworkspace/templates/your_files/files.html
@@ -27,9 +27,11 @@ Modified by the Department for International Trade
             <li class="govuk-breadcrumbs__list-item">
                 <a class="govuk-breadcrumbs__link" href="/">Home</a>
             </li>
-
             <li class="govuk-breadcrumbs__list-item">
-                Files
+              <a class="govuk-breadcrumbs__link" href="{% url 'applications:tools' %}">Tools</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                Your files
             </li>
         </ol>
     </div>

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -1,4 +1,7 @@
+from urllib.parse import urlencode
+
 import botocore
+import pytest
 import requests_mock
 from django.conf import settings
 from django.urls import reverse
@@ -7,7 +10,7 @@ from mock import mock
 from waffle.testutils import override_flag
 
 
-class TestCreateTableView:
+class TestCreateTableViews:
     url = reverse('your-files:create-table')
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
@@ -22,10 +25,8 @@ class TestCreateTableView:
     @mock.patch('dataworkspace.apps.your_files.forms.get_s3_prefix')
     def test_invalid_file_type(self, mock_get_s3_prefix, client):
         mock_get_s3_prefix.return_value = 'user/federated/abc'
-        response = client.post(
-            self.url, data={'path': 'user/federated/abc/not-a-csv.txt'}, follow=True,
-        )
-        assert b'An error occurred while processing your file' in response.content
+        response = client.post(self.url, data={'path': 'not-a-csv.txt'}, follow=True,)
+        assert b'We can\'t process your CSV file' in response.content
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.your_files.forms.get_s3_prefix')
@@ -34,7 +35,7 @@ class TestCreateTableView:
         response = client.post(
             self.url, data={'path': 'user/federated/def/a-csv.csv'}, follow=True,
         )
-        assert b'An error occurred while processing your file' in response.content
+        assert b'We can\'t process your CSV file' in response.content
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.datasets.views.boto3.client')
@@ -50,7 +51,7 @@ class TestCreateTableView:
         response = client.post(
             self.url, data={'path': 'user/federated/abc/a-csv.csv'}, follow=True,
         )
-        assert b'An error occurred while processing your file' in response.content
+        assert b'We can\'t process your CSV file' in response.content
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket')
@@ -77,7 +78,7 @@ class TestCreateTableView:
                 data={'path': 'user/federated/abc/not-a-csv.csv'},
                 follow=True,
             )
-            assert b'An error occurred while processing your file' in response.content
+        assert b'We can\'t process your CSV file' in response.content
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @freeze_time('2021-01-01 01:01:01')
@@ -100,7 +101,7 @@ class TestCreateTableView:
         response = client.post(
             self.url, data={'path': 'user/federated/abc/a-csv.csv'}, follow=True,
         )
-        assert b'Table created' in response.content
+        assert b'Validating a-csv.csv' in response.content
         mock_get_column_types.assert_called_with('user/federated/abc/a-csv.csv')
         mock_copy_file.assert_called_with(
             'user/federated/abc/a-csv.csv',
@@ -113,3 +114,64 @@ class TestCreateTableView:
             {'field1': 'varchar'},
             '_user_40e80e4e-a_csv-2021-01-01T01:01:01',
         )
+
+    @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
+    @pytest.mark.parametrize(
+        'url, success_text',
+        (
+            ('your_files:create-table-validating', b'Validating test.csv'),
+            ('your_files:create-table-ingesting', b'Importing test.csv'),
+            ('your_files:create-table-success', b'Table created'),
+        ),
+    )
+    @pytest.mark.parametrize(
+        'params, status_code',
+        (
+            ({}, 400),
+            ({'filename': 'test.csv'}, 400),
+            ({'filename': 'test.csv', 'schema': 'test'}, 400),
+            ({'filename': 'test.csv', 'schema': 'test', 'table_name': 'table'}, 400),
+            (
+                {
+                    'filename': 'test.csv',
+                    'schema': 'test',
+                    'table_name': 'table',
+                    'execution_date': '2021-01-01',
+                },
+                200,
+            ),
+        ),
+    )
+    def test_steps(self, url, success_text, params, status_code, client):
+        response = client.get(f'{reverse(url)}?{urlencode(params)}')
+        assert response.status_code == status_code
+        if status_code == 200:
+            assert success_text in response.content
+
+    @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
+    @pytest.mark.parametrize('status_code', (500, 404))
+    def test_dag_status_invalid(self, status_code, client):
+        execution_date = '02-05T13:33:49.266040+00:00'
+        with requests_mock.Mocker() as rmock:
+            rmock.get(
+                f'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline/dag_runs/{execution_date}',
+                status_code=status_code,
+            )
+            response = client.get(
+                reverse('your_files:create-table-status', args=(execution_date,))
+            )
+            assert response.status_code == status_code
+
+    @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
+    def test_dag_status(self, client):
+        execution_date = '02-05T13:33:49.266040+00:00'
+        with requests_mock.Mocker() as rmock:
+            rmock.get(
+                f'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline/dag_runs/{execution_date}',
+                json={'state': 'success'},
+            )
+            response = client.get(
+                reverse('your_files:create-table-status', args=(execution_date,))
+            )
+            assert response.status_code == 200
+            assert response.json() == {'state': 'success'}

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -26,7 +26,7 @@ class TestCreateTableViews:
     def test_invalid_file_type(self, mock_get_s3_prefix, client):
         mock_get_s3_prefix.return_value = 'user/federated/abc'
         response = client.post(self.url, data={'path': 'not-a-csv.txt'}, follow=True,)
-        assert b'We can\'t process your CSV file' in response.content
+        assert 'We can’t process your CSV file' in response.content.decode('utf-8')
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.your_files.forms.get_s3_prefix')
@@ -35,7 +35,7 @@ class TestCreateTableViews:
         response = client.post(
             self.url, data={'path': 'user/federated/def/a-csv.csv'}, follow=True,
         )
-        assert b'We can\'t process your CSV file' in response.content
+        assert 'We can’t process your CSV file' in response.content.decode('utf-8')
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.datasets.views.boto3.client')
@@ -51,7 +51,7 @@ class TestCreateTableViews:
         response = client.post(
             self.url, data={'path': 'user/federated/abc/a-csv.csv'}, follow=True,
         )
-        assert b'We can\'t process your CSV file' in response.content
+        assert 'We can’t process your CSV file' in response.content.decode('utf-8')
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @mock.patch('dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket')
@@ -78,7 +78,7 @@ class TestCreateTableViews:
                 data={'path': 'user/federated/abc/not-a-csv.csv'},
                 follow=True,
             )
-        assert b'We can\'t process your CSV file' in response.content
+        assert 'We can’t process your CSV file' in response.content.decode('utf-8')
 
     @override_flag(settings.YOUR_FILES_CREATE_TABLE_FLAG, active=True)
     @freeze_time('2021-01-01 01:01:01')


### PR DESCRIPTION
### Description of change

- Adds new templates for each step - validate, ingest, success, fail
- Validate waits for dag status to be "running" or "success" and redirects to ingest when it gets a match
- Ingest waits for dag status to be "success" and redirects to success when it gets a match
- If either step gets an http error or a dag status of "failed" it will redirect to the failure template.

### Checklist

* [x] Have tests been added to cover any changes?
