### PR TITLE
feat: dataset finder content updates

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -552,6 +552,7 @@ def find_datasets(request):
             "datasets": paginator.get_page(request.GET.get("page")),
             "data_type": dict(data_types),
             "show_unpublished": has_unpublished_dataset_access(request.user),
+            "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
         },
     )
 

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -50,12 +50,15 @@
       </div>
       <div class="search-field govuk-!-margin-bottom-9">
         <label class="govuk-label search-field__label" for="search">Enter your search term(s)</label>
-        <div class="search-field-wrapper">
+        <div class="search-field-wrapper govuk-!-padding-bottom-6">
           <input type="search" name="q" id="search" title="Search" class="govuk-input search-field__item search-field__input js-class-toggle" value="{{ query }}" aria-controls="search-summary-accessible-hint-wrapper">
           <div class="search-field-submit-wrapper search-field__item">
             <input class="search-field__submit" type="submit" value="Search">
           </div>
         </div>
+        <p class="govuk-body">
+          Switch to <a href="{% url 'finder:find_datasets' %}" class="govuk-link govuk-link--no-visited-state">search all our data</a>.
+        </p>
       </div>
     </div>
 </div>

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -56,9 +56,11 @@
             <input class="search-field__submit" type="submit" value="Search">
           </div>
         </div>
-        <p class="govuk-body">
-          Switch to <a href="{% url 'finder:find_datasets' %}" class="govuk-link govuk-link--no-visited-state">search all our data</a>.
-        </p>
+        {% flag DATASET_FINDER_FLAG %}
+          <p class="govuk-body">
+            Switch to <a href="{% url 'finder:find_datasets' %}" class="govuk-link govuk-link--no-visited-state">search all our data</a>.
+          </p>
+        {% endflag %}
       </div>
     </div>
 </div>

--- a/dataworkspace/dataworkspace/templates/finder/index.html
+++ b/dataworkspace/dataworkspace/templates/finder/index.html
@@ -12,26 +12,34 @@
 {% block content %}
 <form id="ds-finder-search-form" action="{% url 'finder:find_datasets' %}" method="get">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds" style="margin: 0 auto; float: unset">
+    <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
-        <h1 class="govuk-label-wrapper govuk-!-margin-top-5" style="text-align: center"><label class="govuk-label govuk-label--xl" for="q">
-          Dataset finder
-        </label>
+        <h1 class="govuk-label-wrapper">
+          <label class="govuk-label govuk-label--xl" for="q">Search all our data</label>
         </h1>
-        <p class="govuk-body-l" style="text-align: center">
-          Search for master datasets in Data Workspace that contain a specific word or phrase.
+        <p class="govuk-body">
+          Find the datasets which mention for example a particular:
+          <ul class="govuk-list govuk-list--bullet">
+            <li>company</li>
+            <li>country</li>
+            <li>sector</li>
+          </ul>
         </p>
       </div>
     </div>
-    <div class="govuk-grid-column-two-thirds govuk-!-margin-top-9" style="margin: 0 auto; float: unset">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-hint">To search for a phrase, put the phrase in quotation marks.</div>
         <div class="search-field govuk-!-margin-bottom-9">
-          <label class="govuk-label search-field__label" for="search">Search a specific word or phrase</label>
-          <div class="search-field-wrapper">
+          <div class="search-field-wrapper govuk-!-padding-bottom-6">
+            <label class="govuk-label search-field__label" for="search">Search a specific word or phrase</label>
             <input type="search" name="q" id="search" title="Search" class="govuk-input search-field__item search-field__input js-class-toggle" value="{{ search_term }}">
             <div class="search-field-submit-wrapper search-field__item">
               <input class="search-field__submit" type="submit" value="Search">
             </div>
           </div>
+          <p class="govuk-body">
+            Switch to <a href="{% url 'datasets:find_datasets' %}" class="govuk-link govuk-link--no-visited-state">search by title or description</a>.
+          </p>
         </div>
     </div>
   </div>

--- a/dataworkspace/dataworkspace/templates/finder/index.html
+++ b/dataworkspace/dataworkspace/templates/finder/index.html
@@ -46,7 +46,7 @@
 
   {% if search_term %}
   <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds" style="margin: 0 auto; float: unset">
+      <div class="govuk-grid-column-two-thirds">
         {% if results %}
           <p class="govuk-body">
             <strong>{{ results|length }} results</strong>
@@ -55,23 +55,23 @@
           {% for result in results %}
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
             
