### PR TITLE
fix: creation of db creds when there are teams that the master user is not yet granted on

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -159,7 +159,8 @@ def new_private_database_credentials(
                 WHERE
                     (
                         rolname SIMILAR TO '\\_user\\_[0-9a-f]{8}' OR
-                        rolname LIKE '\\_user\\_app\\_%'
+                        rolname LIKE '\\_user\\_app\\_%' OR
+                        rolname LIKE '\\_team_\\_%'
                     )
                     AND NOT pg_has_role(rolname, 'member');
             '''


### PR DESCRIPTION
### Description of change

This is so the master user can call has_table_privilege/has_schema_privilege as needed on the schema owned by the team.

### Checklist

* [ ] Have tests been added to cover any changes?
