### PR TITLE
feature: show code snippets for custom SQL queries on datacut catalogue pages

### DIFF
--- a/dataworkspace/dataworkspace/static/app-tabs.css
+++ b/dataworkspace/dataworkspace/static/app-tabs.css
@@ -13,6 +13,8 @@ pre code {
   display: block;
   padding: 20px;
   overflow-x: auto;
+  overflow-y: scroll;
+  max-height: 345px;
   background-color: #f3f2f1 !important;
   margin-bottom: -1em;
   font-size: 19px;

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -89,35 +89,35 @@
                 </thead>
                 <tbody>
 
-                {% for datacut, can_show_link in datacut_links_info %}
+                {% for datacut_link, can_show_link, code_snippets in datacut_links_info %}
                     <tr class="govuk-table__row">
-                        <td class="govuk-table__cell">
+                        <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
                             {% if has_access and can_show_link %}
-                            <a class="govuk-link" href="{{ datacut.get_absolute_url }}">
-                                {{ datacut.name }}
+                            <a class="govuk-link" href="{{ datacut_link.get_absolute_url }}">
+                                {{ datacut_link.name }}
                             </a>
                             {% else %}
-                                {{ datacut.name }}
+                                {{ datacut_link.name }}
                             {% endif %}
                         </td>
-                        <td class="govuk-table__cell">
-                          {% if datacut.format %}{{ datacut.format }}{% else %}CSV{% endif %}
+                        <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                          {% if datacut_link.format %}{{ datacut_link.format }}{% else %}CSV{% endif %}
                         </td>
-                        <td class="govuk-table__cell">
-                          {% if datacut.get_frequency_display %}
-                            {{ datacut.get_frequency_display }}
+                        <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                          {% if datacut_link.get_frequency_display %}
+                            {{ datacut_link.get_frequency_display }}
                           {% else %}
-                            {{ datacut.frequency }}
+                            {{ datacut_link.frequency }}
                           {% endif %}
                         </td>
-                        <td class="govuk-table__cell">
-                          {{ datacut.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
+                        <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                          {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
                         </td>
-                        <td class="govuk-table__cell">
-                            {% if can_show_link and datacut.type == custom_dataset_query_type %}
+                        <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                            {% if can_show_link and datacut_link.type == custom_dataset_query_type %}
                                 {% if has_access %}
                                     <a class="govuk-link"
-                                        href="{% url "datasets:dataset_query_preview" dataset_uuid=dataset.id query_id=datacut.id %}">
+                                        href="{% url "datasets:dataset_query_preview" dataset_uuid=dataset.id query_id=datacut_link.id %}">
                                         Preview
                                     </a>
                                 {% else %}
@@ -127,6 +127,22 @@
                                 No preview available
                             {% endif %}
                         </td>
+                        {% if code_snippets %}
+                        <tr class="govuk-table__row">
+                            <td colspan="6" class="govuk-table__cell">
+                              <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                                <summary class="govuk-details__summary">
+                                  <span class="govuk-details__summary-text">
+                                    Code snippets<span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+                                  </span>
+                                </summary>
+                                <div class="govuk-details__text">
+                                  {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=source_table %}
+                                </div>
+                              </details>
+                            </td>
+                          </tr>
+                          {% endif %}
                     </tr>
                 {% endfor %}
 
@@ -215,4 +231,16 @@
             {% endif %}
         </div>
     </div>
+{% endblock %}
+{% block footer_scripts %}
+  <script src="{% static 'assets/vendor/highlight/highlight.pack.js' %}"></script>
+  <script nonce="{{ request.csp_nonce }}">hljs.initHighlightingOnLoad();</script>
+
+  <script src="{% static 'app-copy.js' %}"></script>
+  <script nonce="{{ request.csp_nonce }}">
+    let $codeBlocks = document.querySelectorAll('[data-module="app-copy"]')
+    nodeListForEach($codeBlocks, function ($codeBlock) {
+      new Copy($codeBlock).init()
+    });
+  </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
@@ -62,32 +62,6 @@ def test_master_dataset_no_access_preview(client, dataset_db):
     assert 'Preview' not in response.rendered_content
 
 
-def test_view_data_cut_fields(client, dataset_db):
-    ds = factories.DataSetFactory.create(published=True)
-    factories.SourceViewFactory(
-        dataset=ds, database=dataset_db, schema='public', view='dataset_view'
-    )
-
-    response = client.get(ds.get_absolute_url())
-
-    assert response.status_code == 200
-    assert response.context["fields"] == ['id', 'name', 'date']
-
-
-def test_query_data_cut_fields(client, dataset_db):
-    ds = factories.DataSetFactory.create(published=True)
-    factories.CustomDatasetQueryFactory(
-        dataset=ds,
-        database=dataset_db,
-        query="SELECT id customid, name customname FROM dataset_test",
-    )
-
-    response = client.get(ds.get_absolute_url())
-
-    assert response.status_code == 200
-    assert response.context["fields"] == ['customid', 'customname']
-
-
 def test_query_data_cut_preview(client, dataset_db):
     ds = factories.DataSetFactory.create(
         user_access_type='REQUIRES_AUTHENTICATION', published=True,
@@ -160,16 +134,6 @@ def test_query_data_cut_preview_staff_user_no_access(staff_client, dataset_db):
         not in response.rendered_content
     )
     assert 'Preview' not in response.rendered_content
-
-
-def test_link_data_cut_doesnt_have_fields(client):
-    ds = factories.DataSetFactory.create(published=True)
-    factories.SourceLinkFactory(dataset=ds)
-
-    response = client.get(ds.get_absolute_url())
-
-    assert response.status_code == 200
-    assert response.context["fields"] is None
 
 
 def test_link_data_cut_doesnt_have_preview(client):

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -8,7 +8,8 @@ from dataworkspace.apps.datasets.constants import DataSetType
 from dataworkspace.apps.datasets.models import DataSet
 from dataworkspace.apps.datasets.utils import (
     dataset_type_to_manage_unpublished_permission_codename,
-    get_code_snippets,
+    get_code_snippets_for_query,
+    get_code_snippets_for_table,
     update_quicksight_visualisations_last_updated_date,
 )
 from dataworkspace.tests.factories import (
@@ -36,16 +37,23 @@ def test_dataset_type_to_manage_unpublished_permission_codename():
 
 
 @pytest.mark.django_db
-def test_get_code_snippets(metadata_db):
+def test_get_code_snippets_for_table(metadata_db):
     ds = DataSetFactory.create(type=DataSetType.MASTER.value)
     sourcetable = SourceTableFactory.create(
         dataset=ds, schema="public", table="MY_LOVELY_TABLE"
     )
 
-    snippets = get_code_snippets(sourcetable)
+    snippets = get_code_snippets_for_table(sourcetable)
     assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['python']
     assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['r']
     assert snippets['sql'] == """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50"""
+
+
+def test_get_code_snippets_for_query(metadata_db):
+    snippets = get_code_snippets_for_query('SELECT * FROM foo')
+    assert 'SELECT * FROM foo' in snippets['python']
+    assert 'SELECT * FROM foo' in snippets['r']
+    assert snippets['sql'] == 'SELECT * FROM foo'
 
 
 class TestUpdateQuickSightVisualisationsLastUpdatedDate:


### PR DESCRIPTION
### Description of change

Show code snippets for Datacut catalogue page SQL queries. This PR also removes the 'fields' key from the datacut view context data as it wasn't being used in the template.

![Screenshot_2021-03-19 Test datacut - Data Workspace](https://user-images.githubusercontent.com/915598/111761278-a4210a00-8897-11eb-93e4-3593bd911788.png)

https://trello.com/c/nqGh0b0V/1592-franks-favourite-card-data-cut-query-on-data-cut-page

### Checklist

* [ ] Have tests been added to cover any changes?
