### PR TITLE
Move to ECR

### DIFF
--- a/healthcheck/Dockerfile
+++ b/healthcheck/Dockerfile
@@ -7,7 +7,9 @@ ENV \
 
 RUN \
 	apk add --no-cache \
-		python3=3.6.8-r0 && \
+		build-base=0.5-r1 \
+		python3=3.6.9-r1 \
+		python3-dev=3.6.9-r1 && \
 	python3 -m ensurepip && \
 	pip3 install \
 		aiohttp==3.5.4

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -2,6 +2,58 @@ resource "aws_ecr_repository" "user_provided" {
   name = "${var.prefix}-user-provided"
 }
 
+resource "aws_ecr_repository" "admin" {
+  name = "${var.prefix}-admin"
+}
+
+resource "aws_ecr_repository" "jupyterlab_python" {
+  name = "${var.prefix}-jupyterlab-python"
+}
+
+resource "aws_ecr_repository" "rstudio" {
+  name = "${var.prefix}-rstudio"
+}
+
+resource "aws_ecr_repository" "pgadmin" {
+  name = "${var.prefix}-pgadmin"
+}
+
+resource "aws_ecr_repository" "remotedesktop" {
+  name = "${var.prefix}-remotedesktop"
+}
+
+resource "aws_ecr_repository" "theia" {
+  name = "${var.prefix}-theia"
+}
+
+resource "aws_ecr_repository" "s3sync" {
+  name = "${var.prefix}-s3sync"
+}
+
+resource "aws_ecr_repository" "metrics" {
+  name = "${var.prefix}-metrics"
+}
+
+resource "aws_ecr_repository" "sentryproxy" {
+  name = "${var.prefix}-sentryproxy"
+}
+
+resource "aws_ecr_repository" "dns_rewrite_proxy" {
+  name = "${var.prefix}-dns-rewrite-proxy"
+}
+
+resource "aws_ecr_repository" "healthcheck" {
+  name = "${var.prefix}-healthcheck"
+}
+
+resource "aws_ecr_repository" "prometheus" {
+  name = "${var.prefix}-prometheus"
+}
+
+resource "aws_ecr_repository" "gitlab" {
+  name = "${var.prefix}-gitlab"
+}
+
 resource "aws_ecr_repository" "visualisation_base" {
   name = "${var.prefix}-visualisation-base"
 }
