### PR TITLE
Adding GDS phase name banner to visualisation preview

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -356,6 +356,10 @@
             </h3>
             <p class="govuk-body">
               {{ visualisation.summary }}
+              {% if visualisation.gds_phase_name %}
+                <br>
+                <strong class="govuk-tag govuk-phase-banner__content__tag govuk-!-margin-top-2">{{ visualisation.gds_phase_name }}</strong>
+              {% endif %}
             </p>
 
           </div>

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -61,6 +61,16 @@ class TopicTagFactory(TagFactory):
     type = TagType.TOPIC
 
 
+class VisualisationDatasetFactory(factory.django.DjangoModelFactory):
+    name = factory.fuzzy.FuzzyText()
+    summary = factory.fuzzy.FuzzyText()
+    gds_phase_name = "prototype"
+    database = factory.SubFactory(DatabaseFactory)
+
+    class Meta:
+        model = 'datasets.DataSetVisualisation'
+
+
 class DataSetFactory(factory.django.DjangoModelFactory):
     grouping = factory.SubFactory(DataGroupingFactory)
     name = factory.fuzzy.FuzzyText()


### PR DESCRIPTION
### Description of change
Added back the GDS phase banner against visualisation previews on master dataset catalogue page

### Checklist

* [x] Have tests been added to cover any changes?
