### PR TITLE
fix: do not show deleted visualisations in search

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1638,6 +1638,8 @@ class ReferenceDatasetUploadLogRecord(TimeStampedModel):
 
 
 class VisualisationCatalogueItem(DeletableTimestampedUserModel):
+    objects = DeletableQuerySet()
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     visualisation_template = models.OneToOneField(
         VisualisationTemplate, on_delete=models.CASCADE, null=True, blank=True

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -398,7 +398,7 @@ def sorted_datasets_and_visualisations_matching_query_for_user(
     )
 
     visualisations = get_visualisations_data_for_user_matching_query(
-        VisualisationCatalogueItem.objects, query, user=user
+        VisualisationCatalogueItem.objects.live(), query, user=user
     )
 
     # Combine all datasets and visualisations and order them.

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -275,6 +275,30 @@ def test_find_datasets_combines_results(client):
     )
 
 
+def test_find_datasets_does_not_show_deleted_entries(client, staff_client):
+    factories.DataSetFactory.create(
+        deleted=True, published=True, name='Unpublished search dataset'
+    )
+    factories.DataSetFactory.create(
+        deleted=True, published=True, name='A search dataset'
+    )
+    factories.ReferenceDatasetFactory.create(
+        deleted=True, published=True, name='A search reference dataset'
+    )
+    factories.VisualisationCatalogueItemFactory.create(
+        deleted=True, published=True, name='A search visualisation'
+    )
+
+    response = client.get(reverse('datasets:find_datasets'))
+    staff_response = staff_client.get(reverse('datasets:find_datasets'))
+
+    assert response.status_code == 200
+    assert list(response.context["datasets"]) == []
+
+    assert staff_response.status_code == 200
+    assert list(staff_response.context["datasets"]) == []
+
+
 def test_find_datasets_filters_by_query(client):
     factories.DataSetFactory.create(published=True, name='A dataset')
     factories.ReferenceDatasetFactory.create(published=True, name='A reference dataset')


### PR DESCRIPTION
### Description of change
We were missing a `.live()` call on the VisualisationCatalogueItem
queryset on the dataset search page, so deleted items could still show
up in results. This fixes that and brings it in line with the other
three kinds of dataset.

### Checklist

* [x] Have tests been added to cover any changes?