@@ -148,6 +200,35 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
 
     resources = [
       "*",
+    ]
+  }
+
+  /* For ECS to fetch images */
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.admin.arn}",
+      "${aws_ecr_repository.jupyterlab_python.arn}",
+      "${aws_ecr_repository.rstudio.arn}",
+      "${aws_ecr_repository.pgadmin.arn}",
+      "${aws_ecr_repository.remotedesktop.arn}",
+      "${aws_ecr_repository.theia.arn}",
+      "${aws_ecr_repository.s3sync.arn}",
+      "${aws_ecr_repository.metrics.arn}",
+      "${aws_ecr_repository.sentryproxy.arn}",
+      "${aws_ecr_repository.dns_rewrite_proxy.arn}",
+      "${aws_ecr_repository.healthcheck.arn}",
+      "${aws_ecr_repository.prometheus.arn}",
+      "${aws_ecr_repository.gitlab.arn}",
     ]
   }
 

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -1,6 +1,6 @@
 locals {
   admin_container_vars = {
-    container_image   = "${var.admin_container_image}:${data.external.admin_current_tag.result.tag}"
+    container_image   = "${aws_ecr_repository.admin.repository_url}:${data.external.admin_current_tag.result.tag}"
     container_name    = "${local.admin_container_name}"
     container_port    = "${local.admin_container_port}"
     container_cpu     = "${local.admin_container_cpu}"
@@ -260,6 +260,27 @@ data "aws_iam_policy_document" "admin_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.admin.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.admin.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -92,7 +92,7 @@ data "template_file" "dns_rewrite_proxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
 
   vars = {
-    container_image    = "${var.dns_rewrite_proxy_container_image}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
+    container_image    = "${aws_ecr_repository.dns_rewrite_proxy.repository_url}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
     container_name     = "${local.dns_rewrite_proxy_container_name}"
     container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
     container_memory   = "${local.dns_rewrite_proxy_container_memory}"
@@ -159,6 +159,27 @@ data "aws_iam_policy_document" "dns_rewrite_proxy_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.dns_rewrite_proxy.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.dns_rewrite_proxy.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -78,7 +78,7 @@ data "template_file" "gitlab_container_definitions" {
   template = "${file("${path.module}/ecs_main_gitlab_container_definitions.json")}"
 
   vars = {
-    container_image   = "${var.gitlab_container_image}"
+    container_image   = "${aws_ecr_repository.gitlab.repository_url}:master"
     container_name    = "gitlab"
     log_group         = "${aws_cloudwatch_log_group.gitlab.name}"
     log_region        = "${data.aws_region.aws_region.name}"
@@ -165,6 +165,27 @@ data "aws_iam_policy_document" "gitlab_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.gitlab.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.gitlab.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_main_healthcheck.tf
+++ b/infra/ecs_main_healthcheck.tf
@@ -76,7 +76,7 @@ data "template_file" "healthcheck_container_definitions" {
   template = "${file("${path.module}/ecs_main_healthcheck_container_definitions.json")}"
 
   vars = {
-    container_image   = "${var.healthcheck_container_image}:${data.external.healthcheck_current_tag.result.tag}"
+    container_image   = "${aws_ecr_repository.healthcheck.repository_url}:${data.external.healthcheck_current_tag.result.tag}"
     container_name    = "${local.healthcheck_container_name}"
     container_port    = "${local.healthcheck_container_port}"
     container_cpu     = "${local.healthcheck_container_cpu}"
@@ -140,6 +140,27 @@ data "aws_iam_policy_document" "healthcheck_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.healthcheck.arn}:*",
+    ]
+  }
+
+   statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.healthcheck.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_main_prometheus.tf
+++ b/infra/ecs_main_prometheus.tf
@@ -75,7 +75,7 @@ data "template_file" "prometheus_container_definitions" {
   template = "${file("${path.module}/ecs_main_prometheus_container_definitions.json")}"
 
   vars = {
-    container_image   = "${var.prometheus_container_image}:${data.external.prometheus_current_tag.result.tag}"
+    container_image   = "${aws_ecr_repository.prometheus.repository_url}:${data.external.prometheus_current_tag.result.tag}"
     container_name    = "${local.prometheus_container_name}"
     container_port    = "${local.prometheus_container_port}"
     container_cpu     = "${local.prometheus_container_cpu}"
@@ -141,6 +141,27 @@ data "aws_iam_policy_document" "prometheus_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.prometheus.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.prometheus.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_main_sentryproxy.tf
+++ b/infra/ecs_main_sentryproxy.tf
@@ -65,7 +65,7 @@ data "template_file" "sentryproxy_container_definitions" {
   template = "${file("${path.module}/ecs_main_sentryproxy_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.sentryproxy_container_image}:${data.external.sentryproxy_current_tag.result.tag}"
+    container_image  = "${aws_ecr_repository.sentryproxy.repository_url}:${data.external.sentryproxy_current_tag.result.tag}"
     container_name   = "${local.sentryproxy_container_name}"
     container_cpu    = "${local.sentryproxy_container_cpu}"
     container_memory = "${local.sentryproxy_container_memory}"
@@ -125,6 +125,27 @@ data "aws_iam_policy_document" "sentryproxy_task_execution" {
 
     resources = [
       "${aws_cloudwatch_log_group.sentryproxy.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.sentryproxy.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
     ]
   }
 }

--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -50,7 +50,7 @@ data "template_file" "jupyterlabpython_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.jupyterlab_python_container_image}:${data.external.jupyterlabpython_current_tag.result.tag}"
+    container_image  = "${aws_ecr_repository.jupyterlab_python.repository_url}:${data.external.jupyterlabpython_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
@@ -59,8 +59,8 @@ data "template_file" "jupyterlabpython_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.jupyterlabpython_s3sync_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.jupyterlabpython_s3sync_current_tag.result.tag}"
 
     home_directory = "/home/jovyan"
   }

--- a/infra/ecs_notebooks_jupyterlab_r.tf
+++ b/infra/ecs_notebooks_jupyterlab_r.tf
@@ -59,8 +59,8 @@ data "template_file" "jupyterlabr_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.jupyterlabr_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.jupyterlabr_s3sync_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabr_metrics_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.jupyterlabr_s3sync_current_tag.result.tag}"
 
     home_directory = "/home/jovyan"
   }

--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -59,8 +59,8 @@ data "template_file" "notebook_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.notebook_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.notebook_s3sync_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.notebook_metrics_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.notebook_s3sync_current_tag.result.tag}"
 
     home_directory = "/home/jovyan"
   }

--- a/infra/ecs_notebooks_pgweb.tf
+++ b/infra/ecs_notebooks_pgweb.tf
@@ -59,8 +59,8 @@ data "template_file" "pgweb_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:master"
-    s3sync_container_image = "${var.s3sync_container_image}:master"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
 
     home_directory = "/home/jovyan"
   }

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -49,7 +49,7 @@ data "template_file" "remotedesktop_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.remotedesktop_container_image}:${data.external.remotedesktop_current_tag.result.tag}"
+    container_image  = "${aws_ecr_repository.remotedesktop.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
 
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
@@ -58,8 +58,8 @@ data "template_file" "remotedesktop_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.remotedesktop_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.remotedesktop_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
 
     home_directory = "/home/dw"
   }

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -58,8 +58,8 @@ data "template_file" "superset_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:master"
-    s3sync_container_image = "${var.s3sync_container_image}:master"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
 
     home_directory = "/home/superset"
   }

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -49,7 +49,7 @@ data "template_file" "theia_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.theia_container_image}:master"
+    container_image  = "${aws_ecr_repository.theia.repository_url}:master"
     container_name   = "${local.notebook_container_name}"
 
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
@@ -58,8 +58,8 @@ data "template_file" "theia_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:master"
-    s3sync_container_image = "${var.s3sync_container_image}:master"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
 
     home_directory = "/home/theia"
   }

