### PR TITLE
feat: add local test makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,19 @@ save-requirements:
 
 .PHONY: docker-test-unit-local
 docker-test-unit-local:
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest /dataworkspace/dataworkspace
+	TEST_DIR="$(TARGET)" ; \
+	if [ -z "$$TEST_DIR" ]; \
+		then TEST_DIR="/dataworkspace/dataworkspace"; \
+ 	fi; \
+	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest $$TEST_DIR
 
 .PHONY: docker-test-integration-local
 docker-test-integration-local:
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest /test
+	TEST_DIR="$(TARGET)" ; \
+	if [ -z "$$TEST_DIR" ]; \
+		then TEST_DIR="/test"; \
+ 	fi; \
+	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest $$TEST_DIR
 
 .PHONY: docker-test-local
 docker-test-local: docker-test-unit-local docker-test-integration-local

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,14 @@ format:
 save-requirements:
 	pip-compile requirements.in
 	pip-compile requirements-dev.in
+
+.PHONY: docker-test-unit-local
+docker-test-unit-local:
+	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest /dataworkspace/dataworkspace
+
+.PHONY: docker-test-integration-local
+docker-test-integration-local:
+	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest /test
+
+.PHONY: docker-test-local
+docker-test-local: docker-test-unit-local docker-test-integration-local

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ Django tests
 make docker-test-unit
 ```
 
+### Running unit and integration tests locally
+
+To run the tests locally without having to rebuild the containers every time append `-local` to the test make commands
+
+```bash
+make docker-test-unit-local
+```
+
+```bash
+make docker-test-integration-local
+```
+
+```bash
+make docker-test-local
+```
+
 ### Running selenium tests locally
 
 We have some selenium integration tests that launch a (headless) browser in order to interact with a running instance of Data Workspace to assure some core flows (only Data Explorer at the time of writing). It is sometimes desirable to watch these tests run, e.g. in order to debug where it is failing. To run the selenium tests through docker-compose using a local browser, do the following:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ make docker-test-integration-local
 make docker-test-local
 ```
 
+To run specific tests pass `-e TARGET=<test>` into make
+```bash
+make docker-test-unit-local -e TARGET=dataworkspace/dataworkspace/tests/test_admin.py::TestCustomAdminSite::test_non_admin_access
+ ```
+
+```bash
+make docker-test-integration-local -e TARGET=test/test_application.py
+ ```
+
 ### Running selenium tests locally
 
 We have some selenium integration tests that launch a (headless) browser in order to interact with a running instance of Data Workspace to assure some core flows (only Data Explorer at the time of writing). It is sometimes desirable to watch these tests run, e.g. in order to debug where it is failing. To run the selenium tests through docker-compose using a local browser, do the following:

--- a/docker-compose-test-local.yml
+++ b/docker-compose-test-local.yml
@@ -1,0 +1,60 @@
+version: "3.4"
+services:
+  data-workspace-test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: test
+    image: data-workspace-test
+    stdin_open: true
+    tty: true
+    env_file:
+      - ./.envs/test.env
+    shm_size: '200mb'  # needed for chromium selenium tests - otherwise page/tab crashes
+    ports:
+      - "8000"
+    links:
+      - "data-workspace-postgres"
+      - "data-workspace-redis"
+      - "data-workspace-es"
+    extra_hosts:
+      - "dataworkspace.test:127.0.0.1"
+      - "testapplication-23b40dd9.dataworkspace.test:127.0.0.1"
+      - "testvisualisation.dataworkspace.test:127.0.0.1"
+      - "testvisualisation--8888.dataworkspace.test:127.0.0.1"
+      - "testvisualisation--11372717.dataworkspace.test:127.0.0.1"
+      - "testvisualisation--11372717--8888.dataworkspace.test:127.0.0.1"
+      - "testvisualisation-a.dataworkspace.test:127.0.0.1"
+      - "testvisualisation-b.dataworkspace.test:127.0.0.1"
+      - "api.ecr.my-region-1.amazonaws.com:127.0.0.1"
+    volumes:
+      - db-logs-dev:/var/log/postgres
+      - ./dataworkspace:/dataworkspace
+      - ./test:/test
+  data-workspace-postgres:
+    build:
+      context: postgres
+      dockerfile: Dockerfile
+    image: data-workspace-postgres
+    ports:
+      - "5432"
+    volumes:
+      - db-logs-dev:/var/log/postgres
+  data-workspace-redis:
+    build:
+      context: redis
+      dockerfile: Dockerfile
+    image: data-workspace-redis
+    ports:
+      - "6379"
+  data-workspace-es:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    environment:
+      - discovery.type=single-node
+      - http.port=9200
+    ports:
+      - "9200:9200"
+
+
+volumes:
+  db-logs-dev:


### PR DESCRIPTION
### Description of change

Reduce the need to constantly rebuild containers when testing locally.

- Add a new docker compose file `docker-compose-test-local.yml` that mounts `/dataworkspace` and `/test`
- Add new local test commands to `Makefile`
  - `make docker-test-unit-local`
  - `make docker-test-integration-local`
  - `make docker-test-local`
- Update readme

### Checklist

~~* [ ] Have tests been added to cover any changes?~~
