### PR TITLE
cicd: cache build layers for faster deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,11 @@ pipeline {
                     -c ${env.WORKSPACE} \
                     --destination=165562107270.dkr.ecr.eu-west-2.amazonaws.com/analysisworkspace-dev-admin:${params.GIT_COMMIT} \
                     --destination=165562107270.dkr.ecr.eu-west-2.amazonaws.com/data-workspace-staging-admin:${params.GIT_COMMIT} \
-                    --destination=165562107270.dkr.ecr.eu-west-2.amazonaws.com/jupyterhub-admin:${params.GIT_COMMIT}
+                    --destination=165562107270.dkr.ecr.eu-west-2.amazonaws.com/jupyterhub-admin:${params.GIT_COMMIT} \
+                    --cache=true \
+                    --cache-repo=165562107270.dkr.ecr.eu-west-2.amazonaws.com/data-workspace-admin-cache \
+                    --skip-unused-stages=true \
+                    --target=live
                   """
               }
             }


### PR DESCRIPTION
### Description of change
Now that we've migrated to ECR, we can cache the layers of
data-workspace images in order to speed up our deployment pipeline. We
also add some flags to Kaniko so that it only builds our target stage
from the Dockerfile and ignores unused stages (so no longer needs to
build the test stage, which pulls in node and some other dependencies).

In tests this has taken builds from 7-10 minutes to 1-2 minutes.

### Checklist

* [ ] Have tests been added to cover any changes?
