### PR TITLE
feat: add a summary page before submitting zendesk ticket

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -107,6 +107,7 @@ class EligibilityCriteriaForm(forms.Form):
         coerce=lambda x: x == 'yes',
         choices=(('no', 'No'), ('yes', 'Yes')),
     )
+    access_request = forms.IntegerField(widget=forms.HiddenInput, required=False)
 
 
 class SourceTagField(forms.ModelMultipleChoiceField):

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -773,18 +773,26 @@ def eligibility_criteria_view(request, dataset_uuid):
     if request.method == 'POST':
         form = EligibilityCriteriaForm(request.POST)
         if form.is_valid():
+            access_request_id = form.cleaned_data.get('access_request')
             if form.cleaned_data['meet_criteria']:
-                return HttpResponseRedirect(
-                    reverse('request_access:dataset', args=[dataset_uuid])
-                )
-            else:
-                return HttpResponseRedirect(
-                    reverse(
-                        'datasets:eligibility_criteria_not_met', args=[dataset_uuid]
+                url = reverse('request_access:dataset', args=[dataset_uuid])
+                if access_request_id:
+                    url = reverse(
+                        'request_access:dataset-request-update',
+                        args=[access_request_id],
                     )
+            else:
+                url = reverse(
+                    'datasets:eligibility_criteria_not_met', args=[dataset_uuid]
                 )
 
-    return render(request, 'eligibility_criteria.html', {'dataset': dataset})
+            return HttpResponseRedirect(url)
+
+    return render(
+        request,
+        'eligibility_criteria.html',
+        {'dataset': dataset, 'access_request': request.GET.get('access_request')},
+    )
 
 
 @require_GET

--- a/dataworkspace/dataworkspace/apps/request_access/forms.py
+++ b/dataworkspace/dataworkspace/apps/request_access/forms.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.template.loader import render_to_string
 
 from dataworkspace.apps.request_access.models import AccessRequest
@@ -17,8 +18,9 @@ from dataworkspace.forms import (
 class DatasetAccessRequestForm(GOVUKDesignSystemModelForm):
     class Meta:
         model = AccessRequest
-        fields = ['contact_email', 'reason_for_access']
+        fields = ['id', 'contact_email', 'reason_for_access']
 
+    id = forms.IntegerField(widget=forms.HiddenInput, required=False)
     contact_email = GOVUKDesignSystemCharField(
         label="Contact email",
         widget=GOVUKDesignSystemTextWidget(
@@ -64,6 +66,7 @@ class ToolsAccessRequestFormPart1(GOVUKDesignSystemModelForm):
             heading='h2',
             heading_class='govuk-heading-m',
             extra_label_classes='govuk-!-font-weight-bold',
+            show_selected_file=True,
         ),
         error_messages={
             "required": "You must upload proof that you've completed the training."

--- a/dataworkspace/dataworkspace/apps/request_access/urls.py
+++ b/dataworkspace/dataworkspace/apps/request_access/urls.py
@@ -3,7 +3,9 @@ from django.urls import path
 from dataworkspace.apps.accounts.utils import login_required
 from dataworkspace.apps.request_access.views import (
     AccessRequestConfirmationPage,
+    AccessRequestSummaryPage,
     DatasetAccessRequest,
+    DatasetAccessRequestUpdate,
     ToolsAccessRequestPart1,
     ToolsAccessRequestPart2,
     ToolsAccessRequestPart3,
@@ -15,6 +17,11 @@ urlpatterns = [
         '<uuid:dataset_uuid>',
         login_required(DatasetAccessRequest.as_view()),
         name='dataset',
+    ),
+    path(
+        '<int:pk>/dataset',
+        login_required(DatasetAccessRequestUpdate.as_view()),
+        name='dataset-request-update',
     ),
     path(
         '<int:pk>/tools',
@@ -30,6 +37,11 @@ urlpatterns = [
         '<int:pk>/spss-stata-reason',
         login_required(ToolsAccessRequestPart3.as_view()),
         name='tools-3',
+    ),
+    path(
+        '<int:pk>/summary',
+        login_required(AccessRequestSummaryPage.as_view()),
+        name='summary-page',
     ),
     path(
         '<int:pk>/confirmation',

--- a/dataworkspace/dataworkspace/forms.py
+++ b/dataworkspace/dataworkspace/forms.py
@@ -20,6 +20,7 @@ class GOVUKDesignSystemWidgetMixin:
         label_size='l',
         extra_label_classes='',
         small=False,
+        show_selected_file=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -30,6 +31,7 @@ class GOVUKDesignSystemWidgetMixin:
             label_size=label_size,
             extra_label_classes=extra_label_classes,
             small=small,
+            show_selected_file=show_selected_file,
         )
 
     def __deepcopy__(self, memo):
@@ -103,6 +105,14 @@ class GOVUKDesignSystemFileInputWidget(
     GOVUKDesignSystemWidgetMixin, forms.widgets.FileInput
 ):
     template_name = 'design_system/file.html'
+
+    def format_value(self, value):
+        """
+        Return the file object if it has a defined url attribute.
+        """
+        if value:
+            return value.name.split('!')[0]
+        return super().format_value(value)
 
 
 class GOVUKDesignSystemMultipleChoiceField(

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -358,3 +358,7 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
 .training-screenshot {
   content: url("/__django_static/assets/images/rit-screenshot.png")
 }
+
+.govuk-hint.currently-selected-file {
+  font-size: 1rem;
+}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -303,17 +303,18 @@
                   </details>
                 {% endif %}
 
-                <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                                            <span class="govuk-details__summary-text">
-                                            Use this data <span
-                                              class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
-                                            </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=source_table %}
-                  </div>
-                </details>
+                {% if has_access %}
+                  <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">
+                        Use this data <span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+                      </span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=source_table %}
+                    </div>
+                  </details>
+                {% endif %}
               </td>
             </tr>
           {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -194,16 +194,18 @@
           </details>
         {% endif %}
 
-        <details class="govuk-details govuk" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Use this data <span class="govuk-visually-hidden">for "{{ model.name }}"</span>
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            {% include 'partials/code_snippets.html' with code_snippets=code_snippets %}
-          </div>
-        </details>
+        {% if model.external_database %}
+          <details class="govuk-details govuk" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Use this data <span class="govuk-visually-hidden">for "{{ model.name }}"</span>
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              {% include 'partials/code_snippets.html' with code_snippets=code_snippets %}
+            </div>
+          </details>
+          {% endif %}
       {% endif %}
     </div>
   </div>

--- a/dataworkspace/dataworkspace/templates/design_system/file.html
+++ b/dataworkspace/dataworkspace/templates/design_system/file.html
@@ -24,8 +24,14 @@
   </span>
   {% endif %}
 
+  {% if widget.show_selected_file and widget.value %}
+    <div id="{{ id }}-currently-selected-hint" class="govuk-hint currently-selected-file">
+      Currently selected file: {{ widget.value }}
+    </div>
+  {% endif %}
+
   <input
-          class="govuk-file-upload bla foo"
+          class="govuk-file-upload"
           type="file"
           name="{{ widget.name }}"
           {% if widget.help_text %}aria-describedby="{{ id }}-hint" {% endif %}

--- a/dataworkspace/dataworkspace/templates/eligibility_criteria.html
+++ b/dataworkspace/dataworkspace/templates/eligibility_criteria.html
@@ -47,6 +47,9 @@
                     </div>
                 </fieldset>
               </div>
+              {% if access_request %}
+                <input type="hidden" name="access_request" value="{{ access_request }}" />
+              {% endif %}
               <div class="govuk-form-group">
                   <button data-prevent-double-click="true" type="submit" class="govuk-button">Continue
                   </button>

--- a/dataworkspace/dataworkspace/templates/request_access/dataset.html
+++ b/dataworkspace/dataworkspace/templates/request_access/dataset.html
@@ -34,9 +34,10 @@
               </a>
             </p>
 
-            <form method="post" novalidate>
+            <form method="post" novalidate{% if form.instance.id %} action="{% url 'request_access:dataset-request-update' form.instance.id %}{% endif %}">
                 {% csrf_token %}
                 <fieldset class="govuk-fieldset">
+                    {{ form.id }}
                     {{ form.contact_email }}
                     {{ form.reason_for_access }}
 

--- a/dataworkspace/dataworkspace/templates/request_access/partials/summary-list-row.html
+++ b/dataworkspace/dataworkspace/templates/request_access/partials/summary-list-row.html
@@ -1,0 +1,13 @@
+<div class="govuk-summary-list__row">
+  <dt class="govuk-summary-list__key">
+    {{ title }}
+  </dt>
+  <dd class="govuk-summary-list__value">
+    {{ description }}
+  </dd>
+  <dd class="govuk-summary-list__actions">
+    <a href="{% url change_link object_id %}{{ query_params }}" class="govuk-link govuk-link--no-visited-state">
+      Change
+    </a>
+  </dd>
+</div>

--- a/dataworkspace/dataworkspace/templates/request_access/summary.html
+++ b/dataworkspace/dataworkspace/templates/request_access/summary.html
@@ -1,0 +1,56 @@
+{% extends '_main.html' %}
+{% block page_title %}Check your answers before sending your request - {{ block.super }}{% endblock page_title %}
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">Request access
+      </li>
+    </ol>
+  </div>
+{% endblock breadcrumbs %}
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Check your answers before sending your request</h1>
+      {% if catalogue_item %}
+        <p class="govuk-body">
+          <strong>Dataset</strong>
+          <br />
+          <a href="{{ catalogue_item.get_absolute_url }}" class="govuk-link govuk-link--no-visited-state">
+            {{ catalogue_item }}
+          </a>
+        </p>
+      {% endif %}
+      <form method="post" novalidate>
+        {% csrf_token %}
+        <div class="govuk-form-group">
+          <dl class="govuk-summary-list">
+            {% if object.journey == object.JOURNEY_DATASET_ACCESS or object.journey == object.JOURNEY_DATASET_AND_TOOLS_ACCESS %}
+              {% if catalogue_item.eligibility_criteria %}
+                {% with object.id|stringformat:'s' as req_id %}
+                  {% include 'request_access/partials/summary-list-row.html' with title='Eligibility criteria' description='Yes' change_link='datasets:eligibility_criteria' object_id=catalogue_item.id query_params='?access_request='|add:req_id %}
+                {% endwith %}
+              {% endif %}
+              {% include 'request_access/partials/summary-list-row.html' with title='Contact email' description=object.contact_email change_link='request_access:dataset-request-update' object_id=object.id %}
+              {% include 'request_access/partials/summary-list-row.html' with title='Reason to access this data' description=object.reason_for_access change_link='request_access:dataset-request-update' object_id=object.id %}
+            {% endif %}
+            {% if object.journey == object.JOURNEY_TOOLS_ACCESS or object.journey == object.JOURNEY_DATASET_AND_TOOLS_ACCESS%}
+              {% include 'request_access/partials/summary-list-row.html' with title='Responsible for Information training proof' description='Uploaded' change_link='request_access:tools-1' object_id=object.id %}
+              {% if object.spss_and_stata %}
+                {% include 'request_access/partials/summary-list-row.html' with title='Request SPSS and Stata' description='Yes' change_link='request_access:tools-2' object_id=object.id %}
+                {% include 'request_access/partials/summary-list-row.html' with title='Line manager&apos;s email address' description=object.line_manager_email_address change_link='request_access:tools-3' object_id=object.id %}
+                {% include 'request_access/partials/summary-list-row.html' with title='Reason for needing SPSS and Stata' description=object.reason_for_spss_and_stata change_link='request_access:tools-3' object_id=object.id %}
+              {% else %}
+                {% include 'request_access/partials/summary-list-row.html' with title='Request SPSS and Stata' description='No' change_link='request_access:tools-2' object_id=object.id %}
+              {% endif %}
+            {% endif %}
+          </dl>
+          <button class="govuk-button" data-module="govuk-button">Submit</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock content %}

--- a/dataworkspace/dataworkspace/tests/request_access/factories.py
+++ b/dataworkspace/dataworkspace/tests/request_access/factories.py
@@ -1,0 +1,17 @@
+import uuid
+
+import factory.fuzzy
+
+from dataworkspace.apps.request_access import models
+from dataworkspace.tests.factories import UserFactory
+
+
+class AccessRequestFactory(factory.django.DjangoModelFactory):
+    requester = factory.SubFactory(UserFactory)
+    contact_email = factory.LazyAttribute(
+        lambda _: f'test.user+{uuid.uuid4()}@example.com'
+    )
+    reason_for_access = factory.fuzzy.FuzzyText()
+
+    class Meta:
+        model = models.AccessRequest


### PR DESCRIPTION
### Description of change

Show a summary page before creating/confirming an access request.

- Adds functionality "continue" an access request from the dataset eligibility/access request start pages
- Also includes a small bug fix for hiding code snippets from unauthorised users
- And a fix to stop showing snippets for reference datasets that are not published to the datasets db

This branch is live on dev now for testing

### Screens

#### 1. Dataset only
![dataset-only](https://user-images.githubusercontent.com/594496/132688678-aa496997-457c-401c-a7be-db9c6be66185.png)

#### 2. Dataset and tools (with spss)
![dataset-and-tools-and-spss](https://user-images.githubusercontent.com/594496/132687634-8c410a71-1f19-4fce-9ec2-9c1844dbda1c.png)

#### 3. Tools only (no spss)
![tools-only](https://user-images.githubusercontent.com/594496/132687689-9786626e-2380-4800-a83a-bebbabce2ae5.png)

#### 4. Tools only (with spss)
![tools-and-spss](https://user-images.githubusercontent.com/594496/132687713-a2c0a0df-d2d2-4c3f-b6d4-430d2f057fa6.png)


### Checklist

* [x] Have tests been added to cover any changes?
