### PR TITLE
fix: set explorer_credentials_version to never expire

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/core/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/core/views.py
@@ -32,20 +32,16 @@ class UserSatisfactionSurveyViewSet(viewsets.ModelViewSet):
 credentials_version_key = 'superset_credentials_version'
 
 
-def initialise_credentials_version_key():
+def get_cached_credentials_key(user_profile_sso_id):
     # Set to never expire as reverting to a previous version will cause
     # potentially invalid cached credentials to be used if the user loses
     # or gains access to a dashboard
     cache.set(credentials_version_key, 1, nx=True, timeout=None)
-
-
-def get_cached_credentials_key(user_profile_sso_id):
     credentials_version = cache.get(credentials_version_key, None)
     return f"superset_credentials_{credentials_version}_{user_profile_sso_id}"
 
 
 def get_superset_credentials(request):
-    initialise_credentials_version_key()
     cache_key = get_cached_credentials_key(request.headers['sso-profile-user-id'])
     response = cache.get(cache_key, None)
 
@@ -94,7 +90,6 @@ def get_superset_credentials(request):
 
 
 def remove_superset_user_cached_credentials(user):
-    initialise_credentials_version_key()
     cache_key = get_cached_credentials_key(user.profile.sso_id)
     cache.delete(cache_key)
 

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -125,10 +125,11 @@ credentials_version_key = 'explorer_credentials_version'
 
 
 def get_user_cached_credentials_key(user):
+    # Set to never expire as reverting to a previous version will cause
+    # potentially invalid cached credentials to be used if the user loses
+    # or gains access to a dashboard
+    cache.set(credentials_version_key, 1, nx=True, timeout=None)
     credentials_version = cache.get(credentials_version_key, None)
-    if not credentials_version:
-        credentials_version = 1
-        cache.set(credentials_version_key, credentials_version)
     return f"explorer_credentials_{credentials_version}_{user.profile.sso_id}"
 
 
@@ -198,6 +199,17 @@ def get_user_explorer_connection_settings(user, alias):
     return db_aliases_to_credentials[alias]
 
 
+def remove_data_explorer_user_cached_credentials(user):
+    cache_key = get_user_cached_credentials_key(user)
+    cache.delete(cache_key)
+
+
+def invalidate_data_explorer_user_cached_credentials():
+    credentials_version = cache.get(credentials_version_key, None)
+    if credentials_version:
+        cache.incr(credentials_version_key)
+
+
 @contextmanager
 def user_explorer_connection(connection_settings):
     with psycopg2.connect(
@@ -217,18 +229,6 @@ def get_total_pages(total_rows, page_size):
     if remainder:
         remainder = 1
     return int(total_rows / page_size) + remainder
-
-
-def remove_data_explorer_user_cached_credentials(user):
-    logger.info("Clearing Data Explorer cached credentials for %s", user)
-    cache_key = get_user_cached_credentials_key(user)
-    cache.delete(cache_key)
-
-
-def invalidate_data_explorer_user_cached_credentials():
-    credentials_version = cache.get(credentials_version_key, None)
-    if credentials_version:
-        cache.incr(credentials_version_key)
 
 
 def tempory_query_table_name(user, query_log_id):


### PR DESCRIPTION
Set the explorer_credentials_version key to never expire, otherwise invalid cached credentials that haven't been deleted yet may be used
