### PR TITLE
fix: replace requests to mapbox with our own mirror

### DIFF
--- a/docker-compose-superset-dev.yml
+++ b/docker-compose-superset-dev.yml
@@ -6,7 +6,7 @@ services:
        dockerfile: Dockerfile
        target: dev
      image: data-workspace-superset
-     environment: 
+     environment:
        DB_USER: postgres
        DB_PASSWORD: postgres
        DB_HOST: data-workspace-postgres

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -41,11 +41,10 @@ ENV \
 COPY superset_config.py /etc/superset/
 COPY start.sh /
 
-FROM base as dev
+COPY monkey-patch-requests.js /usr/local/lib/python3.7/dist-packages/superset/static/assets/
 
-USER superset
-
-CMD ["/start.sh"]
+RUN sed -i 's/<\/title>/<\/title><script src="\/static\/assets\/monkey-patch-requests.js"><\/script>/g' \
+    /usr/local/lib/python3.7/dist-packages/superset/templates/superset/basic.html
 
 FROM base as live
 

--- a/superset/monkey-patch-requests.js
+++ b/superset/monkey-patch-requests.js
@@ -1,0 +1,35 @@
+var STYLE_FILEPATH = '/__mirror/maps/bright/osm-bright-gl-style.json';
+var STYLES_RE = /.*?api\.mapbox\.com\/styles.*?/;
+var TILES_RE = /^protocol:\/\/host\/.*?/;
+
+(function(window){
+
+  // Patch fetch() calls for the style file and tiles
+  var x = window.fetch;
+  window.fetch = function() {
+    if (arguments[0] instanceof Request) {
+      if (STYLES_RE.test(arguments[0].url)) {
+        arguments[0] = new Request(window.location.origin + STYLE_FILEPATH, arguments[0])
+      }
+      else if (TILES_RE.test(arguments[0].url)) {
+        arguments[0] = new Request(
+          arguments[0].url.replace('protocol://host', window.location.origin),
+          arguments[0]
+        )
+      }
+    }
+    return x.apply(this, arguments);
+  }
+
+  // Patch worker postMessage calls to inject our own glyphs
+  var postMessage = Worker.prototype.postMessage
+  Worker.prototype.postMessage = function(args) {
+    if (args.data instanceof Object && args.data.request instanceof Object) {
+      var url = args.data.request.url;
+      if (url.startsWith('protocol://host')) {
+        args.data.request.url = url.replace('protocol://host', window.location.origin)
+      }
+    }
+    postMessage.call(this, args);
+  }
+})(window);


### PR DESCRIPTION
### Description of change

Overrides `fetch()` and `Worker.postMessage()` to inject our map tiles into the mapbox and deck.gl superset charts.

![Screenshot from 2021-07-16 16-59-55](https://user-images.githubusercontent.com/594496/125976154-d6066453-9825-4b54-975b-4cc38e5405f5.png)
