### PR TITLE
fix: include h2 for screenreaders on tools page

### DIFF
--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -70,36 +70,40 @@
       </div>
     </div>
 
-    {% with application_summary='The Data Explorer is a simple tool to explore and work with master datasets on Data Workspace using SQL.' %}
-      {% url 'explorer:index' as data_explorer_url %}
-      {% include 'partials/tool_section.html' with application_name="Data Explorer" application_summary=application_summary application_help_link=None instance=None application_url=data_explorer_url customisable_instance=False has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
-    {% endwith %}
+    <div>
+      <h2 class="govuk-visually-hidden">Available tools</h2>
 
-    {% for application in applications %}
-      {# This check can be removed when the Data Explorer tool has been removed from Django-Admin/Data Workspace env altogether #}
-      {% if application.nice_name != 'Data Explorer' %}
-        {% include 'partials/tool_section.html' with application_host_basename=application.host_basename application_name=application.nice_name application_summary=application.summary application_help_link=application.help_link instance=application.instance application_url=application.link customisable_instance=True has_access=perms.applications.start_all_applications tool_configuration=application.tool_configuration trailing_horizontal_rule=True %}
-      {% endif %}
-    {% endfor %}
-
-    {% if your_files_enabled %}
-      {% url 'your-files:files' as files_url %}
-      {% with application_summary='Each Data Workspace user has a private home folder accessible by the tools JupyterLab, RStudio, and Theia. You can use "Your files" to upload files to this folder, and download files from this folder.' %}
-        {% include 'partials/tool_section.html' with application_name="Your files" application_summary=application_summary application_help_link=None instance=None application_url=files_url customisable_instance=False has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
+      {% with application_summary='The Data Explorer is a simple tool to explore and work with master datasets on Data Workspace using SQL.' %}
+        {% url 'explorer:index' as data_explorer_url %}
+        {% include 'partials/tool_section.html' with application_name="Data Explorer" application_summary=application_summary application_help_link=None instance=None application_url=data_explorer_url customisable_instance=False has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
       {% endwith %}
-    {% endif %}
 
-    {% if appstream_url != "https:///" %}
-      {% with spss_state_help_link='https://data-services-help.trade.gov.uk/data-workspace/how-articles/tools-and-how-access-them/start-using-spss/' %}
-        {% with application_summary='SPSS and STATA are statistical software packages supplied by IBM and StataCorp respectively. Use them to view, manage and analyse data, as well as create graphical outputs.' %}
-          {% include 'partials/tool_section.html' with application_name="SPSS / STATA" application_summary=application_summary application_help_link=spss_state_help_link instance=None application_url=appstream_url customisable_instance=False has_access=perms.applications.access_appstream trailing_horizontal_rule=True %}
+      {% for application in applications %}
+        {# This check can be removed when the Data Explorer tool has been removed from Django-Admin/Data Workspace env altogether #}
+        {% if application.nice_name != 'Data Explorer' %}
+          {% include 'partials/tool_section.html' with application_host_basename=application.host_basename application_name=application.nice_name application_summary=application.summary application_help_link=application.help_link instance=application.instance application_url=application.link customisable_instance=True has_access=perms.applications.start_all_applications tool_configuration=application.tool_configuration trailing_horizontal_rule=True %}
+        {% endif %}
+      {% endfor %}
+
+      {% if your_files_enabled %}
+        {% url 'your-files:files' as files_url %}
+        {% with application_summary='Each Data Workspace user has a private home folder accessible by the tools JupyterLab, RStudio, and Theia. You can use "Your files" to upload files to this folder, and download files from this folder.' %}
+          {% include 'partials/tool_section.html' with application_name="Your files" application_summary=application_summary application_help_link=None instance=None application_url=files_url customisable_instance=False has_access=perms.applications.start_all_applications trailing_horizontal_rule=True %}
         {% endwith %}
-      {% endwith %}
-    {% endif %}
+      {% endif %}
 
-    {% with application_summary='QuickSight is a visualisations tool supplied by Amazon Web Services (AWS). Use it to create and share dashboards using data from Data Workspace.' %}
-      {% include 'partials/tool_section.html' with application_name="AWS QuickSight" application_summary=application_summary application_help_link=None instance=None application_url=quicksight_url customisable_instance=False has_access=perms.applications.access_quicksight trailing_horizontal_rule=False %}
-    {% endwith %}
+      {% if appstream_url != "https:///" %}
+        {% with spss_state_help_link='https://data-services-help.trade.gov.uk/data-workspace/how-articles/tools-and-how-access-them/start-using-spss/' %}
+          {% with application_summary='SPSS and STATA are statistical software packages supplied by IBM and StataCorp respectively. Use them to view, manage and analyse data, as well as create graphical outputs.' %}
+            {% include 'partials/tool_section.html' with application_name="SPSS / STATA" application_summary=application_summary application_help_link=spss_state_help_link instance=None application_url=appstream_url customisable_instance=False has_access=perms.applications.access_appstream trailing_horizontal_rule=True %}
+          {% endwith %}
+        {% endwith %}
+      {% endif %}
+
+      {% with application_summary='QuickSight is a visualisations tool supplied by Amazon Web Services (AWS). Use it to create and share dashboards using data from Data Workspace.' %}
+        {% include 'partials/tool_section.html' with application_name="AWS QuickSight" application_summary=application_summary application_help_link=None instance=None application_url=quicksight_url customisable_instance=False has_access=perms.applications.access_quicksight trailing_horizontal_rule=False %}
+      {% endwith %}
+    </div>
 
     <div class="govuk-grid-row govuk-!-margin-top-9">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Description of change
At the moment, we have an h1 for 'Tools' page followed by an 'h3' for
each individual tool, then followed by an 'h2' for access requirements.
Access requirements feels like a separate thing from individual tools,
so to address this gap rather than raising each tool to an h2 we'll add
a visually-hidden h2 above the tool instances that provides a semantic
grouping for them.

### Checklist

* [ ] Have tests been added to cover any changes?
