### PR TITLE
feature: add links to help articles on the Data Explorer homepage

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -43,10 +43,12 @@
               Welcome to Data Explorer
             </h1>
 
-            <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-              You can run a query on this page or see your <a href="{% url 'explorer:list_queries' %}" class="govuk-link">saved
-              queries</a>.
-            </p>
+            <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">You can:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>filter, combine or search datasets using an SQL query</li>
+              <li><a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/3-share-analysis/share-a-subset-of-a-dataset/" class="govuk-link">share an SQL query</a> with your colleagues</li>
+              <li>learn <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/data-explorer/start-data-explorer/" class="govuk-link">how to use Data Explorer</a></li>
+          </ul>
           </div>
         </div>
     </div>


### PR DESCRIPTION
### Description of change

Before

<img width="1257" alt="Screenshot 2021-06-25 at 17 57 35" src="https://user-images.githubusercontent.com/915598/123459958-df418080-d5de-11eb-978d-2a678c0f1b10.png">

After

<img width="1266" alt="Screenshot 2021-06-25 at 17 57 27" src="https://user-images.githubusercontent.com/915598/123459990-e5cff800-d5de-11eb-8149-efab50a664f2.png">



### Checklist

* [ ] Have tests been added to cover any changes?
