### PR TITLE
Fix/superset pre go live fixes

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -227,7 +227,7 @@ def tools_html_GET(request):
             ],
             'appstream_url': settings.APPSTREAM_URL,
             'quicksight_url': reverse('applications:quicksight_redirect'),
-            'superset_url': settings.SUPERSET_EDIT_URL,
+            'superset_url': settings.SUPERSET_DOMAINS['edit'],
             'your_files_enabled': settings.YOUR_FILES_ENABLED,
             'SUPERSET_FLAG': settings.SUPERSET_FLAG,
         },
@@ -280,10 +280,10 @@ def _get_embedded_quicksight_dashboard(request, dashboard_id, catalogue_item):
     return render(request, 'quicksight_running.html', context, status=200)
 
 
-@csp_update(frame_src=settings.SUPERSET_VIEW_URL)
+@csp_update(frame_src=settings.SUPERSET_DOMAINS['view'])
 def _get_embedded_superset_dashboard(request, dashboard_id, catalogue_item):
     context = {
-        'dashboard_url': f'{settings.SUPERSET_VIEW_URL}/superset/dashboard/{dashboard_id}?standalone=true',
+        'dashboard_url': f'{settings.SUPERSET_DOMAINS["view"]}/superset/dashboard/{dashboard_id}?standalone=true',
         'nice_name': catalogue_item,
         'wrap': 'IFRAME_WITH_VISUALISATIONS_HEADER',
         'catalogue_item': catalogue_item,

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -665,5 +665,9 @@ DATAFLOW_API_CONFIG = {
 # per user granted, rather than a single field with e.g. comma-separated users.
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 
-SUPERSET_VIEW_URL = f'https://superset.{APPLICATION_ROOT_DOMAIN}'
-SUPERSET_EDIT_URL = f'https://superset-edit.{APPLICATION_ROOT_DOMAIN}'
+PROTOCOL = 'http://' if LOCAL else 'https://'
+SUPERSET_DOMAINS = {
+    'view': f'{PROTOCOL}superset.{APPLICATION_ROOT_DOMAIN}',
+    'edit': f'{PROTOCOL}superset-edit.{APPLICATION_ROOT_DOMAIN}',
+    'admin': f'{PROTOCOL}superset-admin.{APPLICATION_ROOT_DOMAIN}',
+}

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -179,16 +179,20 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
+LOGGING_HANDLERS = ['dev' if DEBUG else 'console']
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {'ecs': {'()': 'dataworkspace.utils.DataWorkspaceECSFormatter'}},
-    'handlers': {'console': {'class': 'logging.StreamHandler', 'formatter': 'ecs'}},
+    'handlers': {
+        'dev': {'class': 'logging.StreamHandler'},
+        'console': {'class': 'logging.StreamHandler', 'formatter': 'ecs'},
+    },
     'loggers': {
-        'django': {'handlers': ['console'], 'level': 'INFO'},
-        'app': {'handlers': ['console'], 'level': 'INFO'},
-        'dataworkspace': {'handlers': ['console'], 'level': 'INFO'},
-        'celery': {'handlers': ['console'], 'level': 'INFO', 'propagate': False},
+        'django': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'app': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'dataworkspace': {'handlers': LOGGING_HANDLERS, 'level': 'INFO'},
+        'celery': {'handlers': LOGGING_HANDLERS, 'level': 'INFO', 'propagate': False},
     },
 }
 

--- a/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/core/test_views.py
@@ -1,5 +1,6 @@
 from unittest import mock
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -21,11 +22,8 @@ class TestGetSupersetCredentialsAPIView:
         mock_source_tables,
         mock_cache,
         unauthenticated_client,
+        dataset_db,
     ):
-        visualisation = factories.VisualisationLinkFactory(
-            visualisation_type='SUPERSET',
-            visualisation_catalogue_item__user_access_type='REQUIRES_AUTHENTICATION',
-        )
         credentials = [{'db_user': 'foo', 'db_password': 'bar'}]
         mock_cache.get.side_effect = [
             1,  # cache.get(credentials_version_key, None)
@@ -40,23 +38,23 @@ class TestGetSupersetCredentialsAPIView:
         )
         user.user_permissions.add(tools_permission)
 
