### PR TITLE
feature: change mirrors sync to use ecr repo

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -62,6 +62,14 @@ resource "aws_ecr_repository" "visualisation_base_r" {
   name = "${var.prefix}-visualisation-base-r"
 }
 
+resource "aws_ecr_repository" "mirrors_sync" {
+  name = "${var.prefix}-mirrors-sync"
+}
+
+resource "aws_ecr_repository" "mirrors_sync_cran_binary" {
+  name = "${var.prefix}-mirrors-sync-cran-binary"
+}
+
 resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_id              = "${aws_vpc.main.id}"
   service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecr.dkr"
@@ -229,6 +237,8 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
       "${aws_ecr_repository.healthcheck.arn}",
       "${aws_ecr_repository.prometheus.arn}",
       "${aws_ecr_repository.gitlab.arn}",
+      "${aws_ecr_repository.mirrors_sync.arn}",
+      "${aws_ecr_repository.mirrors_sync_cran_binary.arn}",
     ]
   }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -69,8 +69,6 @@ variable alb_logs_account {}
 variable cloudwatch_destination_arn {}
 
 variable mirrors_bucket_name {}
-variable mirrors_sync_container_image {}
-variable mirrors_sync_cran_binary_container_image {}
 variable mirrors_data_bucket_name {}
 
 variable sentry_dsn {}


### PR DESCRIPTION
### Description of change

Change mirrors-sync and mirrors-sync-cran-binary tasks to use ECR images instead of quay.io.

Also adds a missing aws_cloudwatch_event_target for the debian mirror and fixes a typo in the nltk mirror target.

Related terraform-data-workspace PR is number 20

### Checklist

* [ ] Have tests been added to cover any changes?
