### PR TITLE
request access message to only show 'tools' section for master datasets

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -55,7 +55,7 @@
       </div>
 
       {% if master_datasets_info and not has_access %}
-        {% include 'partials/unauthorised_warning.html' with thing='this dataset' %}
+        {% include 'partials/unauthorised_warning.html' with thing='this dataset' show_tools_message=True %}
       {% endif %}
     </div>
   </div>

--- a/dataworkspace/dataworkspace/templates/partials/unauthorised_warning.html
+++ b/dataworkspace/dataworkspace/templates/partials/unauthorised_warning.html
@@ -1,18 +1,22 @@
 <div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <div class="govuk-warning-text__text">
-    <strong>
-      <span class="govuk-warning-text__assistive">Warning</span>
-      You do not have permission to access {{ thing }}. You will also need tool access to use the data. You can check and request access from the <a href="{% url 'applications:tools'%}">tools</a> page.
-      <br>
-    </strong>
-  </div>
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <div class="govuk-warning-text__text">
+        <strong>
+            <span class="govuk-warning-text__assistive">Warning</span>
+            You do not have permission to access {{ thing }}.
+            {% if show_tools_message %}
+                You will also need tools access to use the data.
+                You can check and request access from the <a href="{% url 'applications:tools' %}">tools</a> page.
+            {% endif %}
+            <br>
+        </strong>
+    </div>
 </div>
 
 {% if model.eligibility_criteria %}
-  <a class="govuk-button"
-     href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
+    <a class="govuk-button"
+       href="{% url 'datasets:eligibility_criteria' model.id %}">Request access</a>
 {% else %}
-  <a class="govuk-button"
-     href="{% url 'datasets:request_access' model.id %}">Request access</a>
+    <a class="govuk-button"
+       href="{% url 'datasets:request_access' model.id %}">Request access</a>
 {% endif %}


### PR DESCRIPTION
### Description of change
https://trello.com/c/67gCf7PJ/773-automated-tools-message-on-master-dataset-catalogue-pages

Request access messages only displays tools section for master dataset pages
<img width="869" alt="Screenshot 2021-05-13 at 18 19 47" src="https://user-images.githubusercontent.com/2064710/118161902-0c174b00-b418-11eb-92ed-2dc3790b6605.png">
<img width="779" alt="Screenshot 2021-05-13 at 18 19 34" src="https://user-images.githubusercontent.com/2064710/118161905-0de10e80-b418-11eb-86b9-9587518d9db3.png">
<img width="830" alt="Screenshot 2021-05-13 at 18 19 19" src="https://user-images.githubusercontent.com/2064710/118161907-0de10e80-b418-11eb-8a22-bfe96b2ef2bd.png">



### Checklist

* [x] Have tests been added to cover any changes?