-        header = {'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id}
+        headers = {
+            'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id,
+            'HTTP_HOST': f'superset-edit.{settings.APPLICATION_ROOT_DOMAIN}',
+        }
         response = unauthenticated_client.get(
-            reverse('api-v1:core:get-superset-role-credentials'), **header
+            reverse('api-v1:core:get-superset-role-credentials'), **headers
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['credentials'] == credentials[0]
-        assert response.json()['dashboards'] == [visualisation.identifier]
+        assert response.json()['dashboards'] == []
 
         assert mock_new_credentials.called
         assert mock_cache.set.call_args_list == [
             mock.call('superset_credentials_version', 1, nx=True, timeout=None),
             mock.call(
-                f'superset_credentials_1_{user.profile.sso_id}',
-                {
-                    'credentials': credentials[0],
-                    'dashboards': [visualisation.identifier],
-                },
+                f'superset_credentials_1_edit_{user.profile.sso_id}',
+                {'credentials': credentials[0], 'dashboards': []},
                 timeout=mock.ANY,
             ),
         ]
@@ -71,6 +69,7 @@ class TestGetSupersetCredentialsAPIView:
         mock_source_tables,
         mock_cache,
         unauthenticated_client,
+        dataset_db,
     ):
         credentials = [{'db_user': 'foo', 'db_password': 'bar'}]
         mock_cache.get.side_effect = [
@@ -81,7 +80,10 @@ class TestGetSupersetCredentialsAPIView:
 
         user = factories.UserFactory()
 
-        header = {'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id}
+        header = {
+            'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id,
+            'HTTP_HOST': f'superset-edit.{settings.APPLICATION_ROOT_DOMAIN}',
+        }
         response = unauthenticated_client.get(
             reverse('api-v1:core:get-superset-role-credentials'), **header
         )
@@ -101,32 +103,81 @@ class TestGetSupersetCredentialsAPIView:
         mock_source_tables,
         mock_cache,
         unauthenticated_client,
+        dataset_db,
     ):
-        visualisation = factories.VisualisationLinkFactory(
-            visualisation_type='SUPERSET',
-            visualisation_catalogue_item__user_access_type='REQUIRES_AUTHENTICATION',
-        )
         credentials = [{'db_user': 'foo', 'db_password': 'bar'}]
         mock_cache.get.side_effect = [
             1,  # cache.get(credentials_version_key, None)
             {
                 'credentials': credentials[0],
-                'dashboards': [visualisation.identifier],
+                'dashboards': [],
             },  # cache.get(cache_key, None)
         ]
         mock_new_credentials.return_value = credentials
 
         user = factories.UserFactory()
 
-        header = {'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id}
+        header = {
+            'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id,
+            'HTTP_HOST': f'superset-edit.{settings.APPLICATION_ROOT_DOMAIN}',
+        }
         response = unauthenticated_client.get(
             reverse('api-v1:core:get-superset-role-credentials'), **header
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['credentials'] == credentials[0]
-        assert response.json()['dashboards'] == [visualisation.identifier]
+        assert response.json()['dashboards'] == []
 
         assert not mock_new_credentials.called
         assert mock_cache.set.call_args_list == [
             mock.call('superset_credentials_version', 1, nx=True, timeout=None),
+        ]
+
+    @pytest.mark.django_db
+    @mock.patch('dataworkspace.apps.api_v1.core.views.cache')
+    def test_public_user_gets_db_access(
+        self, mock_cache, unauthenticated_client, dataset_db
+    ):
+        visualisation = factories.VisualisationLinkFactory(
+            visualisation_type='SUPERSET',
+            visualisation_catalogue_item__user_access_type='REQUIRES_AUTHENTICATION',
+        )
+        credentials = {
+            'memorable_name': 'my_database',
+            'db_name': 'test_datasets',
+            'db_host': 'data-workspace-postgres',
+            'db_port': '5432',
+            'db_user': 'postgres',
+            'db_password': 'postgres',
+        }
+        mock_cache.get.side_effect = [
+            1,  # cache.get(credentials_version_key, None)
+            None,  # cache.get(cache_key, None)
+        ]
+
+        user = factories.UserFactory()
+        tools_permission = Permission.objects.get(
+            codename='start_all_applications',
+            content_type=ContentType.objects.get_for_model(ApplicationInstance),
+        )
+        user.user_permissions.add(tools_permission)
+
+        headers = {
+            'HTTP_SSO_PROFILE_USER_ID': user.profile.sso_id,
+            'HTTP_HOST': f'superset.{settings.APPLICATION_ROOT_DOMAIN}',
+        }
+        response = unauthenticated_client.get(
+            reverse('api-v1:core:get-superset-role-credentials'), **headers
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['credentials'] == credentials
+        assert response.json()['dashboards'] == [visualisation.identifier]
+
+        assert mock_cache.set.call_args_list == [
+            mock.call('superset_credentials_version', 1, nx=True, timeout=None),
+            mock.call(
+                f'superset_credentials_1_view_{user.profile.sso_id}',
+                {'credentials': credentials, 'dashboards': [visualisation.identifier]},
+                timeout=mock.ANY,
+            ),
         ]

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -44,17 +44,18 @@ CONTEXT_ALPHABET = string.ascii_letters + string.digits
 
 
 async def async_main():
+    env = normalise_environment(os.environ)
+
     stdout_handler = logging.StreamHandler(sys.stdout)
-    ecs_formatter = ecs_logging.StdlibFormatter(
-        exclude_fields=('log.original', 'message')
-    )
-    stdout_handler.setFormatter(ecs_formatter)
+    if 'dataworkspace.test' not in env['ALLOWED_HOSTS']:
+        stdout_handler.setFormatter(
+            ecs_logging.StdlibFormatter(exclude_fields=('log.original', 'message'))
+        )
     for logger_name in ['aiohttp.server', 'aiohttp.web', 'aiohttp.access', 'proxy']:
         logger = logging.getLogger(logger_name)
         logger.setLevel(logging.INFO)
         logger.addHandler(stdout_handler)
 
-    env = normalise_environment(os.environ)
     port = int(env['PROXY_PORT'])
     admin_root = env['UPSTREAM_ROOT']
     superset_root = env['SUPERSET_ROOT']

--- a/docker-compose-test-local.yml
+++ b/docker-compose-test-local.yml
@@ -20,6 +20,7 @@ services:
     extra_hosts:
       - "dataworkspace.test:127.0.0.1"
       - "superset.dataworkspace.test:127.0.0.1"
+      - "superset-edit.dataworkspace.test:127.0.0.1"
       - "testapplication-23b40dd9.dataworkspace.test:127.0.0.1"
       - "testdbapplication-23b40dd9.dataworkspace.test:127.0.0.1"
       - "testvisualisation.dataworkspace.test:127.0.0.1"

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,6 +20,7 @@ services:
     extra_hosts:
       - "dataworkspace.test:127.0.0.1"
       - "superset.dataworkspace.test:127.0.0.1"
+      - "superset-edit.dataworkspace.test:127.0.0.1"
       - "testapplication-23b40dd9.dataworkspace.test:127.0.0.1"
       - "testdbapplication-23b40dd9.dataworkspace.test:127.0.0.1"
       - "testvisualisation.dataworkspace.test:127.0.0.1"

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -40,10 +40,12 @@ ENV \
 
 COPY superset_config.py /etc/superset/
 
-COPY monkey-patch-requests.js /usr/local/lib/python3.7/dist-packages/superset/static/assets/
+COPY data-workspace-patches.js /usr/local/lib/python3.7/dist-packages/superset/static/assets/
 
-RUN sed -i 's/<\/title>/<\/title><script src="\/static\/assets\/monkey-patch-requests.js"><\/script>/g' \
+RUN sed -i 's/<\/title>/<\/title><script src="\/static\/assets\/data-workspace-patches.js"><\/script>/g' \
     /usr/local/lib/python3.7/dist-packages/superset/templates/superset/basic.html
+
+FROM base AS dev
 
 COPY start-dev.sh /start.sh
 

--- a/superset/create-editor-role.sql
+++ b/superset/create-editor-role.sql
@@ -10,6 +10,7 @@ insert into ab_permission_view_role select nextval('ab_permission_view_role_id_s
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),9, 7;
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),10, 7;
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),11, 7;
+insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),12, 7;
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),13, 7;
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),15, 7;
 insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),16, 7;

