### PR TITLE
fix: replace % with %% for data grid queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -2,6 +2,7 @@ import copy
 import csv
 import operator
 import os
+import re
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -897,8 +898,13 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
             'datasets:custom_dataset_query_data', args=(self.dataset_id, self.id)
         )
 
+    @property
+    def cleaned_query(self):
+        # Replace any single '%' with '%%'
+        return re.sub('(?<!%)%(?!%)', '%%', self.query).rstrip().rstrip(';')
+
     def get_data_grid_query(self):
-        return sql.SQL(self.query.rstrip().rstrip(';'))
+        return sql.SQL(self.cleaned_query)
 
     def get_column_config(self):
         """
@@ -906,7 +912,7 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
         """
         col_defs = []
         for column in datasets_db.get_columns(
-            self.database.memorable_name, query=self.query, include_types=True,
+            self.database.memorable_name, query=self.cleaned_query, include_types=True,
         ):
             col_defs.append(
                 {

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -179,7 +179,9 @@ function initDataGrid(columnConfig, dataEndpoint, records, exportFileName) {
 
   if (dataEndpoint) {
     gridOptions.rowModelType = 'infinite';
-    gridOptions.columnDefs[0].cellRenderer = 'loadingRenderer';
+    if (gridOptions.columnDefs.length > 0) {
+      gridOptions.columnDefs[0].cellRenderer = 'loadingRenderer';
+    }
   }
   else {
     gridOptions.rowData = records;


### PR DESCRIPTION
### Description of change

- Escape `%` in custom dataset queries before running. 
- Fix js issue that broke the page if no columns were returned

### Checklist

* [ ] Have tests been added to cover any changes?
