### PR TITLE
feature: attempt dns query in dns-rewrite-proxy lb healtcheck

### DIFF
--- a/dns-rewrite-proxy/Dockerfile
+++ b/dns-rewrite-proxy/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
 RUN apk --no-cache add \
-	python3=3.7.7-r1
+	python3=3.7.10-r0
 
 RUN pip3 install \
 	aiodnsresolver==0.0.151 \

--- a/dns-rewrite-proxy/nameserver.py
+++ b/dns-rewrite-proxy/nameserver.py
@@ -6,7 +6,7 @@ import re
 import signal
 import sys
 
-from aiodnsresolver import Resolver, IPv4AddressExpiresAt, TYPES
+from aiodnsresolver import DnsError, Resolver, IPv4AddressExpiresAt, TYPES
 from dnsrewriteproxy import DnsProxy
 
 
@@ -72,7 +72,20 @@ async def async_main():
     logger.info('DNS server started')
 
     async def handle_client(reader, writer):
-        logger.info('[Healthcheck] request received')
+        await reader.read(100)
+        resolve, _ = get_resolver()
+        try:
+            await resolve('s3.eu-west-2.amazonaws.com', TYPES.A)
+        except DnsError:
+            status = '503 Service Unavailable'
+        else:
+            status = '200 OK'
+
+        writer.write(
+            b'HTTP/1.1 %b \r\ncontent-length: 0\r\n\r\n' % status.encode('utf8')
+        )
+        await writer.drain()
+        writer.close()
 
     healthcheck_task = await create_task(
         asyncio.start_server(handle_client, '0.0.0.0', 8888)

--- a/dns-rewrite-proxy/nameserver.py
+++ b/dns-rewrite-proxy/nameserver.py
@@ -72,8 +72,12 @@ async def async_main():
     logger.info('DNS server started')
 
     async def handle_client(reader, writer):
+        async def get_nameservers(_, __):
+            yield (1.0, ('127.0.0.1', 53))
+
         await reader.read(100)
-        resolve, _ = get_resolver()
+        resolve, _ = Resolver(get_nameservers=get_nameservers)
+
         try:
             await resolve('s3.eu-west-2.amazonaws.com', TYPES.A)
         except DnsError:

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -34,9 +34,8 @@ resource "aws_lb_target_group" "dns_rewrite_proxy" {
   target_type          = "ip"
 
   health_check {
-    protocol           = "HTTP"
+    protocol           = "TCP"
     port               = "8888"
-    path               = "/"
   }
 
   depends_on = ["aws_lb.dns_rewrite_proxy"]

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -34,8 +34,9 @@ resource "aws_lb_target_group" "dns_rewrite_proxy" {
   target_type          = "ip"
 
   health_check {
-    protocol           = "TCP"
+    protocol           = "HTTP"
     port               = "8888"
+    path               = "/"
   }
 
   depends_on = ["aws_lb.dns_rewrite_proxy"]

--- a/infra/ecs_main_dns_rewrite_proxy_new.tf
+++ b/infra/ecs_main_dns_rewrite_proxy_new.tf
@@ -1,0 +1,102 @@
+resource "aws_lb" "dns_rewrite_proxy_new" {
+  # should be suffixed `dns-rewrite-proxy` but name is limited to 32 chars, and that is too long
+  # for `analysisworkspace-dev-dns-rewrite-proxy`
+  name                             = "${var.prefix}-dnsproxy2"
+  load_balancer_type               = "network"
+  enable_cross_zone_load_balancing = "true"
+
+  internal = true
+  
+  subnet_mapping {
+    subnet_id            = "${aws_subnet.private_with_egress.*.id[0]}"
+    private_ipv4_address = cidrhost("${aws_subnet.private_with_egress.*.cidr_block[0]}", 7)
+  }
+}
+
+resource "aws_lb_listener" "dns_rewrite_proxy_new" {
+  load_balancer_arn = "${aws_lb.dns_rewrite_proxy_new.id}"
+  port              = 53
+  protocol          = "UDP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.dns_rewrite_proxy_new.id}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "dns_rewrite_proxy_new" {
+  # should be suffixed `dns-rewrite-proxy` but name is limited to 32 chars, and that is too long
+  # for `analysisworkspace-dev-dns-rewrite-proxy`
+  name                 = "${var.prefix}-dnsproxy2"
+  port                 = 53
+  protocol             = "UDP"
+  vpc_id               = "${aws_vpc.main.id}"
+  target_type          = "ip"
+
+  health_check {
+    protocol           = "HTTP"
+    port               = "8888"
+    path               = "/"
+  }
+
+  depends_on = ["aws_lb.dns_rewrite_proxy_new"]
+}
+
+resource "aws_ecs_service" "dns_rewrite_proxy_new" {
+  name                 = "${var.prefix}-dns-rewrite-proxy-new"
+  cluster              = "${aws_ecs_cluster.main_cluster.id}"
+  task_definition      = "${aws_ecs_task_definition.dns_rewrite_proxy_new.arn}"
+  desired_count        = 1
+  launch_type          = "FARGATE"
+  platform_version     = "1.4.0"
+
+  network_configuration {
+    subnets            = ["${aws_subnet.private_with_egress.*.id[0]}"]
+    security_groups    = ["${aws_security_group.dns_rewrite_proxy.id}"]
+  }
+
+  load_balancer {
+    target_group_arn  = "${aws_lb_target_group.dns_rewrite_proxy_new.id}"
+    container_name    = "${local.dns_rewrite_proxy_container_name}"
+    container_port    = 53
+  }
+}
+
+resource "aws_ecs_task_definition" "dns_rewrite_proxy_new" {
+  family                = "${var.prefix}-dns-rewrite-proxy-new"
+  container_definitions = "${data.template_file.dns_rewrite_proxy_container_definitions_new.rendered}"
+  execution_role_arn    = "${aws_iam_role.dns_rewrite_proxy_task_execution.arn}"
+  task_role_arn         = "${aws_iam_role.dns_rewrite_proxy_task.arn}"
+  network_mode          = "awsvpc"
+  cpu                   = "${local.dns_rewrite_proxy_container_cpu}"
+  memory                = "${local.dns_rewrite_proxy_container_memory}"
+  requires_compatibilities = ["FARGATE"]
+
+  lifecycle {
+    ignore_changes = [
+      "revision",
+    ]
+  }
+}
+
+data "template_file" "dns_rewrite_proxy_container_definitions_new" {
+  template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
+
+  vars = {
+    container_image    = "${aws_ecr_repository.dns_rewrite_proxy.repository_url}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
+    container_name     = "${local.dns_rewrite_proxy_container_name}"
+    container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
+    container_memory   = "${local.dns_rewrite_proxy_container_memory}"
+
+    log_group  = "${aws_cloudwatch_log_group.dns_rewrite_proxy.name}"
+    log_region = "${data.aws_region.aws_region.name}"
+
+    dns_server   = "${cidrhost(aws_vpc.main.cidr_block, 2)}"
+    aws_region   = "${data.aws_region.aws_region.name}"
+    aws_ec2_host = "ec2.${data.aws_region.aws_region.name}.amazonaws.com"
+    vpc_id       = "${aws_vpc.notebooks.id}"
+    aws_route53_zone = "${var.aws_route53_zone}"
+    ip_address   = "${aws_lb.dns_rewrite_proxy_new.subnet_mapping.*.private_ipv4_address[0]}"
+  }
+}
+


### PR DESCRIPTION
### Description of change

Change healthcheck from TCP to HTTP and attempt DNS query to determine service health. This is to avoid the situation where the DNS proxy is not working but the service is healthy as far as the load balancer is concerned. 

The new healtcheck Is currently set up on dev.

https://trello.com/c/0yRyrLDF/1643-dns-resolver-healthcheck-should-make-a-dns-query

### Checklist

* [ ] Have tests been added to cover any changes?
