### PR TITLE
fix: use source type and query id as cursor name

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -821,7 +821,7 @@ def streaming_query_response(
         filtered_columns = []
         start = timer()
 
-        with conn.cursor(name='data_download') as cur:
+        with conn.cursor(name=cursor_name) as cur:
 
             cur.itersize = batch_size
             cur.arraysize = batch_size

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -48,7 +48,6 @@ from django.http import (
 )
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.text import slugify
 from django.views.decorators.http import (
     require_GET,
     require_http_methods,
@@ -1160,7 +1159,7 @@ class CustomDatasetQueryDownloadView(DetailView):
             query.database.memorable_name,
             filtered_query,
             query.get_filename(),
-            cursor_name=f'custom-query--{query.id}--{slugify(query.name)}',
+            cursor_name=f'custom_query--{query.id}',
         )
 
 


### PR DESCRIPTION
### Description of change

Do not use query name in cursor as it can cause syntax errors if certain chars are used.

### Checklist

* [ ] Have tests been added to cover any changes?
