### PR TITLE
fix: get csrf token from from element to fix missing cookie issue

### DIFF
--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -1,16 +1,8 @@
-function getCookie(name) {
-  var cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    const cookies = document.cookie.split(';');
-    for (var i = 0; i < cookies.length; i++) {
-      const cookie = cookies[i].trim();
-      if (cookie.substring(0, name.length + 1) === (name + '=')) {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
+function getCsrfToken() {
+  if (document.getElementsByName('csrfmiddlewaretoken').length > 0) {
+    return document.getElementsByName('csrfmiddlewaretoken')[0].value;
   }
-  return cookieValue;
+  throw new Error('Unable to find CSRF token in the page');
 }
 
 function autoSizeColumns(columnApi) {
@@ -209,7 +201,7 @@ function initDataGrid(columnConfig, dataEndpoint, records, exportFileName) {
         var xhr = new XMLHttpRequest();
         xhr.open('POST', dataEndpoint, true);
         xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
-        xhr.setRequestHeader("X-CSRFToken", getCookie('data_workspace_csrf'));
+        xhr.setRequestHeader("X-CSRFToken", getCsrfToken());
         xhr.onreadystatechange = function() {
           if (this.readyState === XMLHttpRequest.DONE) {
             if (this.status === 200) {
@@ -244,7 +236,7 @@ function initDataGrid(columnConfig, dataEndpoint, records, exportFileName) {
         form.method = 'POST';
         form.enctype = 'application/x-www-form-urlencoded';
 
-        form.append(createInputFormField('csrfmiddlewaretoken', getCookie('data_workspace_csrf')));
+        form.append(createInputFormField('csrfmiddlewaretoken', getCsrfToken()));
         form.append(createInputFormField('export_file_name', exportFileName));
 
         // Define the columns to include in the csv

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -61,4 +61,5 @@
       </div>
     </div>
   </div>
+  {% csrf_token %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
+++ b/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
@@ -94,4 +94,5 @@
       </div>
     </div>
   {% endwith %}
+  {% csrf_token %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -218,5 +218,5 @@
       {% endif %}
     </div>
   </div>
-
+  {% csrf_token %}
 {% endblock %}


### PR DESCRIPTION
### Description of change

The csrf cookie doesn't exist until a user has seen the `{% csrf_token %}` at least once (or visited an admin form). To workaround this, don't use the cookie, get the token from the form element itself.

### Checklist

* [ ] Have tests been added to cover any changes?
