### PR TITLE
feat: stop using `slim` buster variant in tools

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -1,10 +1,4 @@
-FROM debian:buster-20200607-slim
-
-# Allow man pages to be installed: slim has hacks to exclude them, so we
-# hack the hacks https://unix.stackexchange.com/a/480460/361685
-RUN \
-    sed -i '/path-exclude \/usr\/share\/man/d' /etc/dpkg/dpkg.cfg.d/docker && \
-    sed -i '/path-exclude \/usr\/share\/groff/d' /etc/dpkg/dpkg.cfg.d/docker
+FROM debian:buster
 
 RUN \
 	echo "deb http://s3-eu-west-2.amazonaws.com/mirrors.notebook.uktrade.io/debian/ buster main" > /etc/apt/sources.list && \
@@ -49,8 +43,8 @@ RUN \
 		git=1:2.20.1-2+deb10u3 \
 		libgit2-dev=0.27.7+dfsg.1-0.2 \
 		libgsl-dev=2.5+dfsg-6 \
-		libxml2-dev=2.9.4+dfsg1-7+b3 \
-		libpq-dev=11.7-0+deb10u1 \
+		libxml2-dev \
+		libpq-dev \
 		lmodern=2.004.5-6 \
 		procps=2:3.3.15-2 \
 		r-base-dev=3.6.1-2~bustercran.0 \

--- a/tools/jupyterlab-python/Dockerfile
+++ b/tools/jupyterlab-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster
 
 RUN \
     apt-get update && \
@@ -17,12 +17,6 @@ ENV \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US.UTF-8 \
     LD_LIBRARY_PATH=/lib
-
-# Allow man pages to be installed: slim has hacks to exclude them, so we
-# hack the hacks https://unix.stackexchange.com/a/480460/361685
-RUN \
-    sed -i '/path-exclude \/usr\/share\/man/d' /etc/dpkg/dpkg.cfg.d/docker && \
-    sed -i '/path-exclude \/usr\/share\/groff/d' /etc/dpkg/dpkg.cfg.d/docker
 
 RUN \
     apt-get update && \
@@ -48,14 +42,14 @@ RUN \
         git-man=1:2.20.1-2+deb10u3 \
         libxext6 \
         libxrender1 \
-        man-db=2.8.5-2 \
-        openssl=1.1.1d-0+deb10u4 \
+        openssl \
         openssh-client=1:7.9p1-10+deb10u2 \
         texlive-xetex=2018.20190227-2 \
         texlive-generic-extra=2018.20190227-2 \
         texlive-fonts-recommended=2018.20190227-2 \
         ttf-dejavu \
-        sudo=1.8.27-1+deb10u2 \
+        sudo \
+        man-db=2.8.5-2 \
         tini=0.18.0-1 && \
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 2 && \
 	update-alternatives --install /usr/bin/python python /usr/bin/python2 1 && \

--- a/tools/jupyterlab-r/Dockerfile
+++ b/tools/jupyterlab-r/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster
 
 RUN \
     apt-get update && \
@@ -21,12 +21,6 @@ ENV \
 
 ENV \
     PATH="$CONDA_DIR/bin:$PATH"
-
-# Allow man pages to be installed: slim has hacks to exclude them, so we
-# hack the hacks https://unix.stackexchange.com/a/480460/361685
-RUN \
-    sed -i '/path-exclude \/usr\/share\/man/d' /etc/dpkg/dpkg.cfg.d/docker && \
-    sed -i '/path-exclude \/usr\/share\/groff/d' /etc/dpkg/dpkg.cfg.d/docker
 
 RUN \
     apt-get update && \

--- a/tools/theia/Dockerfile
+++ b/tools/theia/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster
 
 RUN \
 	apt-get update && \
@@ -33,6 +33,7 @@ RUN \
 		python3 \
 		python3-dev \
 		python3-pip \
+		man-db=2.8.5-2 \
 		sudo && \
 	curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs && \


### PR DESCRIPTION
### Description of change
We're currently using `buster-slim` as the base image for our
docker-based tools (e.g. theia, jupyterlab). After a chat with the devs
we don't really have a good reason for this. Our images are already
pretty gargantuan - around 4GB, so the difference between `buster` and
`buster-slim` is insignificant in comparison.

The `-slim` variant specifically excludes man pages from the build, so
in some tools we've had to hack this exclusion to re-introduce them, and
after doing that we're still missing some manpages for common tools,
e.g. grep. So since size isn't a concern, let's go back to using the
"full-fat" `buster` base image. Then we can remove our hacks and benefit
from a more complete man-db with no extra work.

### Checklist

* [ ] Have tests been added to cover any changes?
