### PR TITLE
feature: stop Your Files modals from closing when clicking on backdrop

### DIFF
--- a/dataworkspace/dataworkspace/static/explorer-ie11-compat.js
+++ b/dataworkspace/dataworkspace/static/explorer-ie11-compat.js
@@ -926,14 +926,6 @@ angular.module('aws-js-s3-explorer').directive('modal', function () {
   return {
     link: function link(scope, element, attrs) {
       var name = attrs.modal;
-      element[0].addEventListener('click', function (event) {
-        event.stopPropagation(); // Don't close if clicking anywhere inside the modal, e.g. on a button
-
-        if (event.target == element[0]) {
-          close();
-        }
-      });
-
       function open() {
         scope.modalVisible = true;
         backdrop.classList.remove('modal-backdrop-out');


### PR DESCRIPTION
### Description of change

Clicking on the backdrop during a file upload cancels the upload and this isn't made clear to the user. As each modal has a cancel button there is no need to close the modal when the user clicks on the backdrop.

https://trello.com/c/gSJh9fMv/502-your-files-clicking-outside-of-upload-window-closes-up-and-stops-upload

### Checklist

* [ ] Have tests been added to cover any changes?
