### PR TITLE
feature: give quicksight db user access to the user's DW schema

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -891,7 +891,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
 
                 source_tables = source_tables_for_user(dw_user)
                 db_role_schema_suffix = stable_identification_suffix(
-                    user_arn, short=True
+                    str(dw_user.profile.sso_id), short=True
                 )
 
                 # This creates a DB user for each of our datasets DBs. These users are intended to be long-lived,


### PR DESCRIPTION
### Description of change

Temporary database users created for quicksight users currently have access to a different schema to the one used in DW tools. This PR fixes that, allowing quicksight visualisations to access tables in the user's private schema.

https://trello.com/c/bsp6tZjL/1452-your-files-csv-upload-available-in-quicksight

### Checklist

* [ ] Have tests been added to cover any changes?
