### PR TITLE
fix: ensure all users get their schema info cache cleared

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -294,7 +294,6 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
 
         changed_user_sso_ids = set()
 
-        clear_schema_info_cache = False
         for user in authorized_users - current_authorized_users:
             DataSetUserPermission.objects.create(dataset=obj, user=user)
             log_permission_change(
@@ -305,7 +304,7 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Added dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
-            clear_schema_info_cache = True
+            clear_schema_info_cache_for_user(user)
 
         for user in current_authorized_users - authorized_users:
             DataSetUserPermission.objects.filter(dataset=obj, user=user).delete()
@@ -317,9 +316,6 @@ class BaseDatasetAdmin(PermissionedDatasetAdmin):
                 f"Removed dataset {obj} permission",
             )
             changed_user_sso_ids.add(str(user.profile.sso_id))
-            clear_schema_info_cache = True
-
-        if clear_schema_info_cache:
             clear_schema_info_cache_for_user(user)
 
         if original_user_access_type != obj.user_access_type:

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -3135,7 +3135,9 @@ class TestDatasetAdminPytest:
     def test_master_dataset_authorized_user_changes_calls_sync_job_and_clears_explorer_cache(
         self, mock_clear_cache, mock_sync, staff_client
     ):
-        user = factories.UserFactory()
+        user_1 = factories.UserFactory()
+        user_2 = factories.UserFactory()
+
         dataset = factories.MasterDataSetFactory.create(
             published=True, user_access_type='AUTHORIZATION'
         )
@@ -3156,7 +3158,7 @@ class TestDatasetAdminPytest:
                 'description': 'test description',
                 'type': dataset.type,
                 'requires_authorization': 'on',
-                'authorized_users': str(user.id),
+                'authorized_users': [str(user_1.id), str(user_2.id)],
                 'sourcetable_set-TOTAL_FORMS': '1',
                 'sourcetable_set-INITIAL_FORMS': '1',
                 'sourcetable_set-MIN_NUM_FORMS': '0',
@@ -3172,8 +3174,13 @@ class TestDatasetAdminPytest:
             follow=True,
         )
 
+        _, mock_sync_kwargs = mock_sync.delay.call_args_list[0]
+        mock_clear_cache_args = [args[0] for args, _ in mock_clear_cache.call_args_list]
+
         assert response.status_code == 200
-        assert mock_sync.delay.call_args_list == [
-            mock.call(user_sso_ids_to_update=(str(user.profile.sso_id),))
-        ]
-        assert mock_clear_cache.call_args_list == [mock.call(user)]
+        assert sorted(mock_sync_kwargs['user_sso_ids_to_update']) == sorted(
+            [str(user_1.profile.sso_id), str(user_2.profile.sso_id)]
+        )
+        assert sorted([u.id for u in mock_clear_cache_args]) == sorted(
+            [user_1.id, user_2.id]
+        )


### PR DESCRIPTION
### Description of change

Incorrect indentation meant that only the most recent user in the for loop gets their schema info cache cleared.

### Checklist

* [ ] Have tests been added to cover any changes?
