### PR TITLE
feat: allow tools and visualisations to have different Sentry DSN

### DIFF
--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -56,7 +56,7 @@ data "template_file" "jupyterlabpython_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"

--- a/infra/ecs_notebooks_jupyterlab_r.tf
+++ b/infra/ecs_notebooks_jupyterlab_r.tf
@@ -56,7 +56,7 @@ data "template_file" "jupyterlabr_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabr_metrics_current_tag.result.tag}"

--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -56,7 +56,7 @@ data "template_file" "notebook_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.notebook_metrics_current_tag.result.tag}"

--- a/infra/ecs_notebooks_pgweb.tf
+++ b/infra/ecs_notebooks_pgweb.tf
@@ -56,7 +56,7 @@ data "template_file" "pgweb_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -55,7 +55,7 @@ data "template_file" "remotedesktop_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -55,7 +55,7 @@ data "template_file" "superset_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -55,7 +55,7 @@ data "template_file" "theia_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
     sentry_environment = "${var.sentry_environment}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -36,7 +36,7 @@ data "template_file" "user_provided_container_definitions" {
     log_group  = "${aws_cloudwatch_log_group.notebook.name}"
     log_region = "${data.aws_region.aws_region.name}"
 
-    sentry_dsn = "${var.sentry_dsn}"
+    sentry_dsn = "${var.sentry_notebooks_dsn}"
 
     metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
   }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -75,6 +75,7 @@ variable mirrors_bucket_name {}
 variable mirrors_data_bucket_name {}
 
 variable sentry_dsn {}
+variable sentry_notebooks_dsn {}
 variable sentry_environment {}
 
 variable notebook_task_role_prefix {}


### PR DESCRIPTION
### Description of change

This is so we can send exceptions to a different Sentry project, to then send them to a different Slack channe

### Checklist

* [ ] Have tests been added to cover any changes?
