### PR TITLE
fix: styling on switch to data hub link

### DIFF
--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -50,9 +50,9 @@
         </a>
       </div>
       <div class="app-header--suggestion">
-        <p class="govuk-body">
+        <div class="govuk-header__navigation-item">
           <a class="govuk-header__link" href="https://www.datahub.trade.gov.uk/">Switch to Data Hub</a>
-        </p>
+        </div>
       </div>
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">
         Menu


### PR DESCRIPTION
### Description of change
Make it look the same as the "switch to Data Workspace" link on Data Hub.

#### Before
<img width="978" alt="Screen Shot 2021-02-18 at 08 20 04" src="https://user-images.githubusercontent.com/2920760/108326426-21d2f680-71c2-11eb-9679-e432016f6297.png">

#### After
<img width="978" alt="Screen Shot 2021-02-18 at 08 19 29" src="https://user-images.githubusercontent.com/2920760/108326373-0ff15380-71c2-11eb-9283-646139b49224.png">

#### Data Hub
<img width="975" alt="Screen Shot 2021-02-18 at 08 20 50" src="https://user-images.githubusercontent.com/2920760/108326509-3c0cd480-71c2-11eb-8f85-5bbb6666d108.png">


### Checklist

* [ ] Have tests been added to cover any changes?
