### PR TITLE
fix: use old school function as callback

### DIFF
--- a/dataworkspace/dataworkspace/templates/quicksight_running.html
+++ b/dataworkspace/dataworkspace/templates/quicksight_running.html
@@ -14,7 +14,7 @@
         loadingHeight: "1000px"
     });
 
-    dashboard.on("SHOW_MODAL_EVENT", () => {
+    dashboard.on("SHOW_MODAL_EVENT", function() {
         window.scrollTo({
             top: 0 // iFrame top position
         });


### PR DESCRIPTION
### Description of change

IE11 doesn't like es6 style functions so revert back to function() for the quicksight "show modal" event callback

### Checklist

* [ ] Have tests been added to cover any changes?
