### PR TITLE
fix: allow for bom in uploaded csvs

### DIFF
--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -436,7 +436,9 @@ class ReferenceDataRecordUploadForm(forms.Form):
         super().__init__(*args, **kwargs)
 
     def clean_file(self):
-        reader = csv.DictReader(chunk.decode() for chunk in self.cleaned_data['file'])
+        reader = csv.DictReader(
+            chunk.decode('utf-8-sig') for chunk in self.cleaned_data['file']
+        )
         csv_fields = [x.lower() for x in reader.fieldnames]
         for field in [
             field.name.lower()

--- a/dataworkspace/dataworkspace/apps/dw_admin/views.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/views.py
@@ -215,7 +215,9 @@ class ReferenceDatasetAdminUploadView(ReferenceDataRecordMixin, FormView):
         return kwargs
 
     def form_valid(self, form):
-        reader = csv.DictReader(chunk.decode() for chunk in form.cleaned_data['file'])
+        reader = csv.DictReader(
+            chunk.decode('utf-8-sig') for chunk in form.cleaned_data['file']
+        )
         reader.fieldnames = [x.lower() for x in reader.fieldnames]
         reference_dataset = self._get_reference_dataset()
         record_model_class = reference_dataset.get_record_model_class()

--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -40,7 +40,7 @@ def get_s3_csv_column_types(path):
         Bucket=settings.NOTEBOOKS_BUCKET, Key=path, Range="bytes=0-102400"
     )
 
-    head = file['Body'].read().decode('utf-8')
+    head = file['Body'].read().decode('utf-8-sig')
     csv_data = head.splitlines()
 
     if len(csv_data) <= 2:

--- a/dataworkspace/dataworkspace/tests/your_files/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_utils.py
@@ -1,0 +1,40 @@
+import io
+
+import pytest
+from botocore.response import StreamingBody
+from mock import mock
+
+from dataworkspace.apps.your_files.constants import PostgresDataTypes
+from dataworkspace.apps.your_files.utils import get_s3_csv_column_types
+
+
+@pytest.mark.parametrize(
+    'csv_content',
+    [
+        b'col1,col2\nrow1-col1,1\nrow2-col1,2\nrow3-col1,3\n',
+        b'\xef\xbb\xbfcol1,col2\nrow1-col1,1\nrow2-col1,2\nrow3-col1,3\n',
+    ],
+)
+@mock.patch('dataworkspace.apps.your_files.utils.boto3.client')
+def test_s3_csv_column_types(mock_client, csv_content):
+    mock_client().head_object.return_value = {'ContentType': 'text/csv'}
+    mock_client().get_object.return_value = {
+        'ContentType': 'text/plain',
+        'ContentLength': len(csv_content),
+        'Body': StreamingBody(io.BytesIO(csv_content), len(csv_content)),
+    }
+    response = get_s3_csv_column_types('/a/path.csv')
+    assert response == [
+        {
+            'header_name': 'col1',
+            'column_name': 'col1',
+            'data_type': PostgresDataTypes.TEXT,
+            'sample_data': ['row1-col1', 'row2-col1'],
+        },
+        {
+            'header_name': 'col2',
+            'column_name': 'col2',
+            'data_type': PostgresDataTypes.INTEGER,
+            'sample_data': ['1', '2'],
+        },
+    ]


### PR DESCRIPTION
### Description of change

Ensure "your files" table creation and the reference dataset uploader can handle csvs with byte order mark

### Checklist

* [x] Have tests been added to cover any changes?
