### PR TITLE
feat: avoid warning in RStudio about timedatectl and systemd

### DIFF
--- a/rstudio/rstudio-start.sh
+++ b/rstudio/rstudio-start.sh
@@ -34,5 +34,6 @@ echo "APP_SCHEMA='${APP_SCHEMA}'" >> /etc/R/Renviron.site
 echo "S3_PREFIX='${S3_PREFIX}'" >> /etc/R/Renviron.site
 echo "AWS_DEFAULT_REGION='${AWS_DEFAULT_REGION}'" >> /etc/R/Renviron.site
 echo "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI='${AWS_CONTAINER_CREDENTIALS_RELATIVE_URI}'" >> /etc/R/Renviron.site
+echo "TZ='Europe/London'" >> /etc/R/Renviron.site
 
 sudo -E -H -u rstudio /usr/lib/rstudio-server/bin/rserver


### PR DESCRIPTION
### Description of change

When connecting to the database, suspect in R was calling Sys.timezone(), which in turn was calling, timedatectl which output the warning:

```
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to create bus connection: Host is down
Warning message:
In system("timedatectl", intern = TRUE) :
  running command 'timedatectl' had status 1
```

Manually setting the timezone seems to avoid this.

### Checklist

* [ ] Have tests been added to cover any changes?
