### PR TITLE
fix: do not send "Accept-Encoding" header to SSO

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -946,6 +946,7 @@ async def async_main():
 
                 async with client_session.post(
                     f'{sso_base_url}{token_path}',
+                    headers={'Accept-Encoding': 'identity'},
                     data={
                         'grant_type': grant_type,
                         'code': code,
@@ -1006,7 +1007,11 @@ async def async_main():
                 return await handler_with_sso_headers()
 
             async with client_session.get(
-                f'{sso_base_url}{me_path}', headers={'Authorization': f'Bearer {token}'}
+                f'{sso_base_url}{me_path}',
+                headers={
+                    'Accept-Encoding': 'identity',
+                    'Authorization': f'Bearer {token}',
+                },
             ) as me_response:
                 me_profile_full = (
                     await me_response.json() if me_response.status == 200 else None

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -946,7 +946,6 @@ async def async_main():
 
                 async with client_session.post(
                     f'{sso_base_url}{token_path}',
-                    headers={'Accept-Encoding': 'identity'},
                     data={
                         'grant_type': grant_type,
                         'code': code,
@@ -1008,10 +1007,7 @@ async def async_main():
 
             async with client_session.get(
                 f'{sso_base_url}{me_path}',
-                headers={
-                    'Accept-Encoding': 'identity',
-                    'Authorization': f'Bearer {token}',
-                },
+                headers={'Authorization': f'Bearer {token}'},
             ) as me_response:
                 me_profile_full = (
                     await me_response.json() if me_response.status == 200 else None
@@ -1168,7 +1164,9 @@ async def async_main():
         return _authenticate_by_ip_whitelist
 
     async with aiohttp.ClientSession(
-        auto_decompress=False, cookie_jar=aiohttp.DummyCookieJar()
+        auto_decompress=False,
+        cookie_jar=aiohttp.DummyCookieJar(),
+        skip_auto_headers=['Accept-Encoding'],
     ) as client_session:
         app = web.Application(
             middlewares=[

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2162,8 +2162,8 @@ class TestApplication(unittest.TestCase):
 
         async with session.request('GET', 'http://dataworkspace.test:8000/'):
             assert (
-                headers['Accept-Encoding'] == 'identity'
-            ), 'Incorrect encoding sent to SSO token endpoint'
+                'Accept-Encoding' not in headers
+            ), 'Encoding incorrectly sent to SSO token endpoint'
 
         await sso_site.stop()
 


### PR DESCRIPTION
### Description of change

~~Send `Accept-Encoding` header as `identity` for requests from the proxy to SSO endpoints.~~
Do not send an Accept-Encoding header to sso endpoints

### Checklist

* [x] Have tests been added to cover any changes?
