### PR TITLE
feat: try to turn on APM's instrumentation earlier to instrument queries on the admin db

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -822,7 +822,7 @@ def streaming_query_response(
 
             cur.itersize = batch_size
             cur.arraysize = batch_size
-            cur.execute(query, vars=query_params)
+            cur.execute(query, query_params)
 
             i = 0
             total_bytes = 0

--- a/dataworkspace/start.py
+++ b/dataworkspace/start.py
@@ -4,6 +4,7 @@
 # fmt: off
 from gevent import monkey; monkey.patch_all()  # noqa: E402,E702
 from psycogreen.gevent import patch_psycopg; patch_psycopg()  # noqa: E402,E702
+from elasticapm.instrumentation.control import instrument; instrument()  # noqa: E402,E702
 # fmt: on
 
 # ... and then start the server proper


### PR DESCRIPTION
### Description of change

This is to try to get psycopg2 methods getting instrumented... suspect that our db connection pool imports variables before they are instrumented https://github.com/jneight/django-db-geventpool/blob/master/django_db_geventpool/backends/postgresql_psycopg2/psycopg2_pool.py#L23

Suspect the instrumentation monkey-patching isn't perfect: it seems to have converted keyword arguments to positional: hence the change in stream_query_as_csv_to_queue

Screenshot from staging showing that SQL on the admin db appears to be instrumented with this change:

<img width="1122" alt="Screenshot 2021-06-29 at 18 56 59" src="https://user-images.githubusercontent.com/13877/123845226-d7018200-d90b-11eb-99b2-c4a08e2cf7ba.png">

### Checklist

* [ ] Have tests been added to cover any changes?
