### PR TITLE
feature: redirect to visualisation request access page if unauthorised

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -314,7 +314,10 @@ def visualisation_link_html_view(request, link_id):
     if not visualisation_link.visualisation_catalogue_item.user_has_access(
         request.user
     ):
-        return HttpResponse(status=403)
+        return redirect(
+            'datasets:request_access',
+            dataset_uuid=visualisation_link.visualisation_catalogue_item_id,
+        )
 
     identifier = visualisation_link.identifier
     if visualisation_link.visualisation_type == 'QUICKSIGHT':

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2207,7 +2207,7 @@ class TestVisualisationLinkView:
 
         client = Client(**get_http_sso_data(user))
         response = client.get(link.get_absolute_url())
-        assert response.status_code == 403
+        assert response.status_code == 302
 
         VisualisationUserPermissionFactory.create(visualisation=vis, user=user)
 


### PR DESCRIPTION
### Description of change

Currently if a user accesses a visualisation link directly without having permissions to access the catalogue item then they get a 403 page. Instead they should be redirected to the catalogue item's request access page.

### Checklist

* [ ] Have tests been added to cover any changes?