--- a/superset/data-workspace-patches.js
+++ b/superset/data-workspace-patches.js
@@ -32,4 +32,22 @@ var TILES_RE = /^protocol:\/\/host\/.*?/;
     }
     postMessage.call(this, args);
   }
+
+  if (window.location.pathname === '/tablemodelview/list/') {
+    /*
+     Hide the "create dataset" button on the dataset list view page
+     as we don't want users creating physical datasets
+     */
+    document.head.insertAdjacentHTML(
+        'beforeend',
+        '<style>nav .navbar-right button:nth-child(2) { display: none !important }</style>'
+    )
+    /*
+      Hide the physical/virtual dataset radio button from the edit dataset modal
+     */
+    document.head.insertAdjacentHTML(
+        'beforeend',
+        '<style>.ant-modal-body .ant-radio-wrapper { display: none !important; }</style>'
+    )
+  }
 })(window);

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -1539,7 +1539,112 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(response.status, 403)
 
     @async_test
-    async def test_superset_headers(self):
+    async def test_superset_editor_headers(self):
+        await flush_database()
+        await flush_redis()
+
+        session, cleanup_session = client_session()
+        self.add_async_cleanup(cleanup_session)
+
+        cleanup_superset, superset_requests = await create_superset()
+        self.add_async_cleanup(cleanup_superset)
+
+        cleanup_application = await create_application(
+            env=lambda: {
+                'APPLICATION_IP_WHITELIST__1': '1.2.3.4/32',
+                'APPLICATION_IP_WHITELIST__2': '5.0.0.0/8',
+                'X_FORWARDED_FOR_TRUSTED_HOPS': '2',
+                'SUPERSET_ROOT': 'http://localhost:8008/',
+            }
+        )
+        self.add_async_cleanup(cleanup_application)
+
+        is_logged_in = True
+        codes = iter(['some-code'])
+        tokens = iter(['token-1'])
+        auth_to_me = {
+            'Bearer token-1': {
+                'email': 'test@test.com',
+                'contact_email': 'test@test.com',
+                'related_emails': [],
+                'first_name': 'Peter',
+                'last_name': 'Piper',
+                'user_id': '7f93c2c7-bc32-43f3-87dc-40d0b8fb2cd2',
+            }
+        }
+        sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
+        self.add_async_cleanup(sso_cleanup)
+
+        await until_succeeds('http://dataworkspace.test:8000/healthcheck')
+
+        # Ensure user created
+        async with session.request(
+            'GET', 'http://dataworkspace.test:8000/'
+        ) as response:
+            await response.text()
+
+        stdout, stderr, code = await give_user_app_perms()
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertEqual(code, 0)
+
+        dataset_id_test_dataset = '70ce6fdd-1791-4806-bbe0-4cf880a9cc37'
+        table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'
+        stdout, stderr, code = await create_private_dataset(
+            'my_database',
+            'MASTER',
+            dataset_id_test_dataset,
+            'test_dataset',
+            table_id,
+            'test_dataset',
+        )
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertEqual(code, 0)
+
+        stdout, stderr, code = await give_user_dataset_perms('test_dataset')
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertEqual(code, 0)
+
+        stdout, stderr, code = await create_visusalisation(
+            'test_visualisation', 'REQUIRES_AUTHENTICATION', 'SUPERSET', 1
+        )
+        self.assertEqual(stdout, b'')
+        self.assertEqual(stderr, b'')
+        self.assertEqual(code, 0)
+
+        async with session.request(
+            'GET',
+            'http://superset-edit.dataworkspace.test:8000/',
+            headers={'x-forwarded-for': '1.2.3.4'},
+        ) as response:
+            self.assertEqual(response.status, 200)
+
+        assert (
+            superset_requests[0].headers['Credentials-Memorable-Name'] == 'my_database'
+        )
+        assert superset_requests[0].headers['Credentials-Db-Name'] == 'datasets'
+        assert (
+            superset_requests[0].headers['Credentials-Db-Host']
+            == 'data-workspace-postgres'
+        )
+        assert superset_requests[0].headers['Credentials-Db-Port'] == '5432'
+        assert (
+            superset_requests[0].headers['Credentials-Db-Persistent-Role']
+            == '_user_23b40dd9'
+        )
+        assert (
+            superset_requests[0]
+            .headers['Credentials-Db-User']
+            .startswith('user_test_test_com_')
+        )
+        assert superset_requests[0].headers['Credentials-Db-User'].endswith('superset')
+        assert 'Credentials-Db-Password' in superset_requests[0].headers
+        assert 'Credentials-Db-Id' in superset_requests[0].headers
+
+    @async_test
+    async def test_superset_public_headers(self):
         await flush_database()
         await flush_redis()
 
