### PR TITLE
Fix/data explorer back button

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/schema.py
+++ b/dataworkspace/dataworkspace/apps/explorer/schema.py
@@ -126,3 +126,11 @@ def build_schema_info(user, connection_alias):
             results, lambda row: (row['schema_name'], row['table_name'])
         )
     ]
+
+
+def get_user_schema_info(request):
+    schema = schema_info(
+        user=request.user, connection_alias=settings.EXPLORER_DEFAULT_CONNECTION
+    )
+    tables_columns = ['.'.join(schema_table) for schema_table, _ in schema]
+    return schema, tables_columns

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
@@ -1,5 +1,5 @@
 {% load explorer_tags %}
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" id="query-results">
   {% if headers %}
     <div class="govuk-grid-column-full">
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">

--- a/dataworkspace/dataworkspace/apps/explorer/urls.py
+++ b/dataworkspace/dataworkspace/apps/explorer/urls.py
@@ -11,6 +11,7 @@ from dataworkspace.apps.explorer.views import (
     PlayQueryView,
     QueryLogResultView,
     QueryView,
+    RunningQueryView,
     ShareQueryConfirmationView,
     ShareQueryView,
 )
@@ -21,6 +22,11 @@ urlpatterns = [
         'download/<int:querylog_id>',
         login_required(DownloadFromQuerylogView.as_view()),
         name='download_querylog',
+    ),
+    path(
+        'query/<int:query_log_id>/',
+        login_required(RunningQueryView.as_view()),
+        name='running_query',
     ),
     path('queries/', login_required(ListQueryView.as_view()), name='list_queries'),
     path(

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -304,14 +304,14 @@ class TestHomePage:
         )
         assert resp.status_code == 404
 
-    def test_async_playground_renders_submitting_message(self, staff_client):
+    def test_async_playground_redirects_to_results_page(self, staff_client):
         resp = staff_client.post(
             reverse("explorer:index"),
             {'title': 'test', 'sql': 'select 1+3400;', "action": "run"},
         )
-        assert (
-            'Your query is currently being executed by Data Explorer'
-            in resp.content.decode(resp.charset)
+        assert resp.status_code == 302
+        assert resp['Location'] == reverse(
+            'explorer:running_query', args=(QueryLog.objects.last().id,)
         )
 
     def test_playground_redirects_to_query_create_on_save_with_sql_query_param(

--- a/test/selenium/explorer_pages.py
+++ b/test/selenium/explorer_pages.py
@@ -1,4 +1,7 @@
 from lxml import html
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.wait import WebDriverWait
 
 from test.selenium.common import _BasePage  # pylint: disable=wrong-import-order
 
@@ -37,6 +40,11 @@ class HomePage(_BaseExplorerPage):
 
     def click_format_sql(self):
         self._submit("Format SQL")
+
+    def wait_for_results(self):
+        WebDriverWait(self._driver, 10).until(
+            expected_conditions.visibility_of_element_located((By.ID, "query-results"))
+        )
 
     def read_result_headers(self):
         headers = self._driver.find_elements_by_xpath(

--- a/test/selenium/test_explorer.py
+++ b/test/selenium/test_explorer.py
@@ -60,6 +60,7 @@ class TestDataExplorer:
 
         home_page.enter_query("select 1, 2, 3")
         home_page.click_run()
+        home_page.wait_for_results()
 
         assert home_page.read_result_headers() == ['?column?', '?column?', '?column?']
         assert home_page.read_result_rows() == [["1", "2", "3"]]


### PR DESCRIPTION
### Description of change

On query submission redirect the user to a new "Query running" page. This allows for navigation through the browser history without the post confirmations

### Checklist

* [ ] Have tests been added to cover any changes?
