### PR TITLE
fix: check api path is not for superset

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -290,8 +290,7 @@ async def async_main():
             or request.url.path.startswith('/api/v1/account/')
             or request.url.path.startswith('/api/v1/application-instance/')
             or request.url.path.startswith('/api/v1/core/')
-            and request.url.host == root_domain_no_port
-        )
+        ) and request.url.host == root_domain_no_port
 
     def is_hawk_auth_required(request):
         return is_dataset_requested(request)


### PR DESCRIPTION
### Description of change

workaround the clash between data workspace and superset api paths by checking if the request is for superset _before_ checking if it's for a dataset

### Checklist

* [ ] Have tests been added to cover any changes?
