### PR TITLE
feature: use simple_query_string for finder search queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
+++ b/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
@@ -70,7 +70,13 @@ class ElasticsearchClient:
         for batch in self._batch_indexes(index_aliases):
             resp = self._client.search(
                 body={
-                    "query": {"match_phrase": {"_all": phrase}},
+                    "query": {
+                        "simple_query_string": {
+                            "query": phrase,
+                            "fields": ["_all"],
+                            "flags": "FUZZY|PHRASE",
+                        }
+                    },
                     "aggs": {"indexes": {"terms": {"field": "_index"}}},
                 },
                 index=','.join(batch),


### PR DESCRIPTION
### Description of change

The current "match_phrase" query type means that terms must appear in the same order as they do in the document for a match to occur. Using the "match" query type will get around this but it doesn't seem to support searching for an exact phrase which a user may want to do.

Using "simple_query_string" appears to support both, meaning that searching for terms in any order will still return the correct results, i.e "United Kingdom" and "Kingdom United" will return a similar number of results. However, if a user wants to search for an exact phrase they can still do so by wrapping the phrase in double quotes.

See https://trello.com/c/KRB21anx/1604-dataset-finder-evaluation-of-performance-and-results-and-suggest-improvements for more details

### Checklist

* [ ] Have tests been added to cover any changes?
