### PR TITLE
allow columns to be filtered before downloading

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -640,6 +640,10 @@ class SourceLink(ReferenceNumberedDatasetSource):
             'datasets:data_cut_source_link_preview', args=(self.dataset_id, self.id)
         )
 
+    def show_column_filter(self):
+        # this will be enabled in subsequent PR
+        return False
+
     def can_show_link_for_user(self, user):
         return True
 
@@ -738,6 +742,9 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
         return reverse(
             'datasets:data_cut_query_preview', args=(self.dataset_id, self.id)
         )
+
+    def show_column_filter(self):
+        return True
 
     def can_show_link_for_user(self, user):
         if user.is_superuser:

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_preview.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_preview.html
@@ -16,57 +16,95 @@
       <h1 class="govuk-heading-l">Preview</h1>
     </div>
   </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      {% if columns %}
-        <p class="govuk-body">
-          Showing <strong>{{ records|length }}</strong> record{{ records|length|pluralize }}.
-        </p>
-        <div class="scrollable-table {% if records|length <= fixed_table_height_limit %}fixed-table-height{% endif %}" tabindex="0">
-          <table class="govuk-table govuk-!-font-size-16">
-            <thead>
-              <tr class="govuk-table__row">
-              {% for column in columns %}
-                  <th class="govuk-table__header">{{ column }}</th>
-              {% endfor %}
-              </tr>
-            </thead>
-            <tbody>
-            {% for record in records %}
-              <tr class="govuk-table__row">
+  <form method="get" action="{{ form_action }}">
+    {% csrf_token %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {% if columns %}
+          <p class="govuk-body">
+            Showing <strong>{{ records|length }}</strong> record{{ records|length|pluralize }}.
+          </p>
+          <div class="scrollable-table {% if records|length <= fixed_table_height_limit %}fixed-table-height{% endif %}" tabindex="0">
+            <table class="govuk-table govuk-!-font-size-16">
+              <thead>
+                <tr class="govuk-table__row">
                 {% for column in columns %}
-                  {% with record|get_key:column as value %}
-                    <td class="govuk-table__cell">
-                      {{ value|not_set_if_none|truncatechars:truncate_limit }}
-                    </td>
-                  {% endwith %}
+                    <th class="govuk-table__header">{{ column }}</th>
                 {% endfor %}
-              </tr>
-            {% empty %}
-              <tr class="govuk-table__row">
-                <td colspan="{{ columns|length }}">
-                  This dataset doesn't have any data yet.
-                </td>
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
-        </div>
-        <br/>
-      {% else %}
-        <p class="govuk-body">No preview available</p>
-      {% endif %}
-      {% if can_download %}
-        <a class="govuk-button" href="{{ object.get_absolute_url }}">
-          Download as CSV
-        </a>
+                </tr>
+              </thead>
+              <tbody>
+              {% for record in records %}
+                <tr class="govuk-table__row">
+                  {% for column in columns %}
+                    {% with record|get_key:column as value %}
+                      <td class="govuk-table__cell">
+                        {{ value|not_set_if_none|truncatechars:truncate_limit }}
+                      </td>
+                    {% endwith %}
+                  {% endfor %}
+                </tr>
+              {% empty %}
+                <tr class="govuk-table__row">
+                  <td colspan="{{ columns|length }}">
+                    This dataset doesn't have any data yet.
+                  </td>
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          {% if can_filter_columns %}
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <p class="govuk-body">You can filter columns and rows to download only what is necessary. Limiting the number of columns and rows will decrease the file size and reduce the risk of data breach.</p>
+            </div>
+          </div>
+          <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Filter columns<span class="govuk-visually-hidden">for "{{ object.name }}"</span>
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <div class="govuk-checkboxes__item">
+                <input class="govuk-checkboxes__input" id="toggle-columns" name="toggle-columns" type="checkbox" checked>
+                <label class="govuk-label govuk-checkboxes__label" for="toggle-columns">
+                  Select all
+                </label>
+              </div>
+              <br/>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset" aria-describedby="filter-hint">
+                  <div class="govuk-checkboxes">
+                    {% for column in columns %}
+                    <div class="govuk-checkboxes__item">
+                      <input class="govuk-checkboxes__input" id="filter-{{ column }}" name="columns" type="checkbox" value="{{ column }}" checked>
+                      <label class="govuk-label govuk-checkboxes__label" for="filter-{{ column }}">
+                        {{ column }}
+                      </label>
+                    </div>
+                    {% endfor %}
+                  </div>
+                </fieldset>
+              </div>
+            </div>
+          </details>
+          {% endif %}
+          <br/>
+        {% else %}
+          <p class="govuk-body">No preview available</p>
+        {% endif %}
+        {% if can_download %}
+        <button type="submit" class="govuk-button">Download as CSV</button>
         <br />
-      {% endif %}
-      <a class="govuk-link govuk-link--no-visited-state" href="{{ object.dataset.get_absolute_url }}">
-        Cancel
-      </a>
+        {% endif %}
+        <a class="govuk-link govuk-link--no-visited-state" href="{{ object.dataset.get_absolute_url }}">
+          Cancel
+        </a>
+      </div>
     </div>
-  </div>
+  </form>
   {% if object.dataset.enquiries_contact %}
     <div class="govuk-grid-row govuk-!-margin-top-9">
       <div class="govuk-grid-column-full">
@@ -75,4 +113,18 @@
       </div>
     </div>
   {% endif %}
+{% endblock %}
+{% block footer_scripts %}
+  <script nonce="{{ request.csp_nonce }}">
+    let toggle_columns = document.getElementById('toggle-columns');
+    if (toggle_columns !== null) {
+      toggle_columns.addEventListener('change', function (e) {
+        checkboxes = document.getElementsByName('columns');
+        for(var i=0, n=checkboxes.length;i<n;i++)
+        {
+          checkboxes[i].checked = toggle_columns.checked;
+        }
+      });
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
### Description of change
This PR allows columns to be filtered before downloading. from data cut query preview pages. This change will have to be rolled out separately for source links.

### Checklist

* [ ] Have tests been added to cover any changes?
