### PR TITLE
fix: add column details page for datacut queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -679,6 +679,11 @@ class SourceTable(BaseSource):
     def data_grid_download_limit(self):
         return self.data_grid_column_config.get('download_limit', 5000)
 
+    def get_column_details_url(self):
+        return reverse(
+            'datasets:source_table_column_details', args=(self.dataset_id, self.id),
+        )
+
 
 class SourceView(BaseSource):
     view = models.CharField(
@@ -970,6 +975,11 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
     @property
     def data_grid_download_limit(self):
         return None
+
+    def get_column_details_url(self):
+        return reverse(
+            'datasets:custom_query_column_details', args=(self.dataset_id, self.id),
+        )
 
 
 class CustomDatasetQueryTable(models.Model):

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -135,4 +135,9 @@ urlpatterns = [
         {'model_class': models.DataSet},
         name='dataset_visualisation-preview',
     ),
+    path(
+        '<uuid:dataset_uuid>/datacut/<int:query_id>/columns',
+        login_required(views.CustomQueryColumnDetails.as_view()),
+        name='custom_query_column_details',
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1591,3 +1591,29 @@ class DatasetVisualisationView(View):
             'datasets/visualisation.html',
             context={"dataset_uuid": dataset_uuid, "visualisation": visualisation},
         )
+
+
+class CustomQueryColumnDetails(View):
+    def get(self, request, dataset_uuid, query_id):
+        try:
+            dataset = DataSet.objects.get(id=dataset_uuid, type=DataSetType.DATACUT)
+            query = CustomDatasetQuery.objects.get(
+                id=query_id, dataset__id=dataset_uuid
+            )
+        except (DataSet.DoesNotExist, CustomDatasetQuery.DoesNotExist):
+            return HttpResponse(status=404)
+
+        if not dataset.user_has_access(request.user):
+            return HttpResponseForbidden()
+
+        return render(
+            request,
+            'datasets/data_cut_column_details.html',
+            context={
+                'dataset': dataset,
+                'query': query,
+                'columns': datasets_db.get_columns(
+                    query.database.memorable_name, query=query.query, include_types=True
+                ),
+            },
+        )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1603,9 +1603,6 @@ class CustomQueryColumnDetails(View):
         except (DataSet.DoesNotExist, CustomDatasetQuery.DoesNotExist):
             return HttpResponse(status=404)
 
-        if not dataset.user_has_access(request.user):
-            return HttpResponseForbidden()
-
         return render(
             request,
             'datasets/data_cut_column_details.html',

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_column_details.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_column_details.html
@@ -1,0 +1,26 @@
+{% extends '_main.html' %}
+{% load static core_tags %}
+
+{% block page_title %}Columns names and types for "{{ query.name }}" - {{ block.super }}{% endblock %}
+
+{% block go_back %}
+  <a class="govuk-back-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
+    Back
+  </a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Column names and types</h1>
+      <h2 class="govuk-heading-m">{{ query.name }}</h2>
+      <ul class="govuk-list govuk-!-margin-top-9">
+        {% for column, data_type in columns %}
+        <li>
+          <strong>{{ column }}</strong> ({{ data_type }})
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -193,7 +193,7 @@
               <tr class="govuk-table__row">
                 <td colspan="6" class="govuk-table__cell">
                   {% if columns %}
-                    {% include "partials/column_list.html" with columns=columns dataset=dataset source_table=source_table %}
+                    {% include "partials/column_list.html" with columns=columns dataset=dataset source=datacut_link %}
                   {% endif %}
                   {% if code_snippets and has_access %}
                     <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -182,7 +182,7 @@
               <td colspan="4" class="govuk-table__cell">
                 {% if columns %}
                   <div class="govuk-!-margin-bottom-6">
-                  {% include "partials/column_list.html" with columns=columns dataset=dataset source_table=source_table %}
+                  {% include "partials/column_list.html" with columns=columns dataset=dataset source=source_table %}
                   </div>
                 {% endif %}
 

--- a/dataworkspace/dataworkspace/templates/partials/column_list.html
+++ b/dataworkspace/dataworkspace/templates/partials/column_list.html
@@ -3,7 +3,7 @@
       <span class="govuk-details__summary-text">
         View data structure
         <span class="govuk-visually-hidden">
-          for "{{ source_table.schema }}"."{{ source_table.table }}"
+          for {% if source.schema %}"{{ source.schema }}"."{{ source.table }}"{% else %}{{ source.name }}{% endif %}
         </span>
       </span>
   </summary>
@@ -14,11 +14,13 @@
           <strong>{{ column }}</strong> ({{ data_type }})
         </li>
       {% endfor %}
-      {% if columns|length > 12 and dataset and source_table %}
+      {% if columns|length > 12 %}
         <a class="govuk-link"
-           href="{% url 'datasets:source_table_column_details' dataset_uuid=dataset.id table_uuid=source_table.id %}">
+           href="{{ source.get_column_details_url }}">
           View all columns <span
-          class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+          class="govuk-visually-hidden">
+            for {% if source.schema %}"{{ source.schema }}"."{{ source.table }}"{% else %}{{ source.name }}{% endif %}
+        </span>
         </a>
       {% endif %}
     </ul>


### PR DESCRIPTION
### Description of change

Adds a page to show all columns for a data cut custom query.

![Screenshot from 2021-11-05 12-27-00](https://user-images.githubusercontent.com/594496/140510206-cd173c7f-e34d-49f2-9c62-c23198512151.png)

![Screenshot from 2021-11-05 12-27-21](https://user-images.githubusercontent.com/594496/140510211-7d14acf7-7f0d-492f-a4aa-faa89122e3bb.png)


### Checklist

* [x] Have tests been added to cover any changes?
