### PR TITLE
feature:increase explorer autocomplete width to allow long table names

### DIFF
--- a/dataworkspace/dataworkspace/static/explorer_custom.css
+++ b/dataworkspace/dataworkspace/static/explorer_custom.css
@@ -49,6 +49,10 @@
     position: relative;
 }
 
+.ace_editor.ace_autocomplete {
+    width: 500px!important;
+}
+
 .list {
     -webkit-padding-start: 0px;
     list-style: none;


### PR DESCRIPTION
**Before**

<img width="887" alt="Screenshot 2021-03-23 at 14 18 22" src="https://user-images.githubusercontent.com/915598/112161596-351f1a80-8be3-11eb-9647-1b8deeaf721f.png">

**After**

<img width="891" alt="Screenshot 2021-03-23 at 14 18 34" src="https://user-images.githubusercontent.com/915598/112161616-37817480-8be3-11eb-9b29-0525cdf044ad.png">

https://trello.com/c/GiLeKBIT/1599-data-explorer-auto-fill-enhancement

### Checklist

* [ ] Have tests been added to cover any changes?
