### PR TITLE
fix: add ingress rule for mirrors-sync to talk to the ecr api

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -697,6 +697,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_notebooks" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_mirrors_sync" {
+  description = "ingress-https-from-mirrors-sync"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.mirrors_sync.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 


### PR DESCRIPTION
### Description of change

FARGATE platform version 1.4.0 requires explicit network connectivity set up between the task and the ECR api. It seems that AWS has changed LATEST to now point to 1.4.0 and this has brokenr the mirrors-sync scheduled tasks. This PR adds the missing security group rule to allow the task to authenticate with ECR.

https://trello.com/c/4X92OsBW/1653-fix-mirrors-sync-scheduled-task

### Checklist

* [ ] Have tests been added to cover any changes?
