### PR TITLE
feature: add celery task to link datasets to superset dashboards

### DIFF
--- a/.envs/test.env
+++ b/.envs/test.env
@@ -85,7 +85,9 @@ GITLAB_ECR_PROJECT_TRIGGER_TOKEN=some-token
 NOTIFY_API_KEY=test-key
 FERNET_EMAIL_TOKEN_KEY=testkey00000000-aaaaaaaaaaaaaaaaaaaaaaaaaaa=
 
-SUPERSET_ROOT=http://some.domain.test/
+SUPERSET_ROOT=http://superset.test
+SUPERSET_DW_USER_USERNAME=dw_user
+SUPERSET_DW_USER_PASSWORD=dw_user_password
 
 QUICKSIGHT_USER_REGION=get-from-aws-quicksight
 QUICKSIGHT_VPC_ARN=get-from-aws-quicksight

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -342,6 +342,11 @@ if not strtobool(env.get('DISABLE_CELERY_BEAT_SCHEDULE', '0')):
             'schedule': 60,
             'args': (),
         },
+        'link-superset-visualisations-to-related-datasets': {
+            'task': 'dataworkspace.apps.datasets.utils.link_superset_visualisations_to_related_datasets',
+            'schedule': 60 * 5,
+            'args': (),
+        },
     }
 
 CELERY_REDBEAT_REDIS_URL = env['REDIS_URL']

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -79,6 +79,8 @@ locals {
     google_analytics_site_id = "${var.google_analytics_site_id}"
 
     superset_root = "https://${var.superset_internal_domain}"
+    superset_dw_user_username = "${var.superset_dw_user_username}"
+    superset_dw_user_password = "${var.superset_dw_user_password}"
 
     admin_dashboard_embedding_role_arn = "${aws_iam_role.admin_dashboard_embedding.arn}"
 

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -928,6 +928,14 @@
       "value": "${superset_root}"
     },
     {
+      "name": "SUPERSET_DW_USER_USERNAME",
+      "value": "${superset_dw_user_username}"
+    },
+    {
+      "name": "SUPERSET_DW_USER_PASSWORD",
+      "value": "${superset_dw_user_password}"
+    },
+    {
       "name": "APPSTREAM_URL",
       "value": "${appstream_url}"
     },

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -121,6 +121,9 @@ variable superset_admin_users {}
 variable superset_db_instance_class {}
 variable superset_internal_domain {}
 
+variable superset_dw_user_username {}
+variable superset_dw_user_password {}
+
 variable datasets_rds_cluster_backup_retention_period {}
 variable datasets_rds_cluster_database_name {}
 variable datasets_rds_cluster_master_username {}


### PR DESCRIPTION
This works in a similar way to the existing update_quicksight_visualisations_last_updated_date task, it calls the Superset API to get the datasets for each dashboard. It then extracts tables from each dataset's sql query and links the datasets / datacuts to the visualisation catalogue item accordingly.

Related infra changes are on https://gitlab.ci.uktrade.digital/data-infrastructure/terraform-data-workspace/-/merge_requests/40

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
