### PR TITLE
fix: tweak skip to main content target

### DIFF
--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -77,7 +77,7 @@
   <body class="govuk-template__body">
     {% include 'partials/gtm_body.html' %}
 
-    <a href="{{ request.path }}#main-content" class="govuk-skip-link">Skip to main content</a>
+    <a href="{{ request.path }}#visualisation" class="govuk-skip-link">Skip to main content</a>
 
     {% if wrap == 'IFRAME_WITH_VISUALISATIONS_HEADER' %}
       <div class="header-wrap">
@@ -124,12 +124,10 @@
         </div>
       </div>
     {% endif %}
-    <main id="main-content" role="main">
-      <div id="visualisation" class="visualisation-wrap">
-        {% block visualisation %}
-        {% endblock visualisation %}
-      </div>
-    </main>
+    <div id="visualisation" class="visualisation-wrap" role="main">
+      {% block visualisation %}
+      {% endblock visualisation %}
+    </div>
     {% block javascript %}
     {% endblock javascript %}
   </body>


### PR DESCRIPTION
### Description of change
Remove the `<main>` wrapper which has caused the height of the
visualisation to decrease significantly. We probably don't need this
element if we just put a role=main on the div and point the skip link at
that instead.

### Checklist

* [ ] Have tests been added to cover any changes?
