### PR TITLE
feat: Add local s3 support via localstack

### DIFF
--- a/.envs/sample.env
+++ b/.envs/sample.env
@@ -80,7 +80,7 @@ ZENDESK_SERVICE_FIELD_VALUE=field_value
 NOTIFY_API_KEY=notify-token
 FERNET_EMAIL_TOKEN_KEY=generate-using-fernet-generate-key
 
-UPLOADS_BUCKET=xxx
+UPLOADS_BUCKET=uploads.dataworkspace.local
 MIRROR_REMOTE_ROOT=xxx
 
 X_FORWARDED_FOR_TRUSTED_HOPS=1
@@ -130,9 +130,9 @@ PGAUDIT_LOG_SCOPES='ALL, -MISC'
 PGAUDIT_LOG_TYPE=docker
 DATASETS_DB_INSTANCE_ID=rds-datasets-db-id
 
-DATAFLOW_BASE_URL=https://data-flow-dev.london.cloudapps.digital
-DATAFLOW_HAWK_ID=get-from-vault
-DATAFLOW_HAWK_KEY=get-from-vaule
+DATAFLOW_BASE_URL=http://data-flow:8080
+DATAFLOW_HAWK_ID=local-testing
+DATAFLOW_HAWK_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 DATAFLOW_S3_IMPORT_DAG=DataWorkspaceS3ImportPipeline
 
 DATASET_FINDER_ES_HOST=http://data-workspace-es
@@ -140,3 +140,6 @@ DATASET_FINDER_ES_PORT=9200
 DATASET_FINDER_ES_INSECURE=True
 DATASET_FINDER_AWS_REGION=eu-west-2
 DATASET_FINDER_DB_NAME=my_database
+
+AWS_ENDPOINT_URL=http://data-workspace-localstack:4566
+NOTEBOOKS_BUCKET=notebooks.dataworkspace.local

