### PR TITLE
made dataexplorer 95% of browser width for desktop

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
@@ -124,7 +124,7 @@
               <div class="govuk-footer__section">
                 <h2 class="govuk-footer__heading govuk-heading-m">Services and information</h2>
 
-                <ul class="govuk-footer__list govuk-footer__list--columns-3">
+                <ul class="govuk-footer__list govuk-footer__list">
                   <li class="govuk-footer__list-item">
                     <a class="govuk-footer__link" href="{% url 'explorer:index' %}">
                       Home

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -72,7 +72,7 @@
             </ul>
 
             <div class="govuk-tabs__panel" id="query-tab">
-              <h3 class="govuk-heading-m">Query</h3>
+
 
               <form role="form" action="{{ form_action }}" method="post" id="editor">
                 {% csrf_token %}
@@ -107,7 +107,7 @@
                       <div class="govuk-grid-row">
                         <div class="govuk-grid-column-one-half">
                           <p class="govuk-label">
-                            Your SQL query
+                            Enter your SQL query and click the Run button
                           </p>
                         </div>
                       </div>
@@ -160,7 +160,7 @@
               </form>
             </div>
             <div class="govuk-tabs__panel" id="database-tab">
-              <h3 class="govuk-heading-m">Database</h3>
+             
               <p class="govuk-body">
                 You can see the database tables you have access to here.
               </p>

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -110,12 +110,6 @@
                             Your SQL query
                           </p>
                         </div>
-                        <div id="width-toggle-container" class="govuk-grid-column-one-half govuk-!-display-none">
-                          <p class="govuk-label">
-                            <a id="full-width" class="govuk-link govuk-link--no-visited-state app-page-width-toggle" href="#" style="float: right">Use full page width</a>
-                            <a id="normal-width" class="govuk-link govuk-link--no-visited-state govuk-!-display-none app-page-width-toggle" href="#" style="float: right">Use normal page width</a>
-                          </p>
-                        </div>
                       </div>
                     </div>
                     <div id="inline-error"{% if not form.sql.errors %} class="govuk-!-display-none"{% endif %}>
@@ -191,7 +185,6 @@
   <script nonce="{{ request.csp_nonce }}" src="{% static 'explorer_schema.js' %}"></script>
   <script nonce="{{ request.csp_nonce }}" src="{% static 'explorer_query.js' %}"></script>
   <script nonce="{{ request.csp_nonce }}">
-    document.getElementById('width-toggle-container').classList.remove('govuk-!-display-none');
     window.initSchemaSearch();
   </script>
   {% if query_log %}

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query_list.html
@@ -7,7 +7,7 @@
 <p class="govuk-body govuk-!-margin-bottom-7">You can see your saved and recently run queries on this page.</p>
     
 <div class="govuk-grid-row">
-  <div class="govuk-width-container">
+  <div class="govuk-grid-column-full-from-desktop">
     {% if recent_queries|length > 0 %}
     <h2 class="govuk-heading-l">
       Your most recently run queries
@@ -37,7 +37,7 @@
     {% endif %}
   </div>
   
-  <div class="govuk-width-container">
+  <div class="govuk-grid-column-full-from-desktop">
     <h2 class="govuk-heading-l govuk-!-margin-top-9">Your queries</h2>
 
     <table class="govuk-table">

--- a/dataworkspace/dataworkspace/static/explorer_custom.css
+++ b/dataworkspace/dataworkspace/static/explorer_custom.css
@@ -80,13 +80,13 @@
 
 .schema-cell-left {
     font-size: 0.8rem;
-    padding: 5px 5px 5px 5;
+    padding: 5px 5px 5px 5px;
     word-break: break-word;
 }
 
 .schema-cell-right {
     font-size: 0.8rem;
-    padding: 5px 5px 5px 5;
+    padding: 5px 5px 5px 5px;
 }
 
 .schema-collapse {
@@ -111,13 +111,10 @@
     background-color: #F0F0F0
 }
 
-.app-page-width-toggle {
-    display: none
-}
-
 @media only screen and (min-width: 1020px) {
-    .app-page-width-toggle {
-        display: block
+    /* Tablet and mobile displays already use full width */
+    .govuk-width-container {
+        max-width: 95%;
     }
 }
 .loading-spinner {
@@ -138,3 +135,4 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+

--- a/test/selenium/explorer_pages.py
+++ b/test/selenium/explorer_pages.py
@@ -87,14 +87,6 @@ class HomePage(_BaseExplorerPage):
         )
         fetch_page.click()
 
-    def click_full_width(self):
-        toggle = self._driver.find_element_by_id('full-width')
-        toggle.click()
-
-    def click_normal_width(self):
-        toggle = self._driver.find_element_by_id('normal-width')
-        toggle.click()
-
 
 class CreateQueryPage(_BaseExplorerPage):
     _url_regex = r'/data-explorer/queries/create/\?play_id=(?P<play_id>\d+)'

--- a/test/selenium/test_explorer.py
+++ b/test/selenium/test_explorer.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 import pytest
 import requests
 from django.core.cache import cache
-from selenium.common.exceptions import ElementNotInteractableException
 
 from test.selenium.common import get_driver  # pylint: disable=wrong-import-order
 from test.selenium.conftest import (  # pylint: disable=wrong-import-order
@@ -270,43 +269,3 @@ class TestDataExplorer:
         assert "permission denied for relation" in home_page.get_html()
         assert "Columns in public.explorer_dataset" not in home_page.get_html()
         assert "Columns in public.explorer_2_dataset" in home_page.get_html()
-
-    def test_page_width_toggles(self, _application):
-        home_page = HomePage(driver=self.driver)
-        home_page.open()
-
-        # Check that "normal width" toggle is hidden
-        self.driver.implicitly_wait(0)
-        try:
-            home_page.click_normal_width()
-        except ElementNotInteractableException:
-            pass
-        else:
-            raise AssertionError(
-                "Normal width link should not be visible at this point."
-            )
-        finally:
-            self.driver.implicitly_wait(5)
-
-        # Click the toggle to expand the query box
-        before_size = self.driver.find_element_by_id('ace-sql-editor').size
-        before_width = before_size['width']
-
-        home_page.click_full_width()
-
-        after_size = self.driver.find_element_by_id('ace-sql-editor').size
-        assert after_size['width'] > before_width
-
-        # Check the "full width" toggle has been hidden
-        self.driver.implicitly_wait(1)
-        try:
-            home_page.click_full_width()
-        except ElementNotInteractableException:
-            pass
-        else:
-            raise AssertionError("Full width link should not be visible at this point.")
-        finally:
-            self.driver.implicitly_wait(5)
-
-        # And that the "normal width" toggle is now click-able.
-        home_page.click_normal_width()


### PR DESCRIPTION
### Description of change
Change data explorer to be 95% of browser width at more than 1024px width by overriding GDS `govuk-width-container`
Changed footer links to stack horizintally
Removed redundant  duplicate text from within the tabs

### Checklist

* [x] Have tests been added to cover any changes?
