### PR TITLE
attempt to fix access filter issue

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -161,13 +161,7 @@ def get_datasets_data_for_user_matching_query(
     bookmark_filter = Q(referencedatasetbookmark__user=user)
 
     if user and datasets.model is not ReferenceDataset:
-        access_filter &= (
-            Q(user_access_type='REQUIRES_AUTHENTICATION')
-            & (
-                Q(datasetuserpermission__user=user)
-                | Q(datasetuserpermission__isnull=True)
-            )
-        ) | Q(
+        access_filter &= (Q(user_access_type='REQUIRES_AUTHENTICATION')) | Q(
             user_access_type='REQUIRES_AUTHORIZATION', datasetuserpermission__user=user
         )
 


### PR DESCRIPTION
### Description of change
when a master dataset is in authentication mode (Each user must be individually authorized to access the data) and if at least one user (other than yourself) has given access using authorized users section, then `You have access` filter is not showing the dataset. Fixed this by correcting the access filter queryset conditions.

### Checklist

* [ ] Have tests been added to cover any changes?