@@ -1630,18 +1735,8 @@ class TestApplication(unittest.TestCase):
             == 'data-workspace-postgres'
         )
         assert superset_requests[0].headers['Credentials-Db-Port'] == '5432'
-        assert (
-            superset_requests[0].headers['Credentials-Db-Persistent-Role']
-            == '_user_23b40dd9'
-        )
-        assert (
-            superset_requests[0]
-            .headers['Credentials-Db-User']
-            .startswith('user_test_test_com_')
-        )
-        assert superset_requests[0].headers['Credentials-Db-User'].endswith('superset')
-        assert 'Credentials-Db-Password' in superset_requests[0].headers
-        assert 'Credentials-Db-Id' in superset_requests[0].headers
+        assert superset_requests[0].headers['Credentials-Db-User'] == 'postgres'
+        assert superset_requests[0].headers['Credentials-Db-Password'] == 'postgres'
         assert superset_requests[0].headers['Dashboards'] == '1'
 
     @async_test


### PR DESCRIPTION
### Description of change

- Allow for running superset locally over http
- Ensure public users are given master db credentials
- Remove some unnecessary default public permissions
- Only add/remove public permissions when necessary (as opposed to deleting and re-adding on every request)
- Inject some css into the dataset listing page to hide "physical" dataset creation options
- Rename the monkey patch js file as it now does more than monkey patch requests

This branch is currently running on dev

### Checklist

* [x] Have tests been added to cover any changes?
