### PR TITLE
Feature/dataset finder data grid

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/constants.py
+++ b/dataworkspace/dataworkspace/apps/datasets/constants.py
@@ -17,6 +17,7 @@ GRID_DATA_TYPE_MAP = {
     'timestamp with time zone': 'date',
     'timestamp without time zone': 'date',
     'date': 'date',
+    'boolean': 'boolean',
 }
 
 

--- a/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
+++ b/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Any, List, Optional, Tuple
 
 from django.conf import settings
 
@@ -67,17 +67,32 @@ class ElasticsearchClient:
 
         return lists_of_indexes
 
-    def search(self, phrase: str, index_aliases: List[str], from_: int, size: int):
+    def search(
+        self,
+        phrase: str,
+        index_aliases: List[str],
+        from_: int,
+        size: int,
+        filters: List[dict] = None,
+    ):
+        queries = [
+            {
+                'bool': {
+                    'must': {
+                        "multi_match": {
+                            "query": phrase,
+                            "type": "phrase",
+                            "fields": ["_all"],
+                        }
+                    }
+                }
+            }
+        ] + (filters if filters else [])
+
         return self._client.search(
             body={
                 "sort": [{"_id": {"order": "asc"}}],
-                "query": {
-                    "simple_query_string": {
-                        "query": phrase,
-                        "fields": ["_all"],
-                        "flags": "FUZZY|PHRASE",
-                    }
-                },
+                "query": {"bool": {"must": queries}},
                 "aggs": {"indexes": {"terms": {"field": "_index"}}},
             },
             index=','.join(index_aliases),
@@ -87,12 +102,15 @@ class ElasticsearchClient:
         )
 
     def search_for_phrase(
-        self, phrase: str, index_aliases: List[str]
+        self,
+        phrase: str,
+        index_aliases: List[str],
+        filters: Tuple[Tuple[str, Any]] = None,
     ) -> List[_TableMatchResult]:
         results = []
 
         for batch in self._batch_indexes(index_aliases):
-            resp = self.search(phrase, batch, 0, 0)
+            resp = self.search(phrase, batch, 0, 0, filters=filters)
 
             if resp['hits']['total']['value'] > 0:
                 for r in resp["aggregations"]["indexes"]["buckets"]:
@@ -110,11 +128,18 @@ class ElasticsearchClient:
 
         return sorted(results, key=lambda x: -x.count)
 
-    def get_count(self, phrase, index_alias):
-        matches = self.search_for_phrase(phrase, [index_alias])
+    def get_count(self, phrase, index_alias, filters: Tuple[Tuple[str, Any]] = None):
+        matches = self.search_for_phrase(phrase, [index_alias], filters=filters)
         if matches:
             return matches[0].count
         return 0
+
+    def get_fields(self, index_alias):
+        """
+        Return a list of the fields stored in an elasticsearch index
+        """
+        mapping = self.client.indices.get_mapping(index_alias)
+        return list(mapping[list(mapping.keys())[0]]['mappings']['properties'].keys())
 
 
 es_client = ElasticsearchClient()