--- a/README.md
+++ b/README.md
@@ -32,10 +32,37 @@ And the application will be visible at http://dataworkspace.test:8000. This is t
 
 Some parts of the database are managed and populated by [data-flow](https://github.com/uktrade/data-flow/). To ensure there are no issues with some tables being missing, initial setup should include checking out that repo and running the `docker-compose-dw.yml` file, which will perform migrations on the shared Data Workspace/Data Flow DB.
 
+## Running specific services
+
+The dev compose file is split up into a few parts. This is to reduce the amount of resources used locally while developing.
+
+**The Data Workspace UI** (Django, Postgres, Celery, Localstack)
+```bash
+docker-compose -f docker-compose-dev.yml up
+```
+
+**Dataset finder** (elasticsearch)
+```bash
+docker-compose -f docker-compose-dev.yml --profile finder up
+```
+
+**Superset** (see notes below)
+```bash
+docker-compose -f docker-compose-dev.yml --profile superset up
+```
+
+
+**Visualisations** (gitlab)
+```bash
+docker-compose -f docker-compose-dev.yml --profile visualisations up
+```
+
+**All the services**
+```bash
+docker-compose -f docker-compose-dev.yml --profile visualisations --profile superset --profile finder up
+```
 
 ## Running superset locally
-
-There is a separate compose file to run superset as it's not necessary to run it locally all the time.
 
 To get started you will need to create an env file
 
@@ -45,10 +72,10 @@ cp .envs/superset-sample.env .envs/superset.dev.env
 
 Update the new file with your dit email address (must match your SSO email).
 
-Then run docker-compose using both the dev and dev superset compose files
+Then run docker-compose using the superset profile
 
 ```bash
-docker-compose -f docker-compose-dev.yml -f docker-compose-superset-dev.yml up
+docker-compose -f docker-compose-dev.yml --profile superset up
 ```
 
 Initially you will then need to set up the Editor role by running the following script, replacing container-id with the id of the data-workspace-postgres docker container:

--- a/dataworkspace/dataworkspace/apps/api_v1/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/views.py
@@ -241,7 +241,7 @@ def aws_credentials_api_view(request):
 
 
 def aws_credentials_api_GET(request):
-    client = boto3.client('sts')
+    client = boto3.client('sts', endpoint_url=settings.AWS_ENDPOINT_URL)
     role_arn, _ = create_tools_access_iam_role(
         request.user.email,
         str(request.user.profile.sso_id),

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1053,7 +1053,7 @@ def create_tools_access_iam_role(user_email_address, user_sso_id, access_point_i
     if user.profile.tools_access_role_arn:
         return user.profile.tools_access_role_arn, s3_prefix
 
-    iam_client = boto3.client('iam')
+    iam_client = boto3.client('iam', endpoint_url=settings.AWS_ENDPOINT_URL)
 
     assume_role_policy_document = settings.S3_ASSUME_ROLE_POLICY_DOCUMENT
     policy_name = settings.S3_POLICY_NAME

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -49,7 +49,7 @@ class CreateTableForm(GOVUKDesignSystemForm):
 
     def clean_path(self):
         path = self.cleaned_data['path']
-        client = boto3.client('s3')
+        client = boto3.client('s3', endpoint_url=settings.AWS_ENDPOINT_URL)
 
         if not path.startswith(get_s3_prefix(str(self.user.profile.sso_id))):
             raise ValidationError('You don\'t have permission to access this file')

--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -29,7 +29,7 @@ SCHEMA_POSTGRES_DATA_TYPE_MAP = {
 
 
 def get_s3_csv_column_types(path):
-    client = boto3.client('s3')
+    client = boto3.client('s3', endpoint_url=settings.AWS_ENDPOINT_URL)
 
     # Let's just read the first 100KiB of the file and assume that will give us enough lines to make reasonable
     # assumptions about data types. This is an alternative to reading the first ~10 lines, in which case the first line
@@ -122,7 +122,7 @@ def clean_db_identifier(identifier):
 
 
 def copy_file_to_uploads_bucket(from_path, to_path):
-    client = boto3.client('s3')
+    client = boto3.client('s3', endpoint_url=settings.AWS_ENDPOINT_URL)
     client.copy_object(
         CopySource={'Bucket': settings.NOTEBOOKS_BUCKET, 'Key': from_path},
         Bucket=settings.AWS_UPLOADS_BUCKET,

--- a/dataworkspace/dataworkspace/apps/your_files/views.py
+++ b/dataworkspace/dataworkspace/apps/your_files/views.py
@@ -51,16 +51,18 @@ def file_browser_html_view(request):
     )
 
 
-@csp_update(
-    CONNECT_SRC=[settings.APPLICATION_ROOT_DOMAIN, "https://s3.eu-west-2.amazonaws.com"]
-)
+@csp_update(CONNECT_SRC=settings.YOUR_FILES_CONNECT_SRC)
 def file_browser_html_GET(request):
     prefix = get_s3_prefix(str(request.user.profile.sso_id))
 
     return render(
         request,
         'your_files/files.html',
-        {'prefix': prefix, 'bucket': settings.NOTEBOOKS_BUCKET},
+        {
+            'prefix': prefix,
+            'bucket': settings.NOTEBOOKS_BUCKET,
+            'aws_endpoint': settings.FRONTEND_AWS_ENDPOINT_URL,
+        },
         status=200,
     )
 

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -682,3 +682,11 @@ SUPERSET_DOMAINS = {
 }
 
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
+# Localstack
+AWS_ENDPOINT_URL = env.get('AWS_ENDPOINT_URL', None)
+FRONTEND_AWS_ENDPOINT_URL = 'http://localhost:4566' if LOCAL else None
+YOUR_FILES_CONNECT_SRC = [
+    APPLICATION_ROOT_DOMAIN,
+    'https://s3.eu-west-2.amazonaws.com',
+] + (['http://localhost:4566'] if LOCAL else [])

--- a/dataworkspace/dataworkspace/static/explorer-ie11-compat.js
+++ b/dataworkspace/dataworkspace/static/explorer-ie11-compat.js
@@ -16,7 +16,7 @@ function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o =
 
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
 
-function _iterableToArrayLimit(arr, i) { var _i = arr && (typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]); if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
@@ -36,7 +36,7 @@ function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || func
 
 function _createSuper(Derived) { var hasNativeReflectConstruct = _isNativeReflectConstruct(); return function _createSuperInternal() { var Super = _getPrototypeOf(Derived), result; if (hasNativeReflectConstruct) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
 
-function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } return _assertThisInitialized(self); }
+function _possibleConstructorReturn(self, call) { if (call && (_typeof(call) === "object" || typeof call === "function")) { return call; } else if (call !== void 0) { throw new TypeError("Derived constructors may only return object or undefined"); } return _assertThisInitialized(self); }
 
 function _assertThisInitialized(self) { if (self === void 0) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return self; }
 
@@ -149,6 +149,13 @@ angular.module('aws-js-s3-explorer').factory('s3', function (Config) {
     credentials: new Credentials(),
     region: Config.region
   });
+
+  if (Config.endpointUrl) {
+    AWS.config.update({
+      endpoint: Config.endpointUrl
+    });
+  }
+
   return new AWS.S3();
 });
 angular.module('aws-js-s3-explorer').run(function ($rootScope) {

--- a/dataworkspace/dataworkspace/static/explorer.js
+++ b/dataworkspace/dataworkspace/static/explorer.js
@@ -60,6 +60,11 @@ angular.module('aws-js-s3-explorer').factory('s3', (Config) => {
         credentials: new Credentials(),
         region: Config.region
     });
+    if (Config.endpointUrl) {
+      AWS.config.update({
+        endpoint: Config.endpointUrl
+      });
+    }
     return new AWS.S3();
 });
 

--- a/dataworkspace/dataworkspace/templates/your_files/files.html
+++ b/dataworkspace/dataworkspace/templates/your_files/files.html
@@ -338,7 +338,8 @@ close(conn)</pre></code>
             bucket: '{% endverbatim %}{{ bucket }}{% verbatim %}',
             prefix: '{% endverbatim %}{{ prefix }}{% verbatim %}',
             bigdataPrefix: 'bigdata/',
-            credentialsUrl: '{% endverbatim %}{% url 'api_v1:aws-credentials' %}{% verbatim %}'
+            credentialsUrl: '{% endverbatim %}{% url 'api_v1:aws-credentials' %}{% verbatim %}',
+            endpointUrl: '{% endverbatim %}{{ aws_endpoint }}{% verbatim %}'
         };
     });
     </script>

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -175,8 +175,8 @@ def test_csp_on_files_endpoint_includes_s3(client):
 
     policies = get_response_csp_as_set(response)
     assert (
-        "connect-src dataworkspace.test:8000 https://s3.eu-west-2.amazonaws.com"
-        in policies
+        "connect-src dataworkspace.test:8000 https://s3.eu-west-2.amazonaws.com "
+        "http://localhost:4566" in policies
     )
 
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.9"
 services:
   data-workspace:
     build:
