### PR TITLE
fix: creation of users not finding existing ones

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1043,7 +1043,7 @@ def create_user_from_sso(
         user = User.objects.get(profile__sso_id=sso_id)
     except User.DoesNotExist:
         user, _ = User.objects.get_or_create(
-            email__in=other_emails,
+            email__in=[primary_email] + other_emails,
             defaults={'email': primary_email, 'username': primary_email},
         )
 


### PR DESCRIPTION
### Description of change

Following on from f656f27092388f688d681e1917afa5844408c772, "other_emails" may not contain the primary email, so in some cases existing users are not found.

### Checklist

* [ ] Have tests been added to cover any changes?
