### PR TITLE
Force ws package to minimum version of 7.4.6

### DIFF
--- a/tools/theia/package.json
+++ b/tools/theia/package.json
@@ -31,16 +31,17 @@
         "@theia/cli": "latest"
     },
     "resolutions": {
-      "**/axios": "^0.21.1",
-      "**/debug": "^4.3.1",
-      "**/is-svg": "^4.3.1",
-      "**/js-yaml": "^3.14.1",
-      "**/postcss": "^8.2.10",
-      "**/sanitize-html": "^2.3.3",
-      "**/ssri": "^8.0.1",
-      "**/underscore": "^1.13.1",
-      "**/y18n": "^5.0.8",
-      "**/yargs-parser": "^20.2.7"
+        "**/axios": "^0.21.1",
+        "**/debug": "^4.3.1",
+        "**/is-svg": "^4.3.1",
+        "**/js-yaml": "^3.14.1",
+        "**/postcss": "^8.2.10",
+        "**/sanitize-html": "^2.3.3",
+        "**/ssri": "^8.0.1",
+        "**/underscore": "^1.13.1",
+        "**/y18n": "^5.0.8",
+        "**/yargs-parser": "^20.2.7",
+        "**/ws": "^7.4.6"
     },
     "theiaPluginsDir": "plugins",
     "theiaPlugins": {

--- a/tools/theia/yarn.lock
+++ b/tools/theia/yarn.lock
@@ -2589,11 +2589,6 @@ async-each@^1.0.1:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
   integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
-async-limiter@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
-  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
 async@0.9.x:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
@@ -11647,17 +11642,10 @@ write-json-file@^2.2.0:
     sort-keys "^2.0.0"
     write-file-atomic "^2.0.0"
 
-ws@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
-  dependencies:
-    async-limiter "~1.0.0"
-
-ws@^7.1.2:
-  version "7.4.5"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
-  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
+ws@^6.1.0, ws@^7.1.2, ws@^7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 xdg-basedir@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes security vulnerability GHSA-6fc8-4gx4-v693 which affects versions >= 5.0.0, < 7.4.6

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