-            <h2 class="govuk-heading-m">
-              <a class="govuk-link" href="{% url 'datasets:dataset_detail' dataset_uuid=result.id %}#{{ result.slug }}" target="_blank">
-                {{ result.name }}
-              </a>
-            </h2>
+            <h2 class="govuk-heading-m">{{ result.name }}</h2>
             {% for table in result.table_matches %}
-            <p class="govuk-body">
-              <strong>{{ table.count }}</strong> matching rows in "{{ table.schema }}"."{{ table.table }}"
-              <br>
-              <span class="govuk-hint govuk-!-margin-bottom-0">{{ table.name }}</span>
-
               {% if table.has_access %}
-              <a class="govuk-link" href="{% url 'finder:show_results' schema=table.schema table=table.table %}?name={{ result.name }}&slug={{ result.slug }}&uuid={{ result.id }}&q={{ search_term }}">
-                Show results<span class="govuk-visually-hidden"> for {{table.schema }}.{{ table.table }}</span>
-              </a>
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                  <a class="govuk-link--no-visited-state" href="{% url 'finder:show_results' schema=table.schema table=table.table %}?name={{ result.name }}&slug={{ result.slug }}&uuid={{ result.id }}&q={{ search_term }}">
+                    {{ table.name }}
+                  </a>
+                </p>
+              {% else %}
+                <p class="govuk-body">
+                  You need to <a class="govuk-link govuk-link--no-visited-state" href="{% url 'request_access:dataset' dataset_uuid=result.id %}">request access to view this data</a>.
+                </p>
+                <span class="govuk-hint govuk-!-margin-bottom-0">{{ table.name}}</span>
               {% endif %}
-            </p>
+              <p class="govuk-body">
+                <strong>{{ table.count }}</strong> matching rows in "{{ table.schema }}"."{{ table.table }}"
+              </p>
             {% endfor %}
           {% endfor %}
         {% else %}

--- a/dataworkspace/dataworkspace/tests/finder/test_views.py
+++ b/dataworkspace/dataworkspace/tests/finder/test_views.py
@@ -3,9 +3,9 @@ import pytest
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from django.test import Client, override_settings
 from waffle.testutils import override_flag
 
-from django.test import Client, override_settings
 from dataworkspace.apps.finder.models import DatasetFinderQueryLog
 from dataworkspace.tests import factories
 from dataworkspace.tests.common import get_http_sso_data
@@ -16,7 +16,9 @@ def test_find_datasets_default(client, mocker):
     response = client.get(reverse('finder:find_datasets'))
 
     assert response.status_code == 200
-    assert b"Search for master datasets in Data Workspace" in response.content
+    assert (
+        b"Find the datasets which mention for example a particular:" in response.content
+    )
 
 
 @override_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG, active=True)

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2547,6 +2547,8 @@ class TestApplication(unittest.TestCase):
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
         self.add_async_cleanup(sso_cleanup)
 
+        await set_waffle_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG)
+
         await until_succeeds('http://dataworkspace.test:8000/healthcheck')
         await until_succeeds('http://data-workspace-es:9200/_cat/indices')
         await setup_elasticsearch_indexes()
@@ -2556,8 +2558,6 @@ class TestApplication(unittest.TestCase):
             'GET', 'http://dataworkspace.test:8000/',
         ) as response:
             content = await response.text()
-
-        await set_waffle_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG)
 
         async with session.request(
             'GET', 'http://dataworkspace.test:8000/finder',

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2565,7 +2565,7 @@ class TestApplication(unittest.TestCase):
             content = await response.text()
 
         self.assertEqual(response.status, 200)
-        self.assertIn("Dataset finder", content)
+        self.assertIn("Search all our data", content)
 
         dataset_id_test_dataset = '70ce6fdd-1791-4806-bbe0-4cf880a9cc37'
         table_id = '5a2ee5dd-f025-4939-b0a1-bb85ab7504d7'


### PR DESCRIPTION
- Adds a link to the dataset finder from the search form
- Updates to content and addition of a link from the dataset finder to the main search page
- Adds a link to request access if user doesn't have perms for a search result 

## Homepage

![Screenshot from 2021-09-14 15-12-59](https://user-images.githubusercontent.com/594496/133274703-d5bd7cd1-84f6-430c-a22b-2de5deb2e43b.png)

## Finder page

![Screenshot from 2021-09-14 15-12-51](https://user-images.githubusercontent.com/594496/133274749-9291809f-eaee-43bb-8ec9-82526de65765.png)
