### PR TITLE
fix: link to tool access help page

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/tool_section.html
+++ b/dataworkspace/dataworkspace/templates/partials/tool_section.html
@@ -25,9 +25,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half"><p class="govuk-body"></p></div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-button govuk-button--secondary" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/how-do-i-request-access-tool/">
-            Request access to {{ application_name }}
-          </a>
+          <a class="govuk-button govuk-button--secondary" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/how-do-i-request-access-tool/">Request access to {{ application_name }}</a>
         </div>
       </div>
     {% elif instance %}

--- a/dataworkspace/dataworkspace/templates/partials/tool_section.html
+++ b/dataworkspace/dataworkspace/templates/partials/tool_section.html
@@ -25,7 +25,9 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half"><p class="govuk-body"></p></div>
         <div class="govuk-grid-column-one-half">
-          <a class="govuk-button govuk-button--secondary" href="{% url 'support' %}">Request access to {{ application_name }}</a>
+          <a class="govuk-button govuk-button--secondary" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/how-do-i-request-access-tool/">
+            Request access to {{ application_name }}
+          </a>
         </div>
       </div>
     {% elif instance %}

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -283,7 +283,12 @@ def test_quicksight_link_only_shown_to_user_with_permission(
     "has_appstream_update, expected_href, expected_text",
     (
         (True, "https://appstream", "Open SPSS / STATA"),
-        (False, "/support-and-feedback/", "Request access to SPSS / STATA"),
+        (
+            False,
+            "https://data-services-help.trade.gov.uk/data-workspace"
+            "/how-articles/data-workspace-basics/how-do-i-request-access-tool/",
+            "Request access to SPSS / STATA",
+        ),
     ),
 )
 @override_settings(APPSTREAM_URL='https://appstream')

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -252,7 +252,12 @@ def test_footer_links(request_client):
     "has_quicksight_access, expected_href, expected_text",
     (
         (True, "/tools/quicksight/redirect", "Open Amazon QuickSight"),
-        (False, "/support-and-feedback/", "Request access to Amazon QuickSight"),
+        (
+            False,
+            "https://data-services-help.trade.gov.uk/data-workspace/how-articles"
+            "/data-workspace-basics/how-do-i-request-access-tool/",
+            "Request access to Amazon QuickSight",
+        ),
     ),
 )
 @override_settings(QUICKSIGHT_SSO_URL='https://quicksight')


### PR DESCRIPTION
### Description of change

Link to the "request tool access" help page rather than the support page.

Ticket: https://trello.com/c/FNBAqVso/1778-request-access-link-update-on-tools-page