### PR TITLE
fix: mark vis description as safe html

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -37,7 +37,7 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">{{ model.name }}</h1>
             <div class="govuk-body">
-                {{ model.description | minimal_markdown }}
+                {{ model.description | safe }}
             </div>
 
             {% if not has_access %}


### PR DESCRIPTION
### Description of change

Use `|safe` for visualisation description text to match the other dataset types

### Checklist

~~* [ ] Have tests been added to cover any changes?~~
