### PR TITLE
feat: format last update date with timezone

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
+++ b/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
@@ -1,6 +1,11 @@
+from datetime import datetime
+from typing import Optional
 from urllib import parse
+from dateutil.relativedelta import relativedelta
+import pytz
 
 from django import template
+from django.utils import timezone
 
 
 register = template.Library()
@@ -19,3 +24,29 @@ def url_replace(context, **kwargs):
 @register.filter
 def quote_plus(data):
     return parse.quote_plus(data)
+
+
+@register.filter
+def date_with_gmt_offset(utc_date: Optional[datetime]) -> Optional[str]:
+    """
+    Given a UTC date return a pretty representation with GMT offset.
+
+    E.g.
+
+    2020-01-01 11:40 ->	Jan 1, 2020, 11:40am, GMT
+    2020-07-16 11:40 ->	Jul 16, 2020, 12:40pm, GMT+1
+    """
+    if not utc_date:
+        return None
+
+    if timezone.is_naive(utc_date):
+        utc_date = utc_date.replace(tzinfo=pytz.UTC)
+
+    timezone.activate(pytz.timezone('Europe/London'))
+    localised_date = timezone.localtime(utc_date)
+    offset = relativedelta(
+        localised_date.replace(tzinfo=None), utc_date.replace(tzinfo=None)
+    )
+    return localised_date.strftime(
+        f'%b %-d, %Y, %-I:%M%P, GMT{(f"+{offset.hours}" if offset.hours else "")}'
+    )

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -2,6 +2,7 @@ import logging
 from typing import Tuple
 
 import psycopg2
+import pytz
 from django.db import connections
 
 from dataworkspace.utils import TYPE_CODES_REVERSED
