### PR TITLE
Related datacuts

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -259,3 +259,29 @@ class DatasetSearchForm(forms.Form):
             for topic_id, topic_text in topic_choices
             if topic_id in selected_topic_ids or counts['topic'][topic_id] != 0
         ]
+
+
+class RelatedMastersSortForm(forms.Form):
+    sort = forms.ChoiceField(
+        required=False,
+        choices=[
+            ('dataset__name', 'A to Z'),
+            ('-dataset__name', 'Z to A'),
+            ('-dataset__published_at', 'Recently published'),
+        ],
+        initial="dataset__name",
+        widget=SortSelectWidget(label='Sort by'),
+    )
+
+
+class RelatedDataCutsSortForm(forms.Form):
+    sort = forms.ChoiceField(
+        required=False,
+        choices=[
+            ('query__dataset__name', 'A to Z'),
+            ('-query__dataset__name', 'Z to A'),
+            ('-query__dataset__published_at', 'Recently published'),
+        ],
+        initial="query__dataset__name",
+        widget=SortSelectWidget(label='Sort by'),
+    )

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -65,4 +65,9 @@ urlpatterns = [
         login_required(views.request_access_success_view),
         name='request_access_success',
     ),
+    path(
+        '<uuid:dataset_uuid>/related-data',
+        login_required(views.RelatedDataView.as_view()),
+        name='related_data',
+    ),
 ]

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -34,7 +34,7 @@
   {% block head %}{% endblock %}
 </head>
 
-<body class="govuk-template__body">
+<body id="body" class="govuk-template__body">
   {% include 'partials/gtm_body.html' %}
 
   <script nonce="{{ request.csp_nonce }}">

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -159,28 +159,26 @@
         </div>
     </div>
 
-    {% if related_masters %}
+    {% if related_data %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h2 class="govuk-heading-l govuk-!-margin-top-8">Related data</h2>        
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">Related data</h2>
             <div class="govuk-grid-row">
-                {% for master in related_masters %}
-                    <div class="govuk-grid-column-{% if related_masters|length == 1 %}two-thirds{% else %}one-third{% endif %}">
-                        <div class="govuk-body">
-                            <span class="govuk-caption-m">Master dataset</span>
-                            <h3 class="govuk-heading-m">{{ master.name }}</h3>
-                            <p>{{ master.short_description | truncatechars:225 }}</p>
-                            <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=master.id %}#{{ master.slug }}">Visit page</a>
-                        </div>
-                    </div>
-                    {% if forloop.counter|divisibleby:3 %}
+                {% for master in related_data|slice:":4" %}
+                    {% include "partials/related_data.html" with dataset=master %}
+                    {% if forloop.counter|divisibleby:2 %}
                         </div>
                         <div class="govuk-grid-row">
                     {% endif %}
                 {% endfor %}
+              </div>
+                {% if related_data|length > 4 %}
+                  <a href="{% url "datasets:related_data" dataset_uuid=model.id %}" class="govuk-button govuk-button--secondary">
+                    Show all data cuts
+                  </a>
+                {% endif %}
             </div>
         </div>
-    </div>
     {% endif %}
     
     {% if visualisation_src %}

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -177,7 +177,6 @@
         <li><a class="govuk-link" href="{% url 'request_data:index' %}?tag=data-request">ask for us to add the dataset</a></li>
       </ul>
     </div>
-
   </div>
 </div>
 </form>

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -125,6 +125,28 @@
     </div>
   </div>
 
+  {% if related_data %}
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <h2 class="govuk-heading-l govuk-!-margin-top-8">Related data</h2>
+          <div class="govuk-grid-row">
+              {% for dataset in related_data|slice:":4" %}
+                {% include "partials/related_data.html" with dataset=dataset %}
+                  {% if forloop.counter|divisibleby:2 %}
+                      </div>
+                      <div class="govuk-grid-row">
+                  {% endif %}
+              {% endfor %}
+            </div>
+              {% if related_data|length > 4 %}
+                <a href="{% url "datasets:related_data" dataset_uuid=model.id %}" class="govuk-button govuk-button--secondary">
+                  Show all data cuts
+                </a>
+              {% endif %}
+          </div>
+      </div>
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l govuk-!-margin-top-8">Additional information</h2>

--- a/dataworkspace/dataworkspace/templates/datasets/related_data.html
+++ b/dataworkspace/dataworkspace/templates/datasets/related_data.html
@@ -1,0 +1,49 @@
+{% extends '_main.html' %}
+{% load static core_tags %}
+
+{% block page_title %}Related data for {{ dataset.name }} - Data Workspace{% endblock %}
+
+{% block go_back %}
+  <a class="govuk-back-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
+    Back
+  </a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Related data for {{ dataset.name }}</h1>
+      <form id="sort-form" method="GET">
+        {{ form.sort }}
+      </form>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    {% for dataset in related_data %}
+      {% include "partials/related_data.html" with dataset=dataset %}
+      {% if forloop.counter|divisibleby:2 %}
+        </div>
+        <div class="govuk-grid-row">
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="{{ request.path }}#body">
+    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+    </svg>
+    Back to top
+  </a>
+{% endblock %}
+
+{% block footer_scripts %}
+  <script nonce="{{ request.csp_nonce }}">
+    let sort_by = document.getElementById('{{ form.sort.id_for_label }}');
+    if (sort_by !== null) {
+      sort_by.addEventListener('change', function (e) {
+        console.log('changed');
+        document.getElementById('sort-form').submit();
+      });
+    }
+  </script>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/partials/related_data.html
+++ b/dataworkspace/dataworkspace/templates/partials/related_data.html
@@ -1,0 +1,14 @@
+<div class="govuk-grid-column-one-half">
+  <div class="govuk-body">
+    <span class="govuk-caption-m">
+      {% if dataset.get_type_display == 'Data Cut' %}
+        Download
+      {% else %}
+        {{ dataset.get_type_display }}
+      {% endif %}
+    </span>
+    <h3 class="govuk-heading-m">{{ dataset.name }}</h3>
+    <p>{{ dataset.short_description | truncatechars:225 }}</p>
+    <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">Visit page</a>
+  </div>
+</div>


### PR DESCRIPTION
### Description of change
Adds a "related data" section to master catalogue pages, showing links
to any data cuts that make use of tables in the master dataset. On the
dataset detail page, this is limited to 4 entries, after which it shows
a "display all" link that leads to a separate page.

This new design is also applied to the existing datacut related data
section.

### Design
https://data-workspace-prototypes.herokuapp.com/ece/data-workspace/data-related-II

### Screenshots
<img width="1017" alt="Screen Shot 2021-03-25 at 12 04 57" src="https://user-images.githubusercontent.com/2920760/112470306-6b36d880-8d62-11eb-9c62-c23be2da282a.png">
<img width="1056" alt="Screen Shot 2021-03-25 at 12 05 15" src="https://user-images.githubusercontent.com/2920760/112470312-6c680580-8d62-11eb-8fd9-5e66fa64bd18.png">
<img width="1046" alt="Screen Shot 2021-03-25 at 12 05 20" src="https://user-images.githubusercontent.com/2920760/112470315-6d993280-8d62-11eb-997b-db42ccd4ae23.png">


### Checklist

* [x] Have tests been added to cover any changes?
