### PR TITLE
fix: use table perm checker in finder results

### DIFF
--- a/dataworkspace/dataworkspace/apps/finder/views.py
+++ b/dataworkspace/dataworkspace/apps/finder/views.py
@@ -42,7 +42,7 @@ def find_datasets(request):
             visible_matches, has_suppressed_tables = _enrich_and_suppress_matches(
                 request, matches
             )
-            results = group_tables_by_master_dataset(visible_matches)
+            results = group_tables_by_master_dataset(visible_matches, request.user)
 
         if search_term:
             log_query(request.user, search_term)

--- a/dataworkspace/dataworkspace/templates/finder/index.html
+++ b/dataworkspace/dataworkspace/templates/finder/index.html
@@ -54,19 +54,21 @@
 
           {% for result in results %}
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            
+
             <h2 class="govuk-heading-m">{{ result.name }}</h2>
+            {% if not result.has_access %}
+                <p class="govuk-body">
+                  You need to <a class="govuk-link govuk-link--no-visited-state" href="{% url 'request_access:dataset' dataset_uuid=result.id %}">request access to view this data</a>.
+                </p>
+            {% endif %}
             {% for table in result.table_matches %}
-              {% if table.has_access %}
+              {% if result.has_access %}
                 <p class="govuk-body govuk-!-margin-bottom-0">
                   <a class="govuk-link--no-visited-state" href="{% url 'finder:show_results' schema=table.schema table=table.table %}?name={{ result.name }}&slug={{ result.slug }}&uuid={{ result.id }}&q={{ search_term }}">
                     {{ table.name }}
                   </a>
                 </p>
               {% else %}
-                <p class="govuk-body">
-                  You need to <a class="govuk-link govuk-link--no-visited-state" href="{% url 'request_access:dataset' dataset_uuid=result.id %}">request access to view this data</a>.
-                </p>
                 <span class="govuk-hint govuk-!-margin-bottom-0">{{ table.name}}</span>
               {% endif %}
               <p class="govuk-body">

--- a/dataworkspace/dataworkspace/tests/finder/test_views.py
+++ b/dataworkspace/dataworkspace/tests/finder/test_views.py
@@ -45,7 +45,9 @@ def test_find_datasets_with_no_results(client, mocker):
 @pytest.mark.django_db(transaction=True)
 @override_flag(settings.DATASET_FINDER_ADMIN_ONLY_FLAG, active=True)
 def test_find_datasets_with_results(client, mocker, dataset_finder_db):
-    user = get_user_model().objects.create(is_staff=True, is_superuser=True)
+    user = get_user_model().objects.create(
+        is_staff=True, is_superuser=True, email='test@test.com'
+    )
     client = Client(**get_http_sso_data(user))
 
     master_dataset = factories.MasterDataSetFactory.create(


### PR DESCRIPTION
### Description of change

Check user's access to a dataset via the `user_has_access` method when showing finder results....

1. Fixes a bug where sometimes the user was shown the "request access" link when they already had access
2. The previous way of checking access does not work for allowed email domains 

### Checklist

* [x] Have tests been added to cover any changes?
