### PR TITLE
fix: do not use ecs logging formatter locally

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -179,16 +179,20 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
+LOGGING_HANDLERS = ['dev' if DEBUG else 'console']
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {'ecs': {'()': 'dataworkspace.utils.DataWorkspaceECSFormatter'}},
-    'handlers': {'console': {'class': 'logging.StreamHandler', 'formatter': 'ecs'}},
+    'handlers': {
+        'dev': {'class': 'logging.StreamHandler'},
+        'console': {'class': 'logging.StreamHandler', 'formatter': 'ecs'},
+    },
     'loggers': {
-        'django': {'handlers': ['console'], 'level': 'INFO'},
-        'app': {'handlers': ['console'], 'level': 'INFO'},
-        'dataworkspace': {'handlers': ['console'], 'level': 'INFO'},
-        'celery': {'handlers': ['console'], 'level': 'INFO', 'propagate': False},
+        'django': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'app': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'dataworkspace': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'celery': {'handlers': LOGGING_HANDLERS, 'level': 'INFO', 'propagate': False},
     },
 }
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -44,17 +44,18 @@ CONTEXT_ALPHABET = string.ascii_letters + string.digits
 
 
 async def async_main():
+    env = normalise_environment(os.environ)
+
     stdout_handler = logging.StreamHandler(sys.stdout)
-    ecs_formatter = ecs_logging.StdlibFormatter(
-        exclude_fields=('log.original', 'message')
-    )
-    stdout_handler.setFormatter(ecs_formatter)
+    if 'dataworkspace.test' not in env['ALLOWED_HOSTS']:
+        stdout_handler.setFormatter(
+            ecs_logging.StdlibFormatter(exclude_fields=('log.original', 'message'))
+        )
     for logger_name in ['aiohttp.server', 'aiohttp.web', 'aiohttp.access', 'proxy']:
         logger = logging.getLogger(logger_name)
         logger.setLevel(logging.INFO)
         logger.addHandler(stdout_handler)
 
-    env = normalise_environment(os.environ)
     port = int(env['PROXY_PORT'])
     admin_root = env['UPSTREAM_ROOT']
     superset_root = env['SUPERSET_ROOT']


### PR DESCRIPTION
### Description of change

Turn off ecs log formatting in django and the proxy when running locally

### Checklist

* [ ] Have tests been added to cover any changes?