--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -50,7 +50,7 @@ data "template_file" "pgadmin_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.pgadmin_container_image}:${data.external.pgadmin_current_tag.result.tag}"
+    container_image  = "${aws_ecr_repository.pgadmin.repository_url}:${data.external.pgadmin_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
     container_cpu    = "${local.notebook_container_cpu}"
     container_memory = "${local.notebook_container_memory}"
@@ -61,8 +61,8 @@ data "template_file" "pgadmin_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.pgadmin_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.pgadmin_metrics_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
 
     home_directory = "/home/pgadmin"
   }

--- a/infra/ecs_rstudio.tf
+++ b/infra/ecs_rstudio.tf
@@ -50,7 +50,7 @@ data "template_file" "rstudio_container_definitions" {
   template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
 
   vars = {
-    container_image  = "${var.rstudio_container_image}:${data.external.rstudio_current_tag.result.tag}"
+    container_image  = "${aws_ecr_repository.rstudio.repository_url}:${data.external.rstudio_current_tag.result.tag}"
     container_name   = "${local.notebook_container_name}"
     container_cpu    = "${local.notebook_container_cpu}"
     container_memory = "${local.notebook_container_memory}"
@@ -61,8 +61,8 @@ data "template_file" "rstudio_container_definitions" {
     sentry_dsn = "${var.sentry_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
-    metrics_container_image = "${var.metrics_container_image}:${data.external.rstudio_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${var.s3sync_container_image}:${data.external.rstudio_s3sync_current_tag.result.tag}"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.rstudio_metrics_current_tag.result.tag}"
+    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.rstudio_s3sync_current_tag.result.tag}"
 
     home_directory = "/home/rstudio"
   }

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -38,7 +38,7 @@ data "template_file" "user_provided_container_definitions" {
 
     sentry_dsn = "${var.sentry_dsn}"
 
-    metrics_container_image = "${var.metrics_container_image}:master"
+    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
   }
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -41,7 +41,6 @@ variable registry_proxy_username {}
 variable registry_proxy_password {}
 variable registry_internal_domain {}
 
-variable admin_container_image {}
 variable admin_db_instance_class {}
 
 variable admin_authbroker_client_id {}
@@ -60,20 +59,12 @@ variable notebooks_bucket_cors_domains {
   type = list(string)
 }
 variable notebook_container_image {}
-variable jupyterlab_python_container_image {}
 variable jupyterlab_r_container_image {}
