### PR TITLE
fix: prevent users from seeing other user's access request details

### DIFF
--- a/dataworkspace/dataworkspace/apps/request_access/views.py
+++ b/dataworkspace/dataworkspace/apps/request_access/views.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import CreateView, UpdateView, DetailView
@@ -98,7 +98,15 @@ class DatasetAccessRequest(CreateView):
         )
 
 
-class DatasetAccessRequestUpdate(UpdateView):
+class RequestAccessMixin:
+    def dispatch(self, request, *args, **kwargs):
+        access_request = self.get_object()
+        if access_request.requester != request.user:
+            raise Http404
+        return super().dispatch(request, *args, **kwargs)
+
+
+class DatasetAccessRequestUpdate(RequestAccessMixin, UpdateView):
     model = models.AccessRequest
     template_name = 'request_access/dataset.html'
     form_class = DatasetAccessRequestForm
@@ -109,7 +117,7 @@ class DatasetAccessRequestUpdate(UpdateView):
         return reverse('request-access:tools-1', kwargs={"pk": self.object.pk})
 
 
-class ToolsAccessRequestPart1(UpdateView):
+class ToolsAccessRequestPart1(RequestAccessMixin, UpdateView):
     model = models.AccessRequest
     template_name = 'request_access/tools_1.html'
     form_class = ToolsAccessRequestFormPart1
@@ -118,7 +126,7 @@ class ToolsAccessRequestPart1(UpdateView):
         return reverse('request-access:tools-2', kwargs={"pk": self.object.pk})
 
 
-class ToolsAccessRequestPart2(UpdateView):
+class ToolsAccessRequestPart2(RequestAccessMixin, UpdateView):
     model = models.AccessRequest
     template_name = 'request_access/tools_2.html'
     form_class = ToolsAccessRequestFormPart2
@@ -138,7 +146,7 @@ class ToolsAccessRequestPart3(UpdateView):
         return reverse('request-access:summary-page', kwargs={"pk": self.object.pk})
 
 
-class AccessRequestSummaryPage(DetailView):
+class AccessRequestSummaryPage(RequestAccessMixin, DetailView):
     model = models.AccessRequest
     template_name = 'request_access/summary.html'
 
@@ -159,7 +167,7 @@ class AccessRequestSummaryPage(DetailView):
         )
 
 
-class AccessRequestConfirmationPage(DetailView):
+class AccessRequestConfirmationPage(RequestAccessMixin, DetailView):
     model = models.AccessRequest
     template_name = 'request_access/confirmation-page.html'
 


### PR DESCRIPTION
### Description of change

This stops users from accessing other user's access request data by changing the id in the url

### Checklist

* [ ] Have tests been added to cover any changes?
