### PR TITLE
feat: do not show vega visualisations to ie11 users

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
+++ b/dataworkspace/dataworkspace/apps/core/templatetags/core_tags.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django import template
 from django.utils.html import format_html
@@ -60,3 +61,9 @@ def spawner_memory(value):
 @register.filter
 def spawner_cpu(value):
     return '-' if not value else str(int(value) / 1024).rstrip('0').rstrip('.')
+
+
+@register.simple_tag(takes_context=True)
+def browser_is_internet_explorer(context, **kwargs):
+    user_agent = context['request'].META.get('HTTP_USER_AGENT', '')
+    return re.search(r'MSIE|Trident/7\.0; rv:\d+', user_agent) is not None

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -1,5 +1,5 @@
 {% extends '_main.html' %}
-{% load humanize static datasets_tags %}
+{% load humanize static datasets_tags core_tags %}
 
 {% block page_title %}{{ model.name }} - {{ block.super }}{% endblock %}
 
@@ -49,6 +49,8 @@
 {% endblock %}
 
 {% block content %}
+  {% browser_is_internet_explorer as is_ie %}
+
   {% if not model.published %}
     {% include 'partials/unpublished_banner.html' with type='dataset' %}
   {% endif %}
@@ -327,7 +329,7 @@
     </div>
   </div>
 
-  {% if model.visualisations.all %}
+  {% if model.visualisations.all and not is_ie %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <hr class="govuk-section-break">
@@ -379,6 +381,7 @@
 {% endblock %}
 
 {% block footer_scripts %}
+  {% browser_is_internet_explorer as is_ie %}
   <script src="{% static 'assets/vendor/highlight/highlight.pack.js' %}"></script>
   <script nonce="{{ request.csp_nonce }}">hljs.initHighlightingOnLoad();</script>
 
@@ -390,13 +393,12 @@
     });
   </script>
 
-  <script src="{% static 'vega.js' %}"></script>
-  <script src="{% static 'vega-lite.js' %}"></script>
-  <script src="{% static 'vega-embed.js' %}"></script>
-  <script src="{% static 'vega-interpreter.js' %}"></script>
-  <script src="{% static 'vega-visualisation-builder.js' %}"></script>
-
-  {% if has_access %}
+  {% if has_access and not is_ie %}
+    <script src="{% static 'vega.js' %}"></script>
+    <script src="{% static 'vega-lite.js' %}"></script>
+    <script src="{% static 'vega-embed.js' %}"></script>
+    <script src="{% static 'vega-interpreter.js' %}"></script>
+    <script src="{% static 'vega-visualisation-builder.js' %}"></script>
     <script nonce="{{ request.csp_nonce }}">
       document.addEventListener("DOMContentLoaded", function () {
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -81,6 +81,7 @@ async def async_main():
         'x-scheme',
         'x-forwarded-proto',
         'referer',
+        'user-agent',
     )
 
     # Cookies on the embed path must be allowed to be SameSite=None, so they


### PR DESCRIPTION
- Pass the user agent header through to the django application from the proxy
- Adds a new template tag to determine if a user agent matches ie11 or below
- Do not show master dataset visualisations if the user is using internet explorer

