### PR TITLE
add css class for related dashboard link and make headings consistent

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -103,12 +103,12 @@
           {% endif %}
 
           {% if related_visualisations %}
-            <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related visuals</h3>
+            <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related dashboards</h3>
             <nav role="navigation">
               <ul class="govuk-list">
                 {% for master in related_visualisations %}
                   <li>
-                  {% include "partials/related_data_link.html" with dataset=master %}
+                  {% include "partials/related_data_link.html" with dataset=master css_classname="related-dashboard" %}
                 {% endfor %}
                 </li>
               </ul>

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -109,7 +109,7 @@
         </aside>
       {% endif %}
       {% if related_visualisations %}
-        <aside class="app-related-items" role="complementary">
+        <aside class="govuk-!-margin-top-8" role="complementary">
           <h3 class="govuk-heading-s" id="subsection-title">
             Related dashboards
           </h3>
@@ -117,10 +117,7 @@
             <ul class="govuk-list">
               {% for dataset in related_visualisations %}
                 <li>
-                  <a class="govuk-link"
-                    href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
-                    {{ dataset.name }}
-                  </a>
+                  {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
                 </li>
               {% endfor %}
             </ul>

--- a/dataworkspace/dataworkspace/templates/partials/related_data_link.html
+++ b/dataworkspace/dataworkspace/templates/partials/related_data_link.html
@@ -1,2 +1,2 @@
-<a class="govuk-link related-data"
+<a class="govuk-link {% if css_classname %}{{ css_classname }}{% else %}related-data{% endif %}"
    href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}</a>


### PR DESCRIPTION
### Description of change
Added a new css class for related dashboard links from catalogue pages `related-dashboard`. To be used by performance analytics.
Changed `Related visuals` to `Related dashboards` on datacut catalogue template. This makes it consistent with Master dataset.

### Checklist

~* [ ] Have tests been added to cover any changes? No!~
