### PR TITLE
fix: remove download link from master datasets

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -572,7 +572,7 @@ class SourceTable(BaseSource):
         return f'{self.name} ({self.id})'
 
     def can_show_link_for_user(self, user):
-        return user.is_superuser
+        return False
 
     @property
     def type(self):


### PR DESCRIPTION
### Description of change

download link was visible for superusers.

### Checklist

* [ ] Have tests been added to cover any changes?
