### PR TITLE
fix: remove timezone info from execution date

### DIFF
--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -129,7 +129,7 @@ def get_dataflow_dag_status(execution_date):
     config = settings.DATAFLOW_API_CONFIG
     url = (
         f'{config["DATAFLOW_BASE_URL"]}/api/experimental/'
-        f'dags/{config["DATAFLOW_S3_IMPORT_DAG"]}/dag_runs/{execution_date}'
+        f'dags/{config["DATAFLOW_S3_IMPORT_DAG"]}/dag_runs/{execution_date.split("+")[0]}'
     )
     hawk_creds = {
         'id': config['DATAFLOW_HAWK_ID'],

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -154,7 +154,8 @@ class TestCreateTableViews:
         execution_date = '02-05T13:33:49.266040+00:00'
         with requests_mock.Mocker() as rmock:
             rmock.get(
-                f'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline/dag_runs/{execution_date}',
+                'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline'
+                f'/dag_runs/{execution_date.split("+")[0]}',
                 status_code=status_code,
             )
             response = client.get(
@@ -167,7 +168,8 @@ class TestCreateTableViews:
         execution_date = '02-05T13:33:49.266040+00:00'
         with requests_mock.Mocker() as rmock:
             rmock.get(
-                f'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline/dag_runs/{execution_date}',
+                'https://data-flow/api/experimental/dags/DataWorkspaceS3ImportPipeline'
+                f'/dag_runs/{execution_date.split("+")[0]}',
                 json={'state': 'success'},
             )
             response = client.get(


### PR DESCRIPTION
### Description of change

The execution date airflow returns is not the execution date you can use to query the task via the api. You need to remove the timzone info from it. Undocumented so a good couple of hours spent looking for this :disappointed: 
