### PR TITLE
fix: allow tables to be focused and scrolled

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
@@ -15,7 +15,7 @@
       <p class="govuk-body">
         Execution time: {{ duration|format_duration }}
       </p>
-      <div class="scrollable-table">
+      <div class="scrollable-table" tabindex="0">
         <table class="govuk-table">
           <thead class="govuk-table">
           <tr class="govuk-table__row">

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -14,6 +14,12 @@
   width: 100%;
   overflow-x: auto;
   max-height: 560px;
+  padding: 3px;
+}
+.scrollable-table:focus {
+    border: 3px solid #0b0c0c;
+    outline: 3px solid #fd0;
+    padding: 0;
 }
 .fixed-table-height {
   max-height: 100% !important;

--- a/dataworkspace/dataworkspace/static/explorer_custom.css
+++ b/dataworkspace/dataworkspace/static/explorer_custom.css
@@ -29,6 +29,12 @@
     /*width: 100%;*/
     overflow-x: auto;
     max-height: 560px;
+    padding: 3px;
+}
+.scrollable-table:focus {
+    border: 3px solid #0b0c0c;
+    outline: 3px solid #fd0;
+    padding: 0;
 }
 /* add yellow box shadow to query editor on focus */
 .govuk-textarea:focus-within {

--- a/dataworkspace/dataworkspace/templates/datasets/dataset_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/dataset_preview.html
@@ -46,7 +46,7 @@
         <p class="govuk-body">
           Showing {% if record_count < preview_limit %}all {% else %}<strong>{{ preview_limit }}</strong> random {% endif %}rows from data.
         </p>
-        <div class="scrollable-table {% if record_count <= fixed_table_height_limit %}fixed-table-height{% endif %}">
+        <div class="scrollable-table {% if record_count <= fixed_table_height_limit %}fixed-table-height{% endif %}" tabindex="0">
           <table class="govuk-table govuk-!-font-size-16">
             <thead>
               <tr class="govuk-table__row">

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -110,7 +110,7 @@
         <p class="govuk-body">
           Showing {% if preview_limit < record_count %}first {% endif %}<strong>{{ preview_limit }}</strong> record{{ preview_limit|pluralize }} {% if preview_limit < record_count %} of <strong>{{ record_count }}</strong>{% endif %}
         </p>
-        <div class="scrollable-table">
+        <div class="scrollable-table" tabindex="0">
           <table class="govuk-table govuk-!-font-size-16">
             <thead>
               <tr class="govuk-table__row">


### PR DESCRIPTION
### Description of change
Makes sure that the tables for master/reference dataset previews, and Data Explorer results, can be tabbed into and scrolled using the keyboard. It also adds a GOV.UK Design System-style focus on the tables, with some padding added by default to ensure that the table doesn't jump around slightly when the focus border is added.

![2021-02-22 16 15 31](https://user-images.githubusercontent.com/2920760/108736160-4237e380-7529-11eb-9aa5-821b540cdd26.gif)

### Checklist

* [ ] Have tests been added to cover any changes?
