### PR TITLE
fix: allow client to specify page size

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/pagination.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/pagination.py
@@ -3,3 +3,5 @@ from rest_framework.pagination import CursorPagination
 
 class TimestampCursorPagination(CursorPagination):
     ordering = ('timestamp', 'id')
+    page_size_query_param = 'page_size'
+    max_page_size = 10_000


### PR DESCRIPTION
There are 11,000,000 query log records that to be synced every night and the current page size of 100 rows will probably take some time. So, allow the client to specify the page size - up to a limit of 10k.
