### PR TITLE
feat: associate credentials with a permanent role to speed up db creds creation

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -558,9 +558,9 @@ def _do_delete_unused_datasets_users():
                             usename,
                         )
 
-                        # Multiple concurrent GRANT CONNECT on the same database can cause
+                        # Multiple concurrent GRANT or REVOKE on the same object can result in
                         # "tuple concurrently updated" errors
-                        lock_name = f'database-grant-connect-{database_name}--v4'
+                        lock_name = 'database-grant-v1'
                         with cache.lock(lock_name, blocking_timeout=3, timeout=180):
                             cur.execute(
                                 sql.SQL(
@@ -580,9 +580,7 @@ def _do_delete_unused_datasets_users():
                                 )
                             )
 
-                        for schema in schemas:
-                            lock_name = f'database-grant--{database_name}--{schema}--v4'
-                            with cache.lock(lock_name, blocking_timeout=3, timeout=180):
+                            for schema in schemas:
                                 for schema_revoke in schema_revokes:
                                     try:
                                         cur.execute(


### PR DESCRIPTION
### Description of change

The main aim of this is to speed up db creds creation, to make Data Explorer and Docker-based tools starting feel nicer and be more robust. It's also a step toward the db proxy if we want to go that way, since it means each user has a permanent db role (which would be the case if we were to use a proxy). If the datasets db is slow for example, things should still not be too slow in starting up (with minimal writes)

---

This should eventually be followed by other changes:

- Have the creation of the role + its perms done even earlier than when credentials requested (in this PR, the first request would still be a bit slow I suspect, especially if the user has access to a lot of tables)

- Simplify the user cleanup tasks. They won't have any permissions, so no need for them to be revoked.

### Checklist

* [ ] Have tests been added to cover any changes?
