### PR TITLE
fix: invalidate and clear superset cache when saving visualisation

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/core/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/core/views.py
@@ -32,13 +32,20 @@ class UserSatisfactionSurveyViewSet(viewsets.ModelViewSet):
 credentials_version_key = 'superset_credentials_version'
 
 
+def initialise_credentials_version_key():
+    # Set to never expire as reverting to a previous version will cause
+    # potentially invalid cached credentials to be used if the user loses
+    # or gains access to a dashboard
+    cache.set(credentials_version_key, 1, nx=True, timeout=None)
+
+
 def get_cached_credentials_key(user_profile_sso_id):
     credentials_version = cache.get(credentials_version_key, None)
     return f"superset_credentials_{credentials_version}_{user_profile_sso_id}"
 
 
 def get_superset_credentials(request):
-    cache.set(credentials_version_key, 1, nx=True)
+    initialise_credentials_version_key()
     cache_key = get_cached_credentials_key(request.headers['sso-profile-user-id'])
     response = cache.get(cache_key, None)
 
@@ -87,7 +94,7 @@ def get_superset_credentials(request):
 
 
 def remove_superset_user_cached_credentials(user):
-    cache.set(credentials_version_key, 1, nx=True)
+    initialise_credentials_version_key()
     cache_key = get_cached_credentials_key(user.profile.sso_id)
     cache.delete(cache_key)
 

--- a/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
@@ -50,7 +50,7 @@ class TestGetSupersetCredentialsAPIView:
 
         assert mock_new_credentials.called
         assert mock_cache.set.call_args_list == [
-            mock.call('superset_credentials_version', 1, nx=True),
+            mock.call('superset_credentials_version', 1, nx=True, timeout=None),
             mock.call(
                 f'superset_credentials_1_{user.profile.sso_id}',
                 {
@@ -88,7 +88,7 @@ class TestGetSupersetCredentialsAPIView:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert not mock_new_credentials.called
         assert mock_cache.set.call_args_list == [
-            mock.call('superset_credentials_version', 1, nx=True),
+            mock.call('superset_credentials_version', 1, nx=True, timeout=None),
         ]
 
     @pytest.mark.django_db
@@ -128,5 +128,5 @@ class TestGetSupersetCredentialsAPIView:
 
         assert not mock_new_credentials.called
         assert mock_cache.set.call_args_list == [
-            mock.call('superset_credentials_version', 1, nx=True),
+            mock.call('superset_credentials_version', 1, nx=True, timeout=None),
         ]

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -3296,3 +3296,80 @@ class TestDatasetAdminPytest:
         assert mock_remove_superset_cached_credentials.call_args_list == [
             mock.call(user)
         ]
+
+    @mock.patch(
+        "dataworkspace.apps.datasets.admin.remove_superset_user_cached_credentials"
+    )
+    @pytest.mark.django_db
+    def test_visualisation_permission_changes_clears_authorized_users_cached_credentials(
+        self, mock_remove_superset_user_cached_credentials, staff_client,
+    ):
+        user = factories.UserFactory()
+        visualisation = factories.VisualisationCatalogueItemFactory.create(
+            published=True, user_access_type='REQUIRES_AUTHENTICATION'
+        )
+
+        # Login to admin site
+        staff_client.post(reverse('admin:index'), follow=True)
+
+        response = staff_client.post(
+            reverse(
+                'admin:datasets_visualisationcatalogueitem_change',
+                args=(visualisation.id,),
+            ),
+            {
+                'published': True,
+                'name': visualisation.name,
+                'slug': visualisation.slug,
+                'short_description': 'test short description',
+                'authorized_users': str(user.id),
+                'visualisationlink_set-TOTAL_FORMS': '1',
+                'visualisationlink_set-INITIAL_FORMS': '0',
+                'visualisationlink_set-MIN_NUM_FORMS': '0',
+                'visualisationlink_set-MAX_NUM_FORMS': '1000',
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        # As the user has just been authorized to access the visualisation, their cached
+        # superset credentials should be cleared
+        assert mock_remove_superset_user_cached_credentials.call_args_list == [
+            mock.call(user)
+        ]
+
+    @mock.patch(
+        "dataworkspace.apps.datasets.admin.invalidate_superset_user_cached_credentials"
+    )
+    @pytest.mark.django_db
+    def test_visualisation_access_type_change_invalidates_all_user_cached_credentials(
+        self, mock_invalidate_superset_user_cached_credentials, staff_client
+    ):
+        visualisation = factories.VisualisationCatalogueItemFactory.create(
+            published=True, user_access_type='REQUIRES_AUTHENTICATION'
+        )
+
+        # Login to admin site
+        staff_client.post(reverse('admin:index'), follow=True)
+
+        response = staff_client.post(
+            reverse(
+                'admin:datasets_visualisationcatalogueitem_change',
+                args=(visualisation.id,),
+            ),
+            {
+                'published': True,
+                'name': visualisation.name,
+                'slug': visualisation.slug,
+                'short_description': 'test short description',
+                'requires_authorization': 'on',
+                'visualisationlink_set-TOTAL_FORMS': '1',
+                'visualisationlink_set-INITIAL_FORMS': '0',
+                'visualisationlink_set-MIN_NUM_FORMS': '0',
+                'visualisationlink_set-MAX_NUM_FORMS': '1000',
+            },
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert mock_invalidate_superset_user_cached_credentials.called


### PR DESCRIPTION
- Delete / invalidate superset cached db credentials/permitted dashboards when a visualisation catalogue item is saved
- Set the credentials_version_key to never expire, otherwise invalid cached credentials that haven't been deleted yet may be used