### PR TITLE
don't show paging when there are no documents available

### DIFF
--- a/dataworkspace/dataworkspace/templates/finder/results.html
+++ b/dataworkspace/dataworkspace/templates/finder/results.html
@@ -59,45 +59,45 @@
           </table>
         </div>
         <br/>
+        <p class="govuk-body" style="display: inline">
+            Showing results {{ results.start_index  }}&ndash;{{ results.end_index }} of {{ results.paginator.count }}
+        </p>
+        
+        {% if results.paginator.num_pages > 1 %}
+            <nav role="navigation" class="govuk-body" aria-label="Search result page navigation" style="display: inline">
+            <ul class="pagination govuk-list">
+                {% if results.has_previous %}
+                <li><a class="govuk-link" href="{% url_replace page=results.previous_page_number %}" aria-label="Previous page">Previous</a></li>
+                {% endif %}
+        
+                {% if results.number > 3 %}
+                <li><a class="govuk-link" href="{% url_replace page=1 %}" aria-label="Page 1">{{ 1 }}</a></li>
+                {% if results.number > 4 %}<li>&hellip;</li>{% endif %}
+                {% endif %}
+        
+                {% for i in results.paginator.page_range %}
+                {% if results.number == i %}
+                    <li class="active">{{ i }}</li>
+                {% elif i >= results.number|add:'-2' and i <= results.number|add:'2' %}
+                    <li><a class="govuk-link" href="{% url_replace page=i %}" aria-label="Page {{ i }}">{{ i }}</a></li>
+                {% endif %}
+                {% endfor %}
+        
+                {% if results.paginator.num_pages > results.number|add:'2' %}
+                {% if results.paginator.num_pages > results.number|add:'3' %}<li>&hellip;</li>{% endif %}
+                <li><a class="govuk-link" href="{% url_replace page=results.paginator.num_pages %}" aria-label="Page {{ results.paginator.num_pages }}">{{ results.paginator.num_pages }}</a></li>
+                {% endif %}
+        
+                {% if results.has_next %}
+                <li><a class="govuk-link" href="{% url_replace page=results.next_page_number %}" aria-label="Next page">Next</a></li>
+                {% endif %}
+            </ul>
+            </nav>
+        {% endif %}
       {% else %}
         <p class="govuk-body">No data available</p>
       {% endif %}
     </div>
 </div>
-<p class="govuk-body" style="display: inline">
-    Showing results {{ results.start_index  }}&ndash;{{ results.end_index }} of {{ results.paginator.count }}
-</p>
-
-  {% if results.paginator.num_pages > 1 %}
-<nav role="navigation" class="govuk-body" aria-label="Search result page navigation" style="display: inline">
-  <ul class="pagination govuk-list">
-    {% if results.has_previous %}
-      <li><a class="govuk-link" href="{% url_replace page=results.previous_page_number %}" aria-label="Previous page">Previous</a></li>
-    {% endif %}
-
-    {% if results.number > 3 %}
-      <li><a class="govuk-link" href="{% url_replace page=1 %}" aria-label="Page 1">{{ 1 }}</a></li>
-      {% if results.number > 4 %}<li>&hellip;</li>{% endif %}
-    {% endif %}
-
-    {% for i in results.paginator.page_range %}
-      {% if results.number == i %}
-        <li class="active">{{ i }}</li>
-      {% elif i >= results.number|add:'-2' and i <= results.number|add:'2' %}
-        <li><a class="govuk-link" href="{% url_replace page=i %}" aria-label="Page {{ i }}">{{ i }}</a></li>
-      {% endif %}
-    {% endfor %}
-
-    {% if results.paginator.num_pages > results.number|add:'2' %}
-      {% if results.paginator.num_pages > results.number|add:'3' %}<li>&hellip;</li>{% endif %}
-      <li><a class="govuk-link" href="{% url_replace page=results.paginator.num_pages %}" aria-label="Page {{ results.paginator.num_pages }}">{{ results.paginator.num_pages }}</a></li>
-    {% endif %}
-
-    {% if results.has_next %}
-      <li><a class="govuk-link" href="{% url_replace page=results.next_page_number %}" aria-label="Next page">Next</a></li>
-    {% endif %}
-  </ul>
-</nav>
-{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
### Description of change
This is to fix dataset finder results page, not to show paging when no documents available for indexed table.

### Checklist

* [ ] Have tests been added to cover any changes?
