### PR TITLE
fix: remove intro text from case study list page

### DIFF
--- a/dataworkspace/dataworkspace/templates/case_studies/casestudy_list.html
+++ b/dataworkspace/dataworkspace/templates/case_studies/casestudy_list.html
@@ -17,9 +17,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds govuk-!-padding-bottom-3">
       <h1 class="govuk-heading-xl">Our work</h1>
-      <p class="govuk-body-l">
-        Here's the explanatory text about this page. In a hole in the ground there lived a hobbit.
-      </p>
     </div>
   </div>
   <div class="govuk-grid-row">


### PR DESCRIPTION
Remove intro text from case study listing page until copy has been decided on.

