### PR TITLE
Fix duplicate landmarks 1

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
@@ -72,8 +72,8 @@
                   </p>
                 </div>
                 <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-                <nav>
-                    <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+                <nav aria-label="Top Level Navigation">
+                    <ul id="navigation" class="govuk-header__navigation">
                         <li class="govuk-header__navigation-item{% if active_menu == 'home' %} govuk-header__navigation-item--active{% endif %}">
                             <a class="govuk-header__link" href="{% url 'explorer:index' %}">Home</a>
                         </li>

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -57,8 +57,8 @@
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">
         Menu
       </button>
-      <nav>
-        <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+      <nav aria-label="Top Level Navigation">
+        <ul id="navigation" class="govuk-header__navigation">
           <li class="govuk-header__navigation-item{% if request.get_full_path == '/' %} govuk-header__navigation-item--active{% endif %}">
             <a class="govuk-header__link" href="{{ root_href }}">
               Home

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -124,36 +124,37 @@
     </div>
     {% endfor %}
 
-    {% if datasets.paginator.count %}
-    <nav role="navigation" class="govuk-body">
+    <p class="govuk-body" style="display: inline">
       Displaying datasets {{ datasets.start_index  }}&ndash;{{ datasets.end_index }} of {{ datasets.paginator.count }}
+    </p>
+
+    {% if datasets.paginator.num_pages > 1 %}
+    <nav role="navigation" class="govuk-body" aria-label="Search result page navigation" style="display: inline">
       <ul class="pagination govuk-list">
         {% if datasets.has_previous %}
-          <li><a class="govuk-link" href="{% url_replace page=datasets.previous_page_number %}">Previous</a></li>
+          <li><a class="govuk-link" href="{% url_replace page=datasets.previous_page_number %}" aria-label="Previous page">Previous</a></li>
         {% endif %}
 
         {% if datasets.number > 3 %}
-          <li><a class="govuk-link" href="{% url_replace page=1 %}">{{ 1 }}</a></li>
+          <li><a class="govuk-link" href="{% url_replace page=1 %}" aria-label="Page 1">{{ 1 }}</a></li>
           {% if datasets.number > 4 %}<li>&hellip;</li>{% endif %}
         {% endif %}
 
-        {% if datasets.paginator.num_pages > 1 %}
         {% for i in datasets.paginator.page_range %}
           {% if datasets.number == i %}
             <li class="active">{{ i }}</li>
           {% elif i >= datasets.number|add:'-2' and i <= datasets.number|add:'2' %}
-            <li><a class="govuk-link" href="{% url_replace page=i %}">{{ i }}</a></li>
+            <li><a class="govuk-link" href="{% url_replace page=i %}" aria-label="Page {{ i }}">{{ i }}</a></li>
           {% endif %}
         {% endfor %}
-        {% endif %}
 
         {% if datasets.paginator.num_pages > datasets.number|add:'2' %}
           {% if datasets.paginator.num_pages > datasets.number|add:'3' %}<li>&hellip;</li>{% endif %}
-          <li><a class="govuk-link" href="{% url_replace page=datasets.paginator.num_pages %}">{{ datasets.paginator.num_pages }}</a></li>
+          <li><a class="govuk-link" href="{% url_replace page=datasets.paginator.num_pages %}" aria-label="Page {{ datasets.paginator.num_pages }}">{{ datasets.paginator.num_pages }}</a></li>
         {% endif %}
 
         {% if datasets.has_next %}
-          <li><a class="govuk-link" href="{% url_replace page=datasets.next_page_number %}">Next</a></li>
+          <li><a class="govuk-link" href="{% url_replace page=datasets.next_page_number %}" aria-label="Next page">Next</a></li>
         {% endif %}
       </ul>
     </nav>

--- a/dataworkspace/dataworkspace/templates/explorer/_base.html
+++ b/dataworkspace/dataworkspace/templates/explorer/_base.html
@@ -49,8 +49,8 @@
         </a>
       </div>
      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-      <nav>
-        <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+      <nav aria-label="Top Level Navigation">
+        <ul id="navigation" class="govuk-header__navigation">
           <li class="govuk-header__navigation-item{% if request.get_full_path == '/' %} govuk-header__navigation-item--active{% endif %}">
             <a class="govuk-header__link" href="{% url 'explorer:index' %}">
               Home


### PR DESCRIPTION
### Description of change

#### Commit 1
Better aria descriptions for search result pagination links

#### Commit 2
GOV.UK Design System currently has the aria-label for the header
navigation on a `<ul>` element within a naked `<nav>` element. This came
up in discussion recently on x-gov slack and they seem to have
recognised this isn't ideal, and are planning to move it onto the nav
element for a future release of the Design System. So let's also do the
same.

### Checklist

* [ ] Have tests been added to cover any changes?
