### PR TITLE
fix: display uuid[] as text[] in data explorer output

### DIFF
--- a/dataworkspace/dataworkspace/utils.py
+++ b/dataworkspace/dataworkspace/utils.py
@@ -167,6 +167,7 @@ TYPE_CODES_REVERSED = {
     1270: 'time[]',
     1700: 'numeric',
     2950: 'uuid',
+    2951: 'text[]',
     3802: 'jsonb',
     3807: 'jsonb[]',
     3904: 'type',


### PR DESCRIPTION
### Description of change

Add `uuid[]` to column types and map to string in the ui to stop them looking like `UUID(xxxx-xxxx...)` 

### Checklist

* [ ] Have tests been added to cover any changes?