--- a/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
+++ b/dataworkspace/dataworkspace/apps/finder/elasticsearch.py
@@ -139,7 +139,7 @@ class ElasticsearchClient:
         Return a list of the fields stored in an elasticsearch index
         """
         mapping = self.client.indices.get_mapping(index_alias)
-        return list(mapping[list(mapping.keys())[0]]['mappings']['properties'].keys())
+        return list(list(mapping.values())[0]['mappings']['properties'].keys())
 
 
 es_client = ElasticsearchClient()

--- a/dataworkspace/dataworkspace/apps/finder/urls.py
+++ b/dataworkspace/dataworkspace/apps/finder/urls.py
@@ -7,7 +7,12 @@ urlpatterns = [
     path('', login_required(views.find_datasets), name='find_datasets'),
     path(
         "show-results/<str:schema>/<str:table>",
-        login_required(views.show_results),
+        login_required(views.ResultsView.as_view()),
         name='show_results',
+    ),
+    path(
+        "grid-results/<str:schema>/<str:table>",
+        login_required(views.DataGridResultsView.as_view()),
+        name='data_grid_results',
     ),
 ]

--- a/dataworkspace/dataworkspace/apps/finder/utils.py
+++ b/dataworkspace/dataworkspace/apps/finder/utils.py
@@ -179,6 +179,9 @@ def build_grid_filters(column_config, params):
         if data_type == 'boolean':
             term = bool(int(term))
 
+        if data_type == 'date':
+            term = datetime.strptime(filter_data['dateFrom'], '%Y-%m-%d %H:%M:%S')
+
         if field in column_map:
             if filter_data['type'] == 'contains':
                 es_filters.append(
@@ -203,24 +206,12 @@ def build_grid_filters(column_config, params):
                 )
 
             elif filter_data['type'] == 'equals':
-                if data_type == 'date':
-                    term = datetime.strptime(
-                        filter_data['dateFrom'], '%Y-%m-%d %H:%M:%S'
-                    )
                 es_filters.append({'term': {field: term}})
 
             elif filter_data['type'] == 'notEqual':
-                if data_type == 'date':
-                    term = datetime.strptime(
-                        filter_data['dateFrom'], '%Y-%m-%d %H:%M:%S'
-                    )
-                es_filters.append({'term': {field: term}})
+                es_filters.append({'bool': {'must_not': {'term': {field: term}}}})
 
             elif filter_data['type'] in ['lessThan', 'greaterThan']:
-                if data_type == 'date':
-                    term = datetime.strptime(
-                        filter_data['dateFrom'], '%Y-%m-%d %H:%M:%S'
-                    )
                 es_filters.append(
                     {
                         'range': {
@@ -238,9 +229,7 @@ def build_grid_filters(column_config, params):
                     {
                         'range': {
                             field: {
-                                'gte': datetime.strptime(
-                                    filter_data['dateFrom'], '%Y-%m-%d %H:%M:%S'
-                                ),
+                                'gte': term,
                                 'lte': datetime.strptime(
                                     filter_data['dateTo'], '%Y-%m-%d %H:%M:%S'
                                 ),

--- a/dataworkspace/dataworkspace/apps/finder/views.py
+++ b/dataworkspace/dataworkspace/apps/finder/views.py
@@ -1,17 +1,29 @@
+import json
 import logging
 
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.http import HttpResponseRedirect
-from django.shortcuts import render
+from django.http import (
+    Http404,
+    HttpResponseForbidden,
+    HttpResponseRedirect,
+    JsonResponse,
+)
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views.decorators.http import require_GET
+from django.views.generic import DetailView
 
 from waffle.decorators import waffle_flag
+from waffle.mixins import WaffleFlagMixin
 
+from dataworkspace import datasets_db
+from dataworkspace.apps.datasets.constants import GRID_DATA_TYPE_MAP
+from dataworkspace.apps.datasets.models import SourceTable
 from dataworkspace.apps.finder.elasticsearch import es_client
 from dataworkspace.apps.finder.forms import DatasetFindForm
 from dataworkspace.apps.finder.utils import (
+    build_grid_filters,
     group_tables_by_master_dataset,
     _enrich_and_suppress_matches,
     get_index_aliases_for_all_published_source_tables,
@@ -62,43 +74,125 @@ def find_datasets(request):
     )
 
 
-@waffle_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG)
-@require_GET
-def show_results(request, schema, table):
-    search_term = request.GET.get("q")
-    name = request.GET.get("name")
-    uuid = request.GET.get("uuid")
-    slug = request.GET.get("slug")
-    index_alias = f"{schema}--{table}"
-    results_proxy = ResultsProxy(
-        es_client=es_client,
-        index_alias=index_alias,
-        phrase=search_term,
-        count=es_client.get_count(search_term, index_alias),
-    )
-    paginator = Paginator(
-        results_proxy, settings.DATASET_FINDER_SEARCH_RESULTS_PER_PAGE
-    )
-    results = paginator.get_page(request.GET.get("page"))
-    records = []
-    fields = []
-    if len(results) > 0 and "_source" in results[0]:
-        records = [result['_source'] for result in results]
-        fields = list(records[0].keys())
-    return render(
-        request,
-        'finder/results.html',
-        {
-            "request": request,
-            "uuid": uuid,
-            "name": name,
-            "slug": slug,
-            "schema": schema,
-            "table": table,
-            "search_term": search_term,
-            "fields": fields,
-            "records": records,
-            "results": results,
-            "backlink": f'{reverse("finder:find_datasets")}?q={search_term}',
-        },
-    )
+class BaseResultsView(WaffleFlagMixin, DetailView):
+    waffle_flag = settings.DATASET_FINDER_ADMIN_ONLY_FLAG
+
+    def _user_can_access(self):
+        return self.get_object().dataset.user_has_access(self.request.user)
+
+    def _get_index_alias(self):
+        return f'{self.kwargs["schema"]}--{self.kwargs["table"]}'
+
+    def get_object(self, queryset=None):
+        return get_object_or_404(
+            SourceTable,
+            dataset__deleted=False,
+            dataset__published=True,
+            dataset__id=self.request.GET.get('uuid'),
+            schema=self.kwargs['schema'],
+            table=self.kwargs['table'],
+        )
+
+    def _get_columns(self):
+        """
+        Return a list of columns in the datasets db for this source table
+        """
+        source_table = self.get_object()
+        return datasets_db.get_columns(
+            source_table.database.memorable_name,
+            schema=source_table.schema,
+            table=source_table.table,
+            include_types=True,
+        )
+
+    def _get_column_config(self):
+        """
+        Return a list of column definitions for configuring ag-grid.
+        Any fields present in the dataset but not in the es index are removed.
+        """
+        es_fields = es_client.get_fields(self._get_index_alias())
+
+        filter_map = {
+            'text': ['contains', 'notContains'],
+            'date': ['equals', 'notEqual', 'greaterThan', 'lessThan', 'inRange'],
+            'numeric': ['equals', 'greaterThan', 'lessThan'],
+            'boolean': ['equals'],
+            'uuid': ['contains', 'notContains'],
+        }
+        return [
+            {
+                'field': column[0],
+                'filter': GRID_DATA_TYPE_MAP.get(column[1], 'text') in filter_map,
+                'sortable': False,
+                'dataType': GRID_DATA_TYPE_MAP.get(column[1], 'text'),
+                'filterParams': {
+                    'filterOptions': filter_map.get(
+                        GRID_DATA_TYPE_MAP.get(column[1], column[1])
+                    )
+                },
+            }
+            for column in self._get_columns()
+            if column[0] in es_fields
+        ]
+
+    def dispatch(self, request, *args, **kwargs):
+        if not self._user_can_access():
+            return HttpResponseForbidden()
+        return super().dispatch(request, *args, **kwargs)
+
+
+class ResultsView(BaseResultsView):
+    template_name = 'finder/results.html'
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        search_term = self.request.GET.get("q")
+
+        ctx.update(
+            {
+                'search_term': search_term,
+                'backlink': f'{reverse("finder:find_datasets")}?q={search_term}',
+                'dataset': self.object.dataset,
+                'source_table': self.object,
+                'columns': self._get_columns(),
+                'total_results': es_client.get_count(
+                    search_term, self._get_index_alias()
+                ),
+                'grid_column_definitions': self._get_column_config(),
+            }
+        )
+        return ctx
+
+
+class DataGridResultsView(BaseResultsView):
+    def get(self, request, *args, **kwargs):
+        raise Http404
+
+    def post(self, request, *args, **kwargs):
+        search_term = request.GET.get('q')
+        post_data = json.loads(request.body.decode('utf-8'))
+        start = int(post_data.get('start', 0))
+        limit = int(post_data.get('limit', 100))
+
+        filters = build_grid_filters(
+            self._get_column_config(), post_data.get('filters', {})
+        )
+
+        result_count = es_client.get_count(
+            search_term, self._get_index_alias(), filters=filters
+        )
+
+        results_proxy = ResultsProxy(
+            es_client=es_client,
+            index_alias=self._get_index_alias(),
+            phrase=search_term,
+            count=result_count,
+            filters=filters,
+        )
+        paginator = Paginator(results_proxy, limit)
+        results = paginator.get_page(1 if start <= 0 else int(start / limit) + 1)
+        records = []
+        if len(results) > 0 and '_source' in results[0]:
+            records = [result['_source'] for result in results]
+
+        return JsonResponse({'total': result_count, 'records': records})

--- a/dataworkspace/dataworkspace/templates/finder/results.html
+++ b/dataworkspace/dataworkspace/templates/finder/results.html
@@ -1,106 +1,83 @@
 {% extends '_main.html' %}
-{% load static %}
-{% load datasets_tags %}
+{% load static datasets_tags explorer_tags %}
 
 {% block go_back %}
   {% if backlink %}
     <a href="{{ backlink }}" class="govuk-back-link">Back</a>
   {% endif %}
-{% endblock %}
-
+{% endblock go_back %}
+{% block footer_scripts %}
+  <script src="{% static 'ag-grid-community.min.js' %}"></script>
+  <script src="{% static 'dayjs.min.js' %}"></script>
+  <script src="{% static 'data-grid.js' %}"></script>
+  {# We *have* to include the stylesheet after the ag-grid js as it overrides the default styles #}
+  <link rel="stylesheet" type="text/css" href="{% static 'data-grid.css' %}" />
+  {{ grid_column_definitions|json_script:"column_data" }}
+  <script nonce="{{ request.csp_nonce }}">
+    window.initDataGrid(
+        JSON.parse(document.getElementById('column_data').textContent),
+        '{% url 'finder:data_grid_results' source_table.schema source_table.table %}?{{ request.GET.urlencode }}',
+        null,
+        null
+    );
+  </script>
+{% endblock footer_scripts %}
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full" style="margin: 0 auto; float: unset">
-        <div class="govuk-form-group">
-        <h1 class="govuk-label-wrapper govuk-!-margin-top-5" style="text-align: left"><label class="govuk-label govuk-label--xl" for="q">
-            Dataset finder - results
-        </label>
-        </h1>
-        </div>
-    </div>
-</div>
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <p class="govuk-body-l">
-        Showing results from 
-        <a class="govuk-link" href="{% url 'datasets:dataset_detail' dataset_uuid=uuid %}#{{ slug }}" target="_blank">
-          {{ name }}
-        </a>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Results in {{ dataset.name }}
+      </h1>
+      <p class="govuk-body govuk-!-padding-bottom-2">
+        <strong>{{ search_term }}</strong> found in {{ source_table.name }} in <a class="govuk-link--no-visited-state" href="{{ dataset.get_absolute_url }}">{{ dataset.name }}</a>.
       </p>
-      {% if records %}
-      <h2 class="govuk-body">
-        <span id="search-results-count">{{ results.paginator.count }}</span> results in "{{ schema }}"."{{ table }}", matching "{{ search_term }}"
-      </h2>
-            <div class="scrollable-table {% if record_count <= fixed_table_height_limit %}fixed-table-height{% endif %}" tabindex="0">
-          <table class="govuk-table govuk-!-font-size-16">
-            <thead>
-              <tr class="govuk-table__row">
-              {% for field in fields %}
-                  <th class="govuk-table__header">
-                    {{ field }}
-                  </th>
-              {% endfor %}
-              </tr>
-            </thead>
-            <tbody>
-            {% for record in records %}
-              <tr class="govuk-table__row">
-                {% for key, value in record.items %}
-                    <td class="govuk-table__cell">
-                    {{ value }}
-                    </td>
-                {% endfor %}
-            </tr>
-            {% empty %}
-              <tr class="govuk-table__row">
-                <td colspan="{{ fields|length }}">
-                    No data available.
-                </td>
-              </tr>
+      <p class="govuk-body govuk-!-padding-bottom-2">
+        {{ dataset.short_description }}
+      </p>
+      <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            View data structure <span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul class="govuk-list govuk-list--bullet">
+            {% for column, data_type in columns|slice:":12" %}
+              <li>
+                <strong>{{ column }}</strong> ({{ data_type }})
+              </li>
             {% endfor %}
-            </tbody>
-          </table>
+            {% if columns|length > 12 %}
+              <a class="govuk-link" href="{% url 'datasets:source_table_column_details' dataset_uuid=dataset.id table_uuid=source_table.id %}">
+                View all columns <span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+              </a>
+            {% endif %}
+          </ul>
         </div>
-        <br/>
-        <p class="govuk-body" style="display: inline">
-            Showing results {{ results.start_index  }}&ndash;{{ results.end_index }} of {{ results.paginator.count }}
-        </p>
-        
-        {% if results.paginator.num_pages > 1 %}
-            <nav role="navigation" class="govuk-body" aria-label="Search result page navigation" style="display: inline">
-            <ul class="pagination govuk-list">
-                {% if results.has_previous %}
-                <li><a class="govuk-link" href="{% url_replace page=results.previous_page_number %}" aria-label="Previous page">Previous</a></li>
-                {% endif %}
-        
-                {% if results.number > 3 %}
-                <li><a class="govuk-link" href="{% url_replace page=1 %}" aria-label="Page 1">{{ 1 }}</a></li>
-                {% if results.number > 4 %}<li>&hellip;</li>{% endif %}
-                {% endif %}
-        
-                {% for i in results.paginator.page_range %}
-                {% if results.number == i %}
-                    <li class="active">{{ i }}</li>
-                {% elif i >= results.number|add:'-2' and i <= results.number|add:'2' %}
-                    <li><a class="govuk-link" href="{% url_replace page=i %}" aria-label="Page {{ i }}">{{ i }}</a></li>
-                {% endif %}
-                {% endfor %}
-        
-                {% if results.paginator.num_pages > results.number|add:'2' %}
-                {% if results.paginator.num_pages > results.number|add:'3' %}<li>&hellip;</li>{% endif %}
-                <li><a class="govuk-link" href="{% url_replace page=results.paginator.num_pages %}" aria-label="Page {{ results.paginator.num_pages }}">{{ results.paginator.num_pages }}</a></li>
-                {% endif %}
-        
-                {% if results.has_next %}
-                <li><a class="govuk-link" href="{% url_replace page=results.next_page_number %}" aria-label="Next page">Next</a></li>
-                {% endif %}
-            </ul>
-            </nav>
-        {% endif %}
+      </details>
+    <p class="govuk-body">
+      {{ total_results }} results found in <strong>"{{ source_table.schema }}"."{{ source_table.table }}"</strong>.
+    </p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      {% if total_results > 0 %}
+        <div id="data-grid" class="ag-theme-alpine"></div>
+        <div class="govuk-!-margin-top-4">
+          <a class="govuk-button govuk-button--primary" target="_blank" href="{% query_table_in_explorer_link source_table.schema source_table.table %}">
+            Open in Data Explorer
+          </a>
+          <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-reset-filters">
+            Reset filters
+          </button>
+          <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-reset-columns">
+            Reset columns
+          </button>
+        </div>
       {% else %}
         <p class="govuk-body">No data available</p>
       {% endif %}
     </div>
-</div>
+  </div>
 {% endblock %}
-

--- a/dataworkspace/dataworkspace/tests/conftest.py
+++ b/dataworkspace/dataworkspace/tests/conftest.py
@@ -239,6 +239,12 @@ def dataset_finder_db(metadata_db):
                 frequency VARCHAR(255),
                 "table" VARCHAR(255)
             );
+
+            CREATE TABLE IF NOT EXISTS country_stats (
+                date DATE,
+                driving NUMERIC,
+                country VARCHAR(255)
+            );
             '''
         )
 

--- a/dataworkspace/dataworkspace/tests/factories.py
+++ b/dataworkspace/dataworkspace/tests/factories.py
@@ -72,6 +72,7 @@ class VisualisationDatasetFactory(factory.django.DjangoModelFactory):
 
 
 class DataSetFactory(factory.django.DjangoModelFactory):
+    id = factory.LazyAttribute(lambda _: uuid.uuid4())
     grouping = factory.SubFactory(DataGroupingFactory)
     name = factory.fuzzy.FuzzyText()
     slug = factory.fuzzy.FuzzyText(length=10)

--- a/dataworkspace/dataworkspace/tests/finder/test_views.py
+++ b/dataworkspace/dataworkspace/tests/finder/test_views.py
@@ -1,9 +1,11 @@
+from urllib.parse import urlencode
+
 import pytest
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.urls import reverse
 from django.test import Client, override_settings
+from django.urls import reverse
 from waffle.testutils import override_flag
 
 from dataworkspace.apps.finder.models import DatasetFinderQueryLog
@@ -99,6 +101,18 @@ def test_find_datasets_with_results(client, mocker, dataset_finder_db):
 @pytest.mark.django_db(transaction=True)
 @override_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG, active=True)
 def test_get_results_for_index(client, mocker, dataset_finder_db):
+    source_table = factories.SourceTableFactory.create(
+        dataset=factories.MasterDataSetFactory.create(
+            user_access_type='REQUIRES_AUTHENTICATION'
+        ),
+        schema='public',
+        table='country_stats',
+        database=factories.DatabaseFactory(memorable_name='my_database'),
+    )
+    get_fields = mocker.patch(
+        'dataworkspace.apps.finder.elasticsearch.ElasticsearchClient.get_fields'
+    )
+    get_fields.return_value = ['date', 'country', 'driving']
     dataset_search = mocker.patch('elasticsearch.Elasticsearch.search')
     dataset_search.side_effect = [
         {
@@ -115,7 +129,10 @@ def test_get_results_for_index(client, mocker, dataset_finder_db):
                     'doc_count_error_upper_bound': 0,
                     'sum_other_doc_count': 0,
                     'buckets': [
-                        {'key': '20210316t070000--public--data--1', 'doc_count': 3},
+                        {
+                            'key': '20210316t070000--public--country_stats--1',
+                            'doc_count': 3,
+                        },
                     ],
                 }
             },
@@ -129,7 +146,7 @@ def test_get_results_for_index(client, mocker, dataset_finder_db):
                 'max_score': None,
                 'hits': [
                     {
-                        "_index": "20210316t070000--public--data--1",
+                        "_index": "20210316t070000--public--country_stats--1",
                         "_type": "_doc",
                         "_id": "1",
                         "_score": 1.0,
@@ -140,7 +157,7 @@ def test_get_results_for_index(client, mocker, dataset_finder_db):
                         },
                     },
                     {
-                        "_index": "20210316t070000--public--data--1",
+                        "_index": "20210316t070000--public--country_stats--1",
                         "_type": "_doc",
                         "_id": "1",
                         "_score": 1.0,
@@ -151,7 +168,7 @@ def test_get_results_for_index(client, mocker, dataset_finder_db):
                         },
                     },
                     {
-                        "_index": "20210316t070000--public--data--1",
+                        "_index": "20210316t070000--public--country_stats--1",
                         "_type": "_doc",
                         "_id": "1",
                         "_score": 1.0,
@@ -166,32 +183,50 @@ def test_get_results_for_index(client, mocker, dataset_finder_db):
         },
     ]
 
-    response = client.get(
-        reverse('finder:show_results', kwargs={'schema': 'public', 'table': 'data'}),
-        {
-            "q": "albania",
-            'name': 'test',
-            'uuid': '3c5cf428-63c1-4c60-bab9-17d4613992d3',
-            'slug': 'slug',
-        },
+    params = {
+        "q": "albania",
+        'name': 'test',
+        'uuid': source_table.dataset.id,
+        'slug': 'slug',
+    }
+    response = client.post(
+        reverse(
+            'finder:data_grid_results',
+            kwargs={'schema': 'public', 'table': 'country_stats'},
+        )
+        + '?'
+        + urlencode(params),
+        {},
+        content_type='application/json',
     )
 
     assert response.status_code == 200
-    assert len(response.context["records"]) == 3
-    assert len(response.context["fields"]) == 3
-    assert response.context["fields"] == ["country", "date", "driving"]
-    assert response.context["records"] == [
-        {"country": "Albania", "date": "2020-01-13", "driving": 0.0},
-        {"country": "Albania", "date": "2020-01-14", "driving": 1.5},
-        {"country": "Albania", "date": "2020-01-15", "driving": 6.7},
-    ]
-    assert response.context["results"].paginator.num_pages == 1
+    assert response.json() == {
+        'total': 3,
+        'records': [
+            {'country': 'Albania', 'date': '2020-01-13', 'driving': 0.0},
+            {'country': 'Albania', 'date': '2020-01-14', 'driving': 1.5},
+            {'country': 'Albania', 'date': '2020-01-15', 'driving': 6.7},
+        ],
+    }
 
 
 @pytest.mark.django_db(transaction=True)
 @override_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG, active=True)
 @override_settings(DATASET_FINDER_SEARCH_RESULTS_PER_PAGE=1)
 def test_paging_get_results_for_index(client, mocker, dataset_finder_db):
+    source_table = factories.SourceTableFactory.create(
+        dataset=factories.MasterDataSetFactory.create(
+            user_access_type='REQUIRES_AUTHENTICATION'
+        ),
+        schema='public',
+        table='country_stats',
+        database=factories.DatabaseFactory(memorable_name='my_database'),
+    )
+    get_fields = mocker.patch(
+        'dataworkspace.apps.finder.elasticsearch.ElasticsearchClient.get_fields'
+    )
+    get_fields.return_value = ['date', 'country', 'driving']
     dataset_search = mocker.patch('elasticsearch.Elasticsearch.search')
     dataset_search.side_effect = [
         {
@@ -208,7 +243,10 @@ def test_paging_get_results_for_index(client, mocker, dataset_finder_db):
                     'doc_count_error_upper_bound': 0,
                     'sum_other_doc_count': 0,
                     'buckets': [
-                        {'key': '20210316t070000--public--data--1', 'doc_count': 3},
+                        {
+                            'key': '20210316t070000--public--country_stats--1',
+                            'doc_count': 3,
+                        },
                     ],
                 }
             },
@@ -218,11 +256,11 @@ def test_paging_get_results_for_index(client, mocker, dataset_finder_db):
             'timed_out': False,
             '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0},
             'hits': {
-                'total': {'value': 3, 'relation': 'eq'},
+                'total': {'value': 1, 'relation': 'eq'},
                 'max_score': None,
                 'hits': [
                     {
-                        "_index": "20210316t070000--public--data--1",
+                        "_index": "20210316t070000--public--country_stats--1",
                         "_type": "_doc",
                         "_id": "1",
                         "_score": 1.0,
@@ -235,17 +273,49 @@ def test_paging_get_results_for_index(client, mocker, dataset_finder_db):
                 ],
             },
         },
+        {
+            'took': 11,
+            'timed_out': False,
+            '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0},
+            'hits': {
+                'total': {'value': 1, 'relation': 'eq'},
+                'max_score': None,
+                'hits': [
+                    {
+                        "_index": "20210316t070000--public--country_stats--1",
+                        "_type": "_doc",
+                        "_id": "1",
+                        "_score": 1.0,
+                        "_source": {
+                            "country": "Albania",
+                            "date": "2020-01-14",
+                            "driving": 1.5,
+                        },
+                    },
+                ],
+            },
+        },
     ]
 
-    response = client.get(
-        reverse('finder:show_results', kwargs={'schema': 'public', 'table': 'data'}),
-        {
-            "q": "albania",
-            'name': 'test',
-            'uuid': '3c5cf428-63c1-4c60-bab9-17d4613992d3',
-            'slug': 'slug',
-        },
+    params = {
+        "q": "albania",
+        'name': 'test',
+        'uuid': source_table.dataset.id,
+        'slug': 'slug',
+    }
+    response = client.post(
+        reverse(
+            'finder:data_grid_results',
+            kwargs={'schema': 'public', 'table': 'country_stats'},
+        )
+        + '?'
+        + urlencode(params),
+        {'limit': 1, 'start': 1},
+        content_type='application/json',
     )
 
     assert response.status_code == 200
-    assert response.context["results"].paginator.num_pages == 3
+    assert response.json() == {
+        'total': 3,
+        'records': [{'country': 'Albania', 'date': '2020-01-13', 'driving': 0.0}],
+    }


### PR DESCRIPTION
Adds a grid to the finder results page.

There are some limitations to the use of the grid due to the our indexes are setup currently.

1. Sort is not supported - we will need to enable this at the index level
2. The number of field level filters have been cut as we would need specific anaylsers setup for each field type (extra work on the elasticsearch side)
    * Available filters are:
        * text: contains/not contains
        * date: equal/not equal, less/greater than, range
        * bool: equals
        * uuid: contains/not contains
3. Fixes an issue where the data grid was expecting a "download json" button that doesn't always exist.

### Screenshot

![2021-09-22_09-15](https://user-images.githubusercontent.com/594496/134307597-79052296-f19f-462e-8162-baaff8d14cb4.png)


