### PR TITLE
Esacape python r code snippets

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1169,10 +1169,7 @@ class ReferenceDatasetColumnDetails(View):
         return render(
             request,
             'datasets/referencedataset_column_details.html',
-            context={
-                "dataset": dataset,
-                "columns": columns,
-            },
+            context={"dataset": dataset, "columns": columns},
         )
 
 
@@ -1185,11 +1182,7 @@ class ReferenceDatasetGridView(View):
         )
 
         return render(
-            request,
-            'datasets/reference_dataset_grid.html',
-            context={
-                "model": dataset,
-            },
+            request, 'datasets/reference_dataset_grid.html', context={"model": dataset},
         )
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -42,8 +42,13 @@ def test_get_code_snippets_for_table(metadata_db):
     )
 
     snippets = get_code_snippets_for_table(sourcetable)
-    assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['python']
-    assert """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50""" in snippets['r']
+    assert (
+        """SELECT * FROM \\"public\\".\\"MY_LOVELY_TABLE\\" LIMIT 50"""
+        in snippets['python']
+    )
+    assert (
+        """SELECT * FROM \\"public\\".\\"MY_LOVELY_TABLE\\" LIMIT 50""" in snippets['r']
+    )
     assert snippets['sql'] == """SELECT * FROM "public"."MY_LOVELY_TABLE" LIMIT 50"""
 
 
@@ -52,6 +57,16 @@ def test_get_code_snippets_for_query(metadata_db):
     assert 'SELECT * FROM foo' in snippets['python']
     assert 'SELECT * FROM foo' in snippets['r']
     assert snippets['sql'] == 'SELECT * FROM foo'
+
+
+def test_r_code_snippets_are_escaped(metadata_db):
+    snippets = get_code_snippets_for_query('SELECT * FROM "foo"')
+    assert 'SELECT * FROM \\"foo\\"' in snippets['r']
+
+
+def test_python_code_snippets_are_escaped(metadata_db):
+    snippets = get_code_snippets_for_query('SELECT * FROM "foo"')
+    assert 'sqlalchemy.text(\"""SELECT * FROM \\"foo\\"\"""' in snippets['python']
 
 
 class TestUpdateQuickSightVisualisationsLastUpdatedDate:

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1816,12 +1816,14 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
         group = factories.DataGroupingFactory.create()
         external_db = factories.DatabaseFactory.create()
         rds = factories.ReferenceDatasetFactory.create(
-            published=published,
-            group=group,
-            external_database=external_db,
+            published=published, group=group, external_database=external_db,
         )
         field1 = factories.ReferenceDatasetFieldFactory.create(
-            reference_dataset=rds, name='code', column_name="code", data_type=2, is_identifier=True
+            reference_dataset=rds,
+            name='code',
+            column_name="code",
+            data_type=2,
+            is_identifier=True,
         )
         field2 = factories.ReferenceDatasetFieldFactory.create(
             reference_dataset=rds, name='name', column_name="name", data_type=1
@@ -1845,13 +1847,11 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
         response = request_client.get(rds.get_absolute_url())
 
         assert response.status_code == 200
-        assert (
-            "<strong>code</strong> (integer)"
-            in response.content.decode(response.charset)
+        assert "<strong>code</strong> (integer)" in response.content.decode(
+            response.charset
         )
-        assert (
-            "<strong>name</strong> (text)"
-            in response.content.decode(response.charset)
+        assert "<strong>name</strong> (text)" in response.content.decode(
+            response.charset
         )
 
     @pytest.mark.parametrize(
@@ -1859,7 +1859,9 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
         [('client', True), ('staff_client', True), ('staff_client', False)],
         indirect=['request_client'],
     )
-    def test_reference_dataset_shows_show_all_columns_link(self, request_client, published):
+    def test_reference_dataset_shows_show_all_columns_link(
+        self, request_client, published
+    ):
         group = factories.DataGroupingFactory.create()
         linked_rds = factories.ReferenceDatasetFactory.create(
             group=group, table_name='test_get_ref_data_linked'
@@ -1931,10 +1933,7 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
         response = request_client.get(rds.get_absolute_url())
 
         assert response.status_code == 200
-        assert (
-            "View all columns"
-            not in response.content.decode(response.charset)
-        )
+        assert "View all columns" not in response.content.decode(response.charset)
 
 
 class TestRequestAccess(DatasetsCommon):


### PR DESCRIPTION
### Description of change
This PR is to escape both Python and R code snippets, so that the code can be run without any errors in JupyterLab and RStudio.



### Checklist

* [x] Have tests been added to cover any changes?
