### PR TITLE
feature: allow user to download logs for visualisations in any branch

### DIFF
--- a/dataworkspace/dataworkspace/templates/visualisation_branch.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_branch.html
@@ -8,7 +8,7 @@
     <svg class="branch-icon-large" focusable="false" data-prefix="fas" data-icon="code-branch" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><title>Branch</title><path fill="currentColor" d="M384 144c0-44.2-35.8-80-80-80s-80 35.8-80 80c0 36.4 24.3 67.1 57.5 76.8-.6 16.1-4.2 28.5-11 36.9-15.4 19.2-49.3 22.4-85.2 25.7-28.2 2.6-57.4 5.4-81.3 16.9v-144c32.5-10.2 56-40.5 56-76.3 0-44.2-35.8-80-80-80S0 35.8 0 80c0 35.8 23.5 66.1 56 76.3v199.3C23.5 365.9 0 396.2 0 432c0 44.2 35.8 80 80 80s80-35.8 80-80c0-34-21.2-63.1-51.2-74.6 3.1-5.2 7.8-9.8 14.9-13.4 16.2-8.2 40.4-10.4 66.1-12.8 42.2-3.9 90-8.4 118.2-43.4 14-17.4 21.1-39.8 21.6-67.9 31.6-10.8 54.4-40.7 54.4-75.9zM80 64c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16zm0 384c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zm224-320c8.8 0 16 7.2 16 16s-7.2 16-16 16-16-7.2-16-16 7.2-16 16-16z"></path></svg> {{ current_branch.name }}
 </h1>
 
-{% if current_branch.name == gitlab_project.default_branch %}
+{% if is_default_branch %}
 <section class="production govuk-!-padding-5 govuk-!-margin-bottom-5">
     <h2 class="govuk-heading-m govuk-heading-production">
         Production{% if production_commit_id %}: {{ production_commit_id }}{% endif %}
@@ -69,12 +69,12 @@
                 View<span class="govuk-visually-hidden"> latest</span> commit<span class="govuk-visually-hidden">{{ latest_commit.short_id }}</span> in GitLab
             </a>
         </li>
-        <li{% if not can_release_latest_commit %} class="govuk-!-margin-bottom-0"{% endif %}>
+        <li{% if not can_download_logs %} class="govuk-!-margin-bottom-0"{% endif %}>
             <a class="govuk-link govuk-link--no-visited-state" href="{{ latest_commit_preview_link }}">
                 Preview visualisation<span class="govuk-visually-hidden"> at<span class="govuk-visually-hidden"> latest</span> commit {{ latest_commit.short_id }}</span>
             </a>
         </li>
-        {% if can_release_latest_commit %}
+        {% if can_download_logs %}
             <li class="govuk-!-margin-bottom-0">
                 <a class="govuk-link govuk-link--no-visited-state" href="{% url 'visualisations:logs' gitlab_project.id latest_commit.short_id %}">
                     Download latest application log


### PR DESCRIPTION
### Description of change

Currently application logs can only be downloaded for previewed/production visualisations on the master branch. This PR allows the user to download logs on any branch as long as the visualisation has been previewed.

![Screenshot_2021-02-19 Branch feature test - Visualisations - Data Workspace](https://user-images.githubusercontent.com/915598/108499224-e14ca900-72a5-11eb-9dc5-4c432c47f939.png)

https://trello.com/c/s6kQ3Vah/1442-link-to-visualisation-application-logs-for-any-branch-not-just-deployed-master

### Checklist

* [ ] Have tests been added to cover any changes?
