### PR TITLE
Fix/query timeouts

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -888,7 +888,10 @@ def streaming_query_response(
 
         with connect(
             database_dsn(settings.DATABASES_DATA[database]),
-            options=f'-c idle_in_transaction_session_timeout={query_timeout}',
+            options=(
+                '-c idle_in_transaction_session_timeout={timeout} '
+                '-c statement_timeout={timeout}'
+            ).format(timeout=query_timeout),
         ) as conn:
             conn.set_session(readonly=True)
 
@@ -896,7 +899,6 @@ def streaming_query_response(
                 # set statements can't be issued in the server-side cursor,
                 # used by stream_query_as_csv_to_queue so we create a separate
                 # one to set a timeout on the current connection
-                _cur.execute('SET statement_timeout={0}'.format(query_timeout))
                 _cur.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')
 
             (

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -764,6 +764,7 @@ def streaming_query_response(
     query_params=None,
     unfiltered_query=None,
     query_metrics_callback=None,
+    cursor_name='data_download',
 ):
     """
     Returns a streaming http response containing a csv file for download
@@ -779,6 +780,7 @@ def streaming_query_response(
     @param query_params: additional query parameters applied to query
     @param unfiltered_query: the query without any filters applied
     @param query_metrics_callback: function to call with query metrics data
+    @param cursor_name: optional name for the cursor - helps with debugging locks
     @return: Customised DjangoStreamingResponse
     """
     logger.info('streaming_query_response start: %s %s %s', user_email, database, query)
@@ -818,7 +820,7 @@ def streaming_query_response(
         filtered_columns = []
         start = timer()
 
-        with conn.cursor(name='data_download') as cur:
+        with conn.cursor(name=cursor_name) as cur:
 
             cur.itersize = batch_size
             cur.arraysize = batch_size

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -884,7 +884,10 @@ def streaming_query_response(
     def run_queries():
         should_run_query_metrics = unfiltered_query and query_metrics_callback
 
-        with connect(database_dsn(settings.DATABASES_DATA[database])) as conn:
+        with connect(
+            database_dsn(settings.DATABASES_DATA[database]),
+            options=f'-c idle_in_transaction_session_timeout={query_timeout}',
+        ) as conn:
             conn.set_session(readonly=True)
 
             with conn.cursor() as _cur:

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -792,6 +792,7 @@ def streaming_query_response(
 
     batch_size = 1000
     query_timeout = 300 * 1000
+    idle_in_transaction_timeout = 60 * 1000
 
     # done is added to the queue once the download of the data for the browser is complete
     # this causes the generator to finish and processing to continue
@@ -889,9 +890,9 @@ def streaming_query_response(
         with connect(
             database_dsn(settings.DATABASES_DATA[database]),
             options=(
-                '-c idle_in_transaction_session_timeout={timeout} '
-                '-c statement_timeout={timeout}'
-            ).format(timeout=query_timeout),
+                f'-c idle_in_transaction_session_timeout={idle_in_transaction_timeout} '
+                f'-c statement_timeout={query_timeout}'
+            ),
         ) as conn:
             conn.set_session(readonly=True)
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -48,6 +48,7 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.text import slugify
 from django.views.decorators.http import (
     require_GET,
     require_http_methods,
@@ -1159,6 +1160,7 @@ class CustomDatasetQueryDownloadView(DetailView):
             query.database.memorable_name,
             filtered_query,
             query.get_filename(),
+            cursor_name=f'custom-query--{query.id}--{slugify(query.name)}',
         )
 
 
@@ -1544,6 +1546,7 @@ class DataGridDataView(DetailView):
                 params,
                 original_query,
                 write_metrics_to_eventlog,
+                cursor_name=f'data-grid--{self.kwargs["model_class"].__name__}--{source.id}',
             )
 
         records = self._get_rows(source, query, params)


### PR DESCRIPTION
### Description of change

1. Sets a timeout on "idle in transaction" queries to match the existing query timeout.
2. Gives streaming download cursors more descriptive names.

For custom dataset query downloads the cursor name includes the id and the slugified name of the model.

It will look something like:

```
FETCH FORWARD 1000 FROM "custom-query--1--a-long-running-query"
```


And for data grid queries it will include the model type the query is running against and the id of that model.

It will look something like:

```
FETCH FORWARD 1000 FROM "data-grid--CustomDatasetQuery--1"
```

or 

```
FETCH FORWARD 1000 FROM "data-grid--SourceTable--2"
```
