### PR TITLE
fix: use refreshable AWS credentials

### DIFF
--- a/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
+++ b/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
@@ -2,10 +2,8 @@ from dataclasses import dataclass
 from typing import List, Optional
 from django.conf import settings
 
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from elasticsearch import Elasticsearch, RequestsHttpConnection
-from requests_aws4auth import AWS4Auth
-
-import boto3
 
 
 @dataclass
@@ -32,13 +30,10 @@ class ElasticsearchClient:
         else:
             region = settings.DATASET_FINDER_AWS_REGION
 
-            credentials = boto3.Session().get_credentials()
-            self._aws_auth = AWS4Auth(
-                credentials.access_key,
-                credentials.secret_key,
-                region,
-                'es',
-                session_token=credentials.token,
+            self._aws_auth = BotoAWSRequestsAuth(
+                aws_host=settings.DATASET_FINDER_ES_HOST,
+                aws_region=region,
+                aws_service='es',
             )
             self._client = Elasticsearch(
                 hosts=[

--- a/dataworkspace/dataworkspace/templates/finder/index.html
+++ b/dataworkspace/dataworkspace/templates/finder/index.html
@@ -39,7 +39,7 @@
       <div class="govuk-grid-column-two-thirds" style="margin: 0 auto; float: unset">
         {% if results %}
           <p class="govuk-body">
-            <strong>results</strong>
+            <strong>{{ results|length }} results</strong>
           </p>
 
           {% for result in results %}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,8 @@ appdirs==1.4.4
     # via
     #   black
     #   pyppeteer
+appnope==0.1.2
+    # via ipython
 asgiref==3.2.10
     # via django
 astroid==2.4.2
@@ -33,6 +35,8 @@ attrs==20.2.0
     #   flake8-bugbear
     #   jsonschema
     #   pytest
+aws-requests-auth==0.4.3
+    # via -r requirements.in
 backcall==0.2.0
     # via ipython
 beautifulsoup4==4.9.3
@@ -176,6 +180,15 @@ idna==2.10
     #   yarl
 ijson==3.1.3
     # via tabulator
+importlib-metadata==2.1.1
+    # via
+    #   flake8
+    #   jsonschema
+    #   kombu
+    #   markdown
+    #   pluggy
+    #   pyppeteer
+    #   pytest
 iniconfig==1.1.1
     # via pytest
 ipdb==0.13.7
@@ -344,8 +357,6 @@ remote-pdb-client==1.0.4
     # via -r requirements-dev.in
 remote-pdb==2.1.0
     # via -r requirements-dev.in
-requests-aws4auth==1.0.1
-    # via -r requirements.in
 requests-mock==1.8.0
     # via -r requirements-dev.in
 requests-oauthlib==1.3.0
@@ -353,8 +364,8 @@ requests-oauthlib==1.3.0
 requests==2.24.0
     # via
     #   -r requirements.in
+    #   aws-requests-auth
     #   notifications-python-client
-    #   requests-aws4auth
     #   requests-mock
     #   requests-oauthlib
     #   tableschema
@@ -419,7 +430,11 @@ tqdm==4.56.0
 traitlets==5.0.5
     # via ipython
 typed-ast==1.4.2
-    # via black
+    # via
+    #   astroid
+    #   black
+typing-extensions==3.7.4.3
+    # via yarl
 unicodecsv==0.14.1
     # via
     #   tableschema
@@ -455,6 +470,8 @@ yarl==1.5.1
     # via aiohttp
 zenpy==2.0.21
     # via -r requirements.in
+zipp==3.4.1
+    # via importlib-metadata
 zope.event==4.5.0
     # via gevent
 zope.interface==5.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 aiohttp==3.6.2
 aioredis==1.3.1
+aws-requests-auth==0.4.3
 bleach==3.1.5
 boto3==1.14.60
 celery-redbeat==1.0.0
@@ -36,7 +37,6 @@ psycogreen==1.0.2
 psycopg2==2.7.7
 python-dotenv==0.12.0
 redis==3.5.3
-requests-aws4auth==1.0.1
 pyjwt==1.7.1
 requests==2.24.0
 sentry-sdk==0.17.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ attrs==20.2.0
     # via
     #   aiohttp
     #   jsonschema
+aws-requests-auth==0.4.3
+    # via -r requirements.in
 billiard==3.6.3.0
     # via celery
 bleach==3.1.5
@@ -217,15 +219,13 @@ redis==3.5.3
     #   -r requirements.in
     #   celery-redbeat
     #   django-redis
-requests-aws4auth==1.0.1
-    # via -r requirements.in
 requests-oauthlib==1.3.0
     # via django-staff-sso-client
 requests==2.24.0
     # via
     #   -r requirements.in
+    #   aws-requests-auth
     #   notifications-python-client
-    #   requests-aws4auth
     #   requests-oauthlib
     #   tableschema
     #   tabulator


### PR DESCRIPTION
### Description of change
When deployed to ECS, the credentials retrieved by boto have a session
token that expires after a certain amount of time. Therefore for each
request we need to check, before sending, whether the credentials need
to be refreshed. This is handled by the `BotoAWSRequestsAuth` here.

### Checklist

* [ ] Have tests been added to cover any changes?
