### PR TITLE
commands to enable and disable all datagrids against CustomDataSetQueries

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/disable_customdatasetquery_datagrid.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/disable_customdatasetquery_datagrid.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from dataworkspace.apps.datasets.models import CustomDatasetQuery
+
+
+class Command(BaseCommand):
+    help = "Enables ag-grid for CustomDatasetQuery"
+
+    def handle(self, *args, **options):
+        self.stdout.write("enabling ag-grid for DataCut datasets ...")
+
+        CustomDatasetQuery.objects.all().update(data_grid_enabled=False)
+
+        self.stdout.write(
+            self.style.SUCCESS("enabling ag-grid for CustomDatasetQuery (done)")
+        )

--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/enable_customdatasetquery_datagrid.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/enable_customdatasetquery_datagrid.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from dataworkspace.apps.datasets.models import CustomDatasetQuery
+
+
+class Command(BaseCommand):
+    help = "Enables ag-grid for CustomDatasetQuery"
+
+    def handle(self, *args, **options):
+        self.stdout.write("enabling ag-grid for DataCut datasets ...")
+
+        CustomDatasetQuery.objects.all().update(data_grid_enabled=True)
+
+        self.stdout.write(
+            self.style.SUCCESS("enabling ag-grid for CustomDatasetQuery (done)")
+        )


### PR DESCRIPTION
### Description of change
A django management command to enable and disable ag-grid for CustomQueryDatasets.

To enable
`python3 manage.py enable_customdatasetquery_datagrid`

To disable
`python3 manage.py disable_customdatasetquery_datagrid`


### Checklist

~* [ ] Have tests been added to cover any changes?~
