### PR TITLE
Superset disable localstorage

### DIFF
--- a/superset/superset_config.py
+++ b/superset/superset_config.py
@@ -196,3 +196,5 @@ FLASK_APP_MUTATOR = data_workspace_permission_handler
 CUSTOM_SECURITY_MANAGER = DataWorkspaceSecurityManager
 AUTH_TYPE = AUTH_REMOTE_USER
 ADDITIONAL_MIDDLEWARE = [lambda app: ProxyFix(app, x_proto=1)]
+
+FEATURE_FLAGS = {'SQLLAB_BACKEND_PERSISTENCE': True}


### PR DESCRIPTION
### Description of change
When the SQLLAB_BACKEND_PERSISTENCE feature flag is enabled no query data are stored within localstorage.
The metadata is stored in the backend SQLALCHEMY database. 

No query data is persisted to the postgres SQLALCHEMY db

### Checklist

~* [ ] Have tests been added to cover any changes?~
