### PR TITLE
fix: use `my_database` for external db testing

### DIFF
--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1795,7 +1795,9 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
             published=True,
             table_name='ref_my_reference_table',
             name='A search reference dataset',
-            external_database=factories.DatabaseFactory.create(),
+            external_database=factories.DatabaseFactory.create(
+                memorable_name='my_database'
+            ),
         )
 
         client = Client(**get_http_sso_data(user))
@@ -1826,7 +1828,7 @@ class TestReferenceDatasetDetailView(DatasetsCommon):
     @pytest.mark.django_db
     def test_reference_dataset_shows_column_details(self, request_client, published):
         group = factories.DataGroupingFactory.create()
-        external_db = factories.DatabaseFactory.create()
+        external_db = factories.DatabaseFactory.create(memorable_name='my_database')
         rds = factories.ReferenceDatasetFactory.create(
             published=published, group=group, external_database=external_db,
         )


### PR DESCRIPTION
### Description of change

Set external database to `my_database` to workaround the multiple database in tests issue for reference datasets.

### Checklist

* [x] Have tests been added to cover any changes?