@@ -41,7 +42,7 @@ def get_columns(
 
 def get_tables_last_updated_date(database_name: str, tables: Tuple[Tuple[str, str]]):
     """
-    Return the earliest of the last updated dates for a list of tables.
+    Return the earliest of the last updated dates for a list of tables in UTC.
     """
     with connections[database_name].cursor() as cursor:
         cursor.execute(
@@ -59,4 +60,7 @@ def get_tables_last_updated_date(database_name: str, tables: Tuple[Tuple[str, st
             ''',
             [tables],
         )
-        return cursor.fetchone()[0]
+        dt = cursor.fetchone()[0]
+        if dt is None:
+            return None
+        return dt.replace(tzinfo=pytz.UTC)

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -1,6 +1,5 @@
 {% extends '_main.html' %}
-{% load humanize %}
-{% load static %}
+{% load humanize static datasets_tags %}
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
@@ -112,7 +111,7 @@
                           {% endif %}
                         </td>
                         <td class="govuk-table__cell">
-                          {{ datacut.get_data_last_updated_date|default_if_none:"N/A" }}
+                          {{ datacut.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
                         </td>
                         <td class="govuk-table__cell">
                             {% if can_show_link and datacut.type == custom_dataset_query_type %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -1,6 +1,5 @@
 {% extends '_main.html' %}
-{% load humanize %}
-{% load static %}
+{% load humanize static datasets_tags %}
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
@@ -64,7 +63,9 @@
             <td class="govuk-table__cell app-table_cell--no-border">{{ source_table.name }}</td>
             <td class="govuk-table__cell app-table_cell--no-border">"{{ source_table.schema }}"."{{ source_table.table }}"</td>
             <td class="govuk-table__cell app-table_cell--no-border">{{ source_table.get_frequency_display }}</td>
-            <td class="govuk-table__cell app-table_cell--no-border">{{ source_table.get_data_last_updated_date|default_if_none:"N/A" }}</td>
+            <td class="govuk-table__cell app-table_cell--no-border">
+              {{ source_table.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
+            </td>
             <td class="govuk-table__cell app-table_cell--no-border">
               {% if source_table.type == source_table_type %}
                 {% if has_access %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -63,7 +63,7 @@
               </td>
               <td class="govuk-table__cell">JSON</td>
               <td class="govuk-table__cell">{{ model.published_version }}</td>
-              <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
+              <td class="govuk-table__cell">{{ model.data_last_updated|date_with_gmt_offset }}</td>
             </tr>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
@@ -75,7 +75,7 @@
                 CSV
               </td>
               <td class="govuk-table__cell">{{ model.published_version }}</td>
-              <td class="govuk-table__cell">{{ model.data_last_updated }}</td>
+              <td class="govuk-table__cell">{{ model.data_last_updated|date_with_gmt_offset }}</td>
             </tr>
           </tbody>
         </table>

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -1,7 +1,5 @@
 {% extends '_main.html' %}
-{% load humanize %}
-{% load static %}
-{% load core_filters %}
+{% load humanize static core_filters datasets_tags %}
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
@@ -75,7 +73,7 @@
                             {% endif %}
                         </td>
                         <td class="govuk-table__cell">
-                            {{ visualisation_link.modified_date|default_if_none:"N/A" }}
+                            {{ visualisation_link.modified_date|date_with_gmt_offset|default_if_none:"N/A" }}
                         </td>
                         <td class="govuk-table__cell">
                           Web

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import botocore
 import mock
 import pytest
+from pytz import UTC
 
 from dataworkspace.apps.datasets.models import SourceLink
 from dataworkspace.tests import factories
@@ -149,7 +150,9 @@ def test_source_table_data_last_updated(metadata_db):
     table = factories.SourceTableFactory(
         dataset=dataset, database=metadata_db, schema='public', table='table1'
     )
-    assert table.get_data_last_updated_date() == datetime(2020, 9, 2, 0, 1, 0)
+    assert table.get_data_last_updated_date() == datetime(
+        2020, 9, 2, 0, 1, 0, tzinfo=UTC
+    )
 
     table = factories.SourceTableFactory(
         dataset=dataset, database=metadata_db, schema='public', table='doesntexist'
@@ -174,7 +177,9 @@ def test_custom_query_data_last_updated(metadata_db):
     factories.CustomDatasetQueryTableFactory(
         query=query, schema='public', table='table2'
     )
-    assert query.get_data_last_updated_date() == datetime(2020, 9, 1, 0, 1, 0)
+    assert query.get_data_last_updated_date() == datetime(
+        2020, 9, 1, 0, 1, 0, tzinfo=UTC
+    )
 
     # Ensure a single table returns the last update date
     query = factories.CustomDatasetQueryFactory(
@@ -183,7 +188,9 @@ def test_custom_query_data_last_updated(metadata_db):
     factories.CustomDatasetQueryTableFactory(
         query=query, schema='public', table='table1'
     )
-    assert query.get_data_last_updated_date() == datetime(2020, 9, 2, 0, 1, 0)
+    assert query.get_data_last_updated_date() == datetime(
+        2020, 9, 2, 0, 1, 0, tzinfo=UTC
+    )
 
     # Ensure None is returned if we don't have any metadata for the tables
     query = factories.CustomDatasetQueryFactory(

--- a/dataworkspace/dataworkspace/tests/datasets/test_tags.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_tags.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+import pytest
+from pytz import UTC
+
+from dataworkspace.apps.datasets.templatetags import datasets_tags
+
+
+@pytest.mark.parametrize(
+    'input_date, expected_output_date',
+    [
+        (datetime(2020, 1, 1, 11, 40, tzinfo=UTC), 'Jan 1, 2020, 11:40am, GMT'),
+        (datetime(2020, 7, 16, 11, 40, tzinfo=UTC), 'Jul 16, 2020, 12:40pm, GMT+1'),
+        (datetime(2021, 2, 17, 14, 1, tzinfo=UTC), 'Feb 17, 2021, 2:01pm, GMT'),
+        (datetime(2021, 1, 1, 1, 1), 'Jan 1, 2021, 1:01am, GMT'),
+    ],
+)
+def test_date_with_gmt_offset(input_date, expected_output_date):
+    assert datasets_tags.date_with_gmt_offset(input_date) == expected_output_date


### PR DESCRIPTION
### Description of change

Adds GMT offset to catalogue item last updated dates. E.g.

- `2020-01-01 11:40` will be displayed as `Jan 1, 2020, 11:40am, GMT`
- `2020-07-16 11:40` will be displayed as `Jul 16, 2020, 12:40pm, GMT+1`

### UI Changes

**Master dataset**
![Screenshot from 2021-02-17 15-49-21](https://user-images.githubusercontent.com/594496/108735180-21bb5980-7528-11eb-94ac-436e56294329.png)

**Data cut dataset**
![Screenshot from 2021-02-17 15-49-08](https://user-images.githubusercontent.com/594496/108735190-25e77700-7528-11eb-9d48-8efcaef4d630.png)

**Reference dataset**
![Screenshot from 2021-02-17 15-49-17](https://user-images.githubusercontent.com/594496/108735202-2a139480-7528-11eb-95d7-b239a2863a45.png)

**Visualisation**
![Screenshot from 2021-02-17 15-49-27](https://user-images.githubusercontent.com/594496/108735216-2ed84880-7528-11eb-8e1f-105474af4082.png)

### Checklist

* [x] Have tests been added to cover any changes?
