### PR TITLE
fix: dataset finder 413 from Elasticsearch

### DIFF
--- a/dataworkspace/dataworkspace/apps/finder/views.py
+++ b/dataworkspace/dataworkspace/apps/finder/views.py
@@ -33,7 +33,7 @@ def find_datasets(request):
         search_term = form.cleaned_data.get("q")
         index_aliases = get_index_aliases_for_all_published_source_tables()
         matches = (
-            es_client.search_for_phrase(search_term, indexes=index_aliases)
+            es_client.search_for_phrase(search_term, index_aliases=index_aliases)
             if search_term
             else None
         )


### PR DESCRIPTION
### Description of change
For dataset finder, we search across index aliases for nearly every
source table in Data Workspace. This can be quite a lot of indexes. The
request to ES is rejected if the body is too large, and this seems to
happen around ~400 source tables. Let's send multiple ES requests and
batch up the index aliases into groups of roughly 200 to avoid this
issue.

We do this rather than query every index in ES and do all of the
filtering in Data Workspace, because if any indexes are being written to
by Elasticsearch at the time, and we query them, it can introduce
significant delays. All of the indexes we query are effectively
read-only at the time, and so should have slightly better search speeds.

### Checklist

* [ ] Have tests been added to cover any changes?
