### PR TITLE
fix: do not show download limit for data cuts

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -35,7 +35,7 @@
       <div class="govuk-!-margin-top-4">
         {% if object.data_grid_download_enabled %}
           <button class="govuk-button" data-module="govuk-button" id="data-grid-download">
-            Download this data (max {% if object.data_grid_download_limit %}{{ object.data_grid_download_limit|intcomma }}{% else %}5,000{% endif %} rows)
+            Download this data{% if object.data_grid_download_limit %} (max {{ object.data_grid_download_limit|intcomma }} rows){% endif %}
           </button>
           &nbsp;
         {% endif %}


### PR DESCRIPTION
### Description of change

Data cuts are not limited to 5,000 rows so do not say they are on the download button.

### Checklist

* [ ] Have tests been added to cover any changes?
