### PR TITLE
fix: open up the ECR API for the healthcheck service to be able to pull its Docker image

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -721,6 +721,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_superset" {
   protocol    = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_healthcheck" {
+  description = "ingress-https-from-healthcheck-service"
+
+  security_group_id = "${aws_security_group.ecr_api.id}"
+  source_security_group_id = "${aws_security_group.healthcheck_service.id}"
+
+  type        = "ingress"
+  from_port   = "443"
+  to_port     = "443"
+  protocol    = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 


### PR DESCRIPTION
### Description of change

Suspect that if it goes does right now, it won't be able to come back up

### Checklist

* [ ] Have tests been added to cover any changes?
