### PR TITLE
feature: clear data explorer cached credentials if permissions change

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -31,6 +31,9 @@ from dataworkspace.apps.applications.utils import (
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_permission_change
 from dataworkspace.apps.explorer.schema import clear_schema_info_cache_for_user
+from dataworkspace.apps.explorer.utils import (
+    remove_data_explorer_user_cached_credentials,
+)
 
 
 class AppUserCreationForm(forms.ModelForm):
@@ -422,7 +425,7 @@ class AppUserAdmin(UserAdmin):
         )
 
         update_quicksight_permissions = False
-        clear_schema_info_cache = False
+        clear_schema_info_and_credentials_cache = False
         for dataset in authorized_datasets - current_datasets:
             DataSetUserPermission.objects.create(dataset=dataset, user=obj)
             log_permission_change(
@@ -434,7 +437,7 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
-            clear_schema_info_cache = True
+            clear_schema_info_and_credentials_cache = True
 
         for dataset in current_datasets - authorized_datasets:
             DataSetUserPermission.objects.filter(dataset=dataset, user=obj).delete()
@@ -447,10 +450,11 @@ class AppUserAdmin(UserAdmin):
             )
             if dataset.type == DataSetType.MASTER.value:
                 update_quicksight_permissions = True
-            clear_schema_info_cache = True
+            clear_schema_info_and_credentials_cache = True
 
-        if clear_schema_info_cache and obj.pk:
+        if clear_schema_info_and_credentials_cache and obj.pk:
             clear_schema_info_cache_for_user(obj)
+            remove_data_explorer_user_cached_credentials(obj)
 
         if 'authorized_visualisations' in form.cleaned_data:
             current_visualisations = VisualisationCatalogueItem.objects.filter(

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -121,8 +121,11 @@ class QueryException(Exception):
     pass
 
 
+cache_version = 1
+
+
 def user_cached_credentials_key(user):
-    return f"explorer_credentials_{user.profile.sso_id}"
+    return f"explorer_credentials_{cache_version}_{user.profile.sso_id}"
 
 
 def get_user_explorer_connection_settings(user, alias):
@@ -216,6 +219,11 @@ def remove_data_explorer_user_cached_credentials(user):
     logger.info("Clearing Data Explorer cached credentials for %s", user)
     cache_key = user_cached_credentials_key(user)
     cache.delete(cache_key)
+
+
+def invalidate_data_explorer_user_cached_credentials():
+    global cache_version  # pylint: disable=global-statement
+    cache_version += 1
 
 
 def tempory_query_table_name(user, query_log_id):


### PR DESCRIPTION
### Description of change

When a user is granted or revoked access to a dataset, their data explorer cached credentials should be cleared to ensure their database permissions are valid.

Also, when a dataset's user_access_type is changed, all unauthorized users should have their credentials cleared as well. This ensures that users who couldn't access a now "public" dataset get access, and users who had access to a now "private" dataset lose access.

https://trello.com/c/gUDVTJ9n/1591-people-really-get-data-explorer-credentials-when-they-are-granted-clear-cached-data-explorer-credentials-on-permissions-change

### Checklist

* [ ] Have tests been added to cover any changes?
