### PR TITLE
feature: add celery task to push tool usage datasets to geckoboard

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/management/commands/push_tool_monitoring_dashboard_datasets.py
+++ b/dataworkspace/dataworkspace/apps/applications/management/commands/push_tool_monitoring_dashboard_datasets.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from dataworkspace.apps.applications.utils import (
+    push_tool_monitoring_dashboard_datasets,
+)
+
+
+class Command(BaseCommand):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def handle(self, *args, **options):
+        push_tool_monitoring_dashboard_datasets()
+
+
+if __name__ == '__main__':
+    settings.configure()
+    Command().handle()

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -332,6 +332,11 @@ if not strtobool(env.get('DISABLE_CELERY_BEAT_SCHEDULE', '0')):
             'schedule': 60 * 5,
             'args': (),
         },
+        'push-tool-monitoring-dashboard-datasets': {
+            'task': 'dataworkspace.apps.applications.utils.push_tool_monitoring_dashboard_datasets',
+            'schedule': 60,
+            'args': (),
+        },
     }
 
 CELERY_REDBEAT_REDIS_URL = env['REDIS_URL']

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -729,3 +729,33 @@ data "aws_iam_policy_document" "admin_datasets_database_rds_logs" {
     resources = ["*"]
   }
 }
+
+resource "aws_iam_role_policy_attachment" "admin_list_ecs_tasks" {
+  role       = "${aws_iam_role.admin_task.name}"
+  policy_arn = "${aws_iam_policy.admin_list_ecs_tasks.arn}"
+}
+
+resource "aws_iam_policy" "admin_list_ecs_tasks" {
+  name        = "${var.prefix}-admin-list-ecs-tasks"
+  path        = "/"
+  policy       = "${data.aws_iam_policy_document.admin_list_ecs_tasks.json}"
+}
+
+data "aws_iam_policy_document" "admin_list_ecs_tasks" {
+  statement {
+    actions = [
+      "ecs:ListTasks",
+      "ecs:DescribeTasks"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "ecs:cluster"
+      values = [
+        "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:cluster/${aws_ecs_cluster.notebooks.name}",
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
### Description of change

This PR adds a celery task which gets a few ECS task stats and pushes them to geckboard:

<img width="1278" alt="Screenshot 2021-07-05 at 11 09 58" src="https://user-images.githubusercontent.com/915598/124457715-0557e500-dd84-11eb-8f2b-a884cbda6281.png">

Related terraform-data-workspace PR: https://gitlab.ci.uktrade.digital/data-infrastructure/terraform-data-workspace/-/merge_requests/35

### Checklist

* [ ] Have tests been added to cover any changes?
