### PR TITLE
feature: delete unreferenced docker images on the gitlab-runner ec2

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -569,6 +569,8 @@ resource "aws_launch_configuration" "gitlab_runner" {
   echo "concurrent = 10" >> /etc/gitlab-runner/config.toml
   echo "check_interval = 1" >> /etc/gitlab-runner/config.toml
 
+  echo "0 0 * * * /usr/bin/docker image prune -f -a --filter until=168h" >> /var/spool/cron/ec2-user
+
   gitlab-runner install --user=gitlab-runner --working-directory=/home/gitlab-runner
   gitlab-runner start
   # Connects via HTTP, but uses private ip, not public internet


### PR DESCRIPTION
The gitlab-runner ec2 instance runs out of disk space when there are too many docker images and this causes visualisation builds to fail. This PR adds a crontab entry to run a docker image prune once a day to delete images more than 24 hours old.

https://trello.com/c/SQRttjsg/605-reduce-chance-of-visualisation-build-failures-do-something-about-running-out-of-space-in-the-gitlab-runner

This has been tested on dev.
