### PR TITLE
fix: use responsive dashboard height

### DIFF
--- a/dataworkspace/dataworkspace/templates/quicksight_running.html
+++ b/dataworkspace/dataworkspace/templates/quicksight_running.html
@@ -5,11 +5,19 @@
 {% endblock extra_head %}
 {% block javascript %}
   <script nonce="{{ request.csp_nonce }}">
-    QuickSightEmbedding.embedDashboard({
+    dashboard = QuickSightEmbedding.embedDashboard({
         url: '{{ visualisation_src|safe }}',
         container: document.getElementById('visualisation'),
         locale: "en-gb",
         printEnabled: true,
+        height: "AutoFit",
+        loadingHeight: "1000px"
+    });
+
+    dashboard.on("SHOW_MODAL_EVENT", () => {
+        window.scrollTo({
+            top: 0 // iFrame top position
+        });
     });
   </script>
 {% endblock javascript %}


### PR DESCRIPTION
### Description of change
Enable QuickSight's dashboard to automatically set the height of the 
visualisation based on the content, rather than fitting the window and 
scrolling within the iframe.

### Checklist

* [ ] Have tests been added to cover any changes?
