### PR TITLE
fix: use error summary for validation errors

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -5,6 +5,13 @@ from django import forms
 
 from dataworkspace.apps.datasets.constants import DataSetType
 from .models import Tag
+from ...forms import (
+    GOVUKDesignSystemForm,
+    GOVUKDesignSystemCharField,
+    GOVUKDesignSystemTextWidget,
+    GOVUKDesignSystemTextareaField,
+    GOVUKDesignSystemTextareaWidget,
+)
 
 
 class FilterWidget(forms.widgets.CheckboxSelectMultiple):
@@ -54,9 +61,44 @@ class SortSelectWidget(forms.widgets.Select):
         return context
 
 
-class RequestAccessForm(forms.Form):
-    email = forms.CharField(widget=forms.TextInput, required=True)
-    goal = forms.CharField(widget=forms.Textarea, required=True)
+class RequestAccessForm(GOVUKDesignSystemForm):
+    email = GOVUKDesignSystemCharField(
+        label="Contact email",
+        required=True,
+        widget=GOVUKDesignSystemTextWidget(
+            label_is_heading=False, extra_label_classes='govuk-!-font-weight-bold'
+        ),
+    )
+    goal = GOVUKDesignSystemTextareaField(
+        label="Why do you need this data?",
+        help_text=(
+            'For example, I need to create a report for my senior management team '
+            'to show performance trends and delivery against targets.'
+        ),
+        required=True,
+        widget=GOVUKDesignSystemTextareaWidget(
+            label_is_heading=False,
+            extra_label_classes='govuk-!-font-weight-bold',
+            attrs={"rows": 5},
+        ),
+        error_messages={"required": "You must provide details of why you need access."},
+    )
+
+    def __init__(self, *args, visualisation=False, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        initial_email = self.initial.get("email")
+        if initial_email:
+            self.fields['email'].help_text = f"You are logged in as {initial_email}"
+            self.fields['email'].widget.custom_context[
+                'help_text'
+            ] = f"You are logged in as {initial_email}"
+
+        if visualisation:
+            self.fields['goal'].label = "Why do you need this data visualisation?"
+            self.fields['goal'].widget.custom_context[
+                'label'
+            ] = "Why do you need this data visualisation?"
 
 
 class EligibilityCriteriaForm(forms.Form):

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -723,9 +723,12 @@ def eligibility_criteria_not_met_view(request, dataset_uuid):
 @require_http_methods(['GET', 'POST'])
 def request_access_view(request, dataset_uuid):
     dataset = find_dataset_or_visualisation(dataset_uuid, request.user)
+    form = RequestAccessForm(
+        request.POST if request.method == 'POST' else None,
+        initial={"email": request.user.email},
+    )
 
     if request.method == 'POST':
-        form = RequestAccessForm(request.POST)
         if form.is_valid():
             goal = form.cleaned_data['goal']
             contact_email = form.cleaned_data['email']
@@ -775,8 +778,8 @@ def request_access_view(request, dataset_uuid):
         'request_access.html',
         {
             'dataset': dataset,
-            'authenticated_user': request.user,
             'is_visualisation': isinstance(dataset, VisualisationCatalogueItem),
+            'form': form,
         },
     )
 

--- a/dataworkspace/dataworkspace/forms.py
+++ b/dataworkspace/dataworkspace/forms.py
@@ -119,7 +119,9 @@ class GOVUKDesignSystemModelForm(forms.ModelForm):
 
         if self.is_bound:
             for field in self:
-                if self.errors.get(field.name):
+                if self.errors.get(field.name) and not isinstance(
+                    self.fields[field.name].widget, forms.HiddenInput
+                ):
                     self.fields[field.name].widget.custom_context[
                         'errors'
                     ] = self.errors[field.name]
@@ -141,11 +143,14 @@ class GOVUKDesignSystemModelForm(forms.ModelForm):
 
 
 class GOVUKDesignSystemForm(forms.Form):
+    """This is duplicated from above because of issues using a mixin. Feels like it should be possible..."""
+
     def clean(self):
         """We need to attach errors to widgets so that the fields can be rendered correctly. This slightly breaks
         the Django model, which doesn't expose errors/validation to widgets as standard. We need to do this
         in order to render GOV.UK Design System validation correctly."""
         cleaned_data = super().clean()
+
         if self.is_bound:
             for field in self:
                 if self.errors.get(field.name) and not isinstance(
@@ -154,6 +159,7 @@ class GOVUKDesignSystemForm(forms.Form):
                     self.fields[field.name].widget.custom_context[
                         'errors'
                     ] = self.errors[field.name]
+
         return cleaned_data
 
     @property
@@ -166,4 +172,5 @@ class GOVUKDesignSystemForm(forms.Form):
             (field.id_for_label, field.errors[0]) for field in self if field.errors
         ]
         non_field_errors = [(None, e) for e in self.non_field_errors()]
+
         return non_field_errors + field_errors

--- a/dataworkspace/dataworkspace/templates/request_access.html
+++ b/dataworkspace/dataworkspace/templates/request_access.html
@@ -20,6 +20,8 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
+            {% include 'design_system/error_summary.html' with form=form %}
+
             <h1 class="govuk-heading-l">Request access</h1>
             <p class="govuk-body">
               Complete the form below if you need to access this {% if is_visualisation %}data visualisation{% else %}dataset{%endif%} in order to do your job.
@@ -34,30 +36,14 @@
                   {{ dataset.name }}
               </a>
             </p>
-            <form method="post">
+
+            <form method="post" novalidate>
                 {% csrf_token %}
                 <fieldset class="govuk-fieldset">
-                    <div class="govuk-form-group">
-                        <label class="govuk-label govuk-!-font-weight-bold" for="email">Contact email</label>
-                        <span class="govuk-hint">
-                             You are logged in as {{ authenticated_user.email }}
-                        </span>
-                        <input class="govuk-input" type="email" name="email" value="{{ authenticated_user.email }}" id="email" required>
-                    </div>
-                    <div class="govuk-form-group">
-                        <label class="govuk-label govuk-!-font-weight-bold" for="goal">
-                          Why do you need this data{%if is_visualisation %} visualisation{% endif %}?
-                        </label>
-                        <span class="govuk-hint">
-                          For example, I need to create a report for my senior management team to show performance trends and delivery against targets.
-                        </span>
-                        <textarea class="govuk-textarea" id="goal" name="goal" rows="5"
-                                  required></textarea>
-                    </div>
-                    <div class="govuk-form-group">
-                        <button data-prevent-double-click="true" type="submit" class="govuk-button">Submit
-                        </button>
-                    </div>
+                    {{ form.email }}
+                    {{ form.goal }}
+
+                    <button type="submit" class="govuk-button" data-prevent-double-click="true" >Submit</button>
                 </fieldset>
             </form>
         </div>


### PR DESCRIPTION
### Description of change
Disable HTML5 validation as per GOV.UK Design System recommendation and
include an error summary at the top of the page linking to the form
field being validated.

We have to do some slight hacks to fill the dynamically-generated label
and hint text for this page by reaching into the widget's custom context
and manually overwriting that as well. This is some small tech debt from
the Design System form/fields implementation to work with Django's form
system.

### Checklist

* [ ] Have tests been added to cover any changes?
