### PR TITLE
removed duplicate govuk-width-container

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/query.html
@@ -11,7 +11,6 @@
 {% endblock %}
 
 {% block content %}
-<div class="govuk-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full" id="query_area">
             {% if form.errors %}
@@ -143,7 +142,6 @@
             <iframe src="about:blank" height="828px" frameBorder="0" id="schema_frame"></iframe>
         </div>
     </div>
-</div>
 {% endblock content %}
 
 {% block footer_additions %}


### PR DESCRIPTION
### Description of change
removed div with class `govuk-width-container` which was adding extra padding to the query edit. This wouldn't have been a bug until i changed `max-width` to 95% in a previous update

### Checklist

~* [ ] Have tests been added to cover any changes?~