-variable rstudio_container_image {}
-variable pgadmin_container_image {}
 variable pgweb_container_image {}
-variable remotedesktop_container_image {}
-variable theia_container_image {}
 variable superset_container_image {}
 
 variable alb_access_logs_bucket {}
 variable alb_logs_account {}
-
-variable dns_rewrite_proxy_container_image {}
-variable sentryproxy_container_image {}
 
 variable cloudwatch_destination_arn {}
 
@@ -88,10 +79,8 @@ variable sentry_environment {}
 variable notebook_task_role_prefix {}
 variable notebook_task_role_policy_name {}
 
-variable healthcheck_container_image {}
 variable healthcheck_domain {}
 
-variable prometheus_container_image {}
 variable prometheus_domain {}
 
 variable cloudwatch_subscription_filter {}
@@ -106,9 +95,6 @@ variable prometheus_whitelist {
 }
 variable metrics_service_discovery_basic_auth_user {}
 variable metrics_service_discovery_basic_auth_password {}
-variable metrics_container_image {}
-
-variable s3sync_container_image {}
 
 variable google_analytics_site_id {}
 
@@ -117,7 +103,6 @@ variable gitlab_ip_whitelist {
 }
 variable gitlab_domain {}
 variable gitlab_bucket {}
-variable gitlab_container_image {}
 variable gitlab_instance_type {}
 variable gitlab_memory {}
 variable gitlab_cpu {}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -637,11 +637,35 @@ resource "aws_security_group" "ecr_api" {
   }
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_dns_rewrite_proxy" {
+  description = "ingress-https-from-dns-rewrite-proxy"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.dns_rewrite_proxy.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "ecr_api_ingress_https_from_admin-service" {
   description = "ingress-https-from-admin-service"
 
   security_group_id = "${aws_security_group.ecr_api.id}"
   source_security_group_id = "${aws_security_group.admin_service.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_gitlab_ec2" {
+  description = "ingress-https-from-gitlab-ec2"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.gitlab-ec2.id}"
 
   type        = "ingress"
   from_port   = "443"

--- a/s3sync/Dockerfile
+++ b/s3sync/Dockerfile
@@ -1,17 +1,17 @@
-FROM quay.io/uktrade/mobius3:v0.0.34
+FROM alpine:3.10
 
-COPY start.sh /
-
-CMD ["/start.sh"]
-
-USER root
+COPY requirements.txt /app/
+RUN \
+	apk add --no-cache \
+		python3 && \
+	pip3 install \
+		-r /app/requirements.txt
 
 RUN \
 	apk add sudo && \
 	addgroup -S -g 4356 s3sync && \
 	adduser -S -u 4357 s3sync -G s3sync
 
-# Must be created to ensure it has the correct user permissions
-RUN mkdir /home/s3sync/data
+COPY start.sh /
 
-WORKDIR /home/s3sync
+CMD ["/start.sh"]

--- a/s3sync/requirements.txt
+++ b/s3sync/requirements.txt
@@ -1,0 +1,6 @@
+aiodnsresolver==0.0.149
+fifolock==0.0.20
+lowhaio-aws-sigv4-unsigned-payload==0.0.4
+lowhaio-retry>=0.0.5
+lowhaio==0.0.85
+mobius3==0.0.34

--- a/sentryproxy/Dockerfile
+++ b/sentryproxy/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.10
 
 RUN apk --no-cache add \
-	nginx==1.16.1-r0 \
-	openssl=1.1.1c-r0 \
+	nginx==1.16.1-r2 \
+	openssl=1.1.1i-r0 \
 	tini=0.18.0-r0
 
 COPY sentryproxy-entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
### Description of change

Almost everything that is currently used moved to ECR.

An exception is JupyterLab R: we agreed to remove it a while back, so doing it now (usage is virtually non-existant). I have hidden it from production.

Another exception is the mirrors sync, which can be done in less of a rush

Although remotedeskop isn't being used, maintaining that just in case so we can run desktop applications if we need to.

Some of the unused tools are partially modified: s3sync and metrics images have been changed to get the terraform to work, but the their images are not in ECR. Leaving tidy up to later.

### Checklist

* [ ] Have tests been added to cover any changes?
