### PR TITLE
feature: show datacut source link and custom sql download usage history

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -28,6 +28,7 @@ from django.db import (
 )
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.urls import reverse
@@ -50,6 +51,7 @@ from dataworkspace.apps.applications.models import (
 )
 from dataworkspace.apps.datasets.constants import DataSetType, DataLinkType, TagType
 from dataworkspace.apps.datasets.model_utils import external_model_class
+from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.datasets_db import get_tables_last_updated_date
 
 
@@ -197,6 +199,7 @@ class DataSet(DeletableTimestampedUserModel):
     reference_code = models.ForeignKey(
         DatasetReferenceCode, null=True, blank=True, on_delete=models.SET_NULL
     )
+    events = GenericRelation(EventLog)
 
     class Meta:
         db_table = 'app_dataset'

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -87,4 +87,9 @@ urlpatterns = [
         login_required(views.toggle_bookmark),
         name='toggle_bookmark',
     ),
+    path(
+        '<uuid:dataset_uuid>/usage-history',
+        login_required(views.DataCutUsageHistoryView.as_view()),
+        name='usage_history',
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -21,6 +21,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import (
+    Count,
     F,
     IntegerField,
     Q,
@@ -30,6 +31,7 @@ from django.db.models import (
     BooleanField,
     QuerySet,
 )
+from django.db.models.functions import TruncDay
 from django.http import (
     Http404,
     HttpResponse,
@@ -73,6 +75,7 @@ from dataworkspace.apps.datasets.models import (
     SourceView,
     VisualisationCatalogueItem,
     SourceTable,
+    DataCutDataset,
 )
 from dataworkspace.apps.datasets.utils import (
     dataset_type_to_manage_unpublished_permission_codename,
@@ -1319,3 +1322,31 @@ class DataCutPreviewView(WaffleFlagMixin, DetailView):
                 }
             )
         return ctx
+
+
+class DataCutUsageHistoryView(View):
+    model = DataCutDataset
+
+    def get(self, request, dataset_uuid):
+        try:
+            dataset = DataSet.objects.get(id=dataset_uuid)
+        except (DataSet.DoesNotExist, SourceTable.DoesNotExist):
+            return HttpResponse(status=404)
+
+        return render(
+            request,
+            'datasets/data_cut_usage_history.html',
+            context={
+                "dataset": dataset,
+                "rows": dataset.events.filter(
+                    event_type__in=[
+                        EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD,
+                        EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD,
+                    ]
+                )
+                .annotate(day=TruncDay('timestamp'))
+                .order_by('-day')
+                .values('day', 'user__email', 'extra__fields__name')
+                .annotate(count=Count('id'))[:100],
+            },
+        )

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -187,6 +187,9 @@
 
                 </tbody>
             </table>
+            <div class="govuk-body">
+              <a class="govuk-link" href="{% url "datasets:usage_history" dataset_uuid=dataset.id %}">View usage history</a>
+            </div>
         </div>
     </div>
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_usage_history.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_usage_history.html
@@ -1,0 +1,48 @@
+{% extends '_main.html' %}
+{% load static core_tags %}
+
+{% block page_title %}Usage history for {{ dataset.name }} - {{ block.super }}{% endblock %}
+
+{% block go_back %}
+  <a class="govuk-back-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
+    Back
+  </a>
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-l govuk-!-margin-top-8">
+                Usage history for {{ dataset }}
+            </h2>
+        </div>
+        <div class="scrollable-table" tabindex="0">
+            <table class="govuk-table govuk-!-font-size-16">
+                <thead>
+                    <tr class="govuk-table__row">
+                        <th class="govuk-table__header">Date</th>
+                        <th class="govuk-table__header">User</th>
+                        <th class="govuk-table__header">Event</th>
+                        <th class="govuk-table__header">Count</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in rows %}
+                        <tr class="govuk-table__row">
+                            <td>{{ row.day|date:"d M Y" }}</td>
+                            <td>{{ row.user__email }}</td>
+                            <td>Downloaded {{ row.extra__fields__name }}</td>
+                            <td>{{ row.count }}</td>
+                        </tr>
+                    {% empty %}
+                        <tr class="govuk-table__row">
+                            <td colspan="{{ fields|length }}">
+                                This dataset doesn't have any events yet.
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -211,7 +211,7 @@ class RelatedObjectEventFactory(factory.django.DjangoModelFactory):
 
 
 class DatasetLinkDownloadEventFactory(RelatedObjectEventFactory):
-    event_type = EventLog.TYPE_DATASET_CUSTOM_QUERY_DOWNLOAD
+    event_type = EventLog.TYPE_DATASET_SOURCE_LINK_DOWNLOAD
     content_object = factory.SubFactory(DataSetFactory)
     extra = {
         'url': 'http://google.com',


### PR DESCRIPTION
Adds a link to the Datacut catalogue page which shows the 100 most recent download events related to the dataset grouped by date, user and query name:

<img width="905" alt="Screenshot 2021-05-05 at 10 56 24" src="https://user-images.githubusercontent.com/915598/117124743-9dd7e600-ad90-11eb-86f7-4c0c1be20b49.png">

<img width="915" alt="Screenshot 2021-05-05 at 10 56 36" src="https://user-images.githubusercontent.com/915598/117124737-9ca6b900-ad90-11eb-9610-b388de29c443.png">

https://trello.com/c/FklLZGPB/1802-step-1-show-usage-history-for-data-cuts