@@ -15,10 +15,6 @@ services:
       - AWS_SESSION_TOKEN
       - AWS_SECURITY_TOKEN
     env_file: .envs/dev.env
-    links:
-      - "data-workspace-postgres"
-      - "data-workspace-redis"
-      - "data-workspace-es"
     volumes:
       - ./dataworkspace:/dataworkspace
   data-workspace-celery:
@@ -28,9 +24,6 @@ services:
       target: dev
     image: data-workspace
     env_file: .envs/dev.env
-    links:
-      - "data-workspace-postgres"
-      - "data-workspace-redis"
     command: "/dataworkspace/start-celery-dev.sh"
     volumes:
       - ./dataworkspace:/dataworkspace
@@ -52,6 +45,25 @@ services:
     image: data-workspace-redis
     ports:
       - "6379:6379"
+  data-workspace-localstack:
+    build:
+      context: localstack
+      dockerfile: Dockerfile
+    ports:
+      - "127.0.0.1:53:53"
+      - "127.0.0.1:53:53/udp"
+      - "127.0.0.1:443:443"
+      - "127.0.0.1:4566:4566"
+      - "127.0.0.1:4571:4571"
+    environment:
+      - AWS_DEFAULT_REGION=eu-west-2
+      - EDGE_PORT=4566
+      - SERVICES=s3,sts,iam
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://dataworkspace.test:8000
+    volumes:
+      - "${TMPDIR:-/tmp}/localstack:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
   data-workspace-es:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
     environment:
@@ -59,12 +71,41 @@ services:
       - http.port=9200
     ports:
       - "9200:9200"
+    profiles: ["finder"]
+  data-workspace-superset:
+    build:
+      context: superset
+      dockerfile: Dockerfile
+      target: dev
+    image: data-workspace-superset
+    environment:
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: data-workspace-postgres
+      DB_NAME: superset
+      DB_PORT: 5432
+    env_file:
+      - .envs/superset.dev.env
+    volumes:
+      - ./superset/superset_config.py:/etc/superset/superset_config.py
+    profiles: ["superset"]
 
+  data-workspace-gitlab:
+    image: gitlab/gitlab-ee:latest
+    hostname: gitlab.dataworkspace.test
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://gitlab.dataworkspace.test'
+        # Add any other gitlab.rb configuration here, each on its own line
+    ports:
+      - '8001:80'
+      - '2222:22'
+    profiles: ["visualisations"]
 
 volumes:
   db-data-dev:
   db-logs-dev:
-  
+
 networks:
   default:
     external:

--- a/localstack/Dockerfile
+++ b/localstack/Dockerfile
@@ -1,0 +1,2 @@
+FROM localstack/localstack:latest
+COPY ./init/* /docker-entrypoint-initaws.d/

--- a/localstack/init/buckets.sh
+++ b/localstack/init/buckets.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -x
+awslocal s3 mb s3://notebooks.dataworkspace.local
+awslocal s3 mb s3://uploads.dataworkspace.local
+set +x

--- a/postgres/3-init-functions.sql
+++ b/postgres/3-init-functions.sql
@@ -1,0 +1,22 @@
+\c datasets;
+
+-- Save and drop dependencies
+create or replace function dataflow.save_and_drop_dependencies(p_view_schema character varying, p_view_name character varying) returns void as
+$$
+begin
+end;
+$$
+LANGUAGE plpgsql;
+
+alter function dataflow.save_and_drop_dependencies(varchar, varchar) owner to postgres;
+
+-- Restore Dependencies
+create or replace function dataflow.restore_dependencies(p_view_schema character varying, p_view_name character varying) returns void
+    language plpgsql
+as
+$$
+begin
+end;
+$$;
+
+alter function dataflow.restore_dependencies(varchar, varchar) owner to postgres;

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -5,5 +5,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends postgresql-10-p
 COPY /entrypoint.sh /
 COPY /1-init-libraries.sh /docker-entrypoint-initdb.d/
 COPY /2-init-databases.sql /docker-entrypoint-initdb.d/
+COPY /3-init-functions.sql /docker-entrypoint-initdb.d/
 
 ENTRYPOINT /entrypoint.sh


### PR DESCRIPTION
- Allow for hitting s3 locally for your files
- Config update to allow your files table creation via local data-flow
- Adds missing functions to the datasets db to allow for data-flow integration
- Adds profiles to the def docker compose config. Allowing us to run specific parts of the stack locally, e.g.
  - dataset finder `docker-compose -f docker-compose-dev.yml --profile finder up`
  - superset `docker-compose -f docker-compose-dev.yml --profile superset up`

** you will probably need to update docker-compose to get profiles working