### PR TITLE
feat: scrolling display of source filter checkboxes

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/templatetags/core_filters.py
+++ b/dataworkspace/dataworkspace/apps/core/templatetags/core_filters.py
@@ -22,7 +22,10 @@ def get_choice_field_data_for_gtm(field: ChoiceField):
     This is intended to be used to pass filters into Google Tag Manager's Data Layer as JSON for
     analytics.
     """
-    return ';'.join(sorted(x.data['label'] for x in field if x.data['selected']))
+
+    # NB: The str() *is* required here as the labels are overridden for scrolling_filter into
+    # a SearchableChoice object
+    return ';'.join(sorted(str(x.data['label']) for x in field if x.data['selected']))
 
 
 @register.filter

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -331,11 +331,7 @@ class DatasetSearchForm(forms.Form):
         self.fields['source'].choices = [
             (
                 source_id,
-                {
-                    'label': source_text,
-                    'count': counts['source'][source_id.value],
-                    'search_text': str(source_text).lower(),
-                },
+                SearchableChoice(source_text, counts['source'][source_id.value]),
             )
             for source_id, source_text in source_choices
             if source_id.value in selected_source_ids
@@ -348,6 +344,16 @@ class DatasetSearchForm(forms.Form):
             if topic_id.value in selected_topic_ids
             or counts['topic'][topic_id.value] != 0
         ]
+
+
+class SearchableChoice:
+    def __init__(self, label, count=0):
+        self.label = label
+        self.count = count
+        self.search_text = str(label).lower()
+
+    def __str__(self):
+        return self.label
 
 
 class RelatedMastersSortForm(forms.Form):

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -53,10 +53,10 @@ class ScrollingFilterWidget(FilterWidget):
         context = super().get_context(name, value, attrs)
 
         selected_count = 0
-        # for _, options, __ in context['widget']['optgroups']:
-        #     for option in options:
-        #         if option['attrs'].get('checked', False):
-        #             selected_count += 1
+        for _, options, __ in context['widget']['optgroups']:
+            for option in options:
+                if option['attrs'].get('checked', False):
+                    selected_count += 1
 
         context['widget']['selected_count'] = selected_count
 

--- a/dataworkspace/dataworkspace/static/data-workspace.css
+++ b/dataworkspace/dataworkspace/static/data-workspace.css
@@ -356,9 +356,20 @@ Comment: https://github.com/alphagov/govuk-design-system-backlog/issues/28#issue
 }
 
 .training-screenshot {
-  content: url("/__django_static/assets/images/rit-screenshot.png")
+  content: url("/__django_static/assets/images/rit-screenshot.png");
 }
 
 .govuk-hint.currently-selected-file {
   font-size: 1rem;
+}
+
+.filter-widget .filter-container {
+  padding-left: 3px;
+}
+
+.filter-widget .filter-container__scrolling {
+  padding-top: 3px;
+  height: 14rem;
+  /*overflow: hidden;*/
+  overflow-y: scroll;
 }

--- a/dataworkspace/dataworkspace/static/gtm-support.js
+++ b/dataworkspace/dataworkspace/static/gtm-support.js
@@ -1,32 +1,38 @@
-;
 function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-};
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
 
-var GTMDatasetSearchSupport = function() {};
+var GTMDatasetSearchSupport = function () {};
 
 GTMDatasetSearchSupport.prototype.pushSearchEvent = function pushSearchEvent() {
-    if (typeof(dataLayer) !== 'undefined') {
-        var update = {
-            "event": "filter",
-            "searchTerms": document.getElementById('search').value,
-            "resultsReturned": parseInt(document.getElementById('search-results-count').textContent),
-        };
+  if (typeof dataLayer !== "undefined") {
+    var update = {
+      event: "filter",
+      searchTerms: document.getElementById("search").value,
+      resultsReturned: parseInt(
+        document.getElementById("search-results-count").textContent
+      ),
+    };
 
-        $("#live-search-form fieldset").map(
-            function () {
-                labels = [];
-                filter_id = $(this).attr('id').replace(/^id_/, "")
-                $(this).find('input[type=checkbox]:checked').map(
-                    function () {
-                        labels.push($("label[for='" + $(this).attr('id') + "']").text().trim());
-                    }
-                );
-                update['filterData' + capitalizeFirstLetter(filter_id)] = labels.sort().join(';')
-            }
-        )
+    $("#live-search-form fieldset").map(function () {
+      var labels = [];
+      var filterId = $(this).attr("id").replace(/^id_/, "");
+      $(this)
+        .find("input[type=checkbox]:checked")
+        .map(function () {
+          // the filter checkboxes have the number of results in brackets
+          // e.g. "Filter (1)"
+          // We remove the brackets and the number before sending to dataLayer
+          var labelText = $("label[for='" + $(this).attr("id") + "']").text();
+          var cleanText = labelText.replaceAll(/\([0-9]+\)/g, "");
+          labels.push(cleanText.trim());
+        });
 
-        dataLayer.push(update);
-    }
+      update["filterData" + capitalizeFirstLetter(filterId)] = labels
+        .sort()
+        .join(";");
+    });
+
+    dataLayer.push(update);
+  }
 };
-;

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -159,6 +159,7 @@ LiveSearch.prototype.showLoadingIndicators = function showLoadingIndicators() {
 };
 
 LiveSearch.prototype.showErrorIndicator = function showErrorIndicator() {
+  this.$wrapper.css("opacity", "1");
   this.$wrapper.text(
     "Error. Please try modifying your search and trying again."
   );

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -1,32 +1,31 @@
-;
-"use strict";
+("use strict");
 
 var ToggleInputClassOnFocus = function ($el) {
-  var $toggleTarget = $el.find('.js-class-toggle')
+  var $toggleTarget = $el.find(".js-class-toggle");
 
   if (!inputIsEmpty()) {
-    addFocusClass()
+    addFocusClass();
   }
 
-  $toggleTarget.on('focus', addFocusClass)
-  $toggleTarget.on('blur', removeFocusClassFromEmptyInput)
+  $toggleTarget.on("focus", addFocusClass);
+  $toggleTarget.on("blur", removeFocusClassFromEmptyInput);
 
-  function inputIsEmpty () {
-    return $toggleTarget.val() === ''
+  function inputIsEmpty() {
+    return $toggleTarget.val() === "";
   }
 
-  function addFocusClass () {
-    $toggleTarget.addClass('focus')
+  function addFocusClass() {
+    $toggleTarget.addClass("focus");
   }
 
-  function removeFocusClassFromEmptyInput () {
+  function removeFocusClassFromEmptyInput() {
     if (inputIsEmpty()) {
-      $toggleTarget.removeClass('focus')
+      $toggleTarget.removeClass("focus");
     }
   }
-}
+};
 
-var LiveSearch = function(formSelector, wrapperSelector, GTM){
+var LiveSearch = function (formSelector, wrapperSelector, GTM) {
   this.wrapperSelector = wrapperSelector;
   this.$wrapper = $(wrapperSelector);
   this.$form = $(formSelector);
@@ -40,25 +39,23 @@ var LiveSearch = function(formSelector, wrapperSelector, GTM){
   this.saveState();
 
   this.$form.on(
-    'change', 'input[type=checkbox], input[type=search], select',
+    "change",
+    "input[type=checkbox], input[type=search], select",
     this.formChange.bind(this)
   );
-  this.$form.on(
-    'search', 'input[type=search]',
-    this.formChange.bind(this)
-  );
-  $(window).on('popstate', this.popState.bind(this));
+  this.$form.on("search", "input[type=search]", this.formChange.bind(this));
+  $(window).on("popstate", this.popState.bind(this));
 
-  this.$form.find('input[type=submit]').click(
-    function(e){
+  this.$form.find("input[type=submit]").click(
+    function (e) {
       this.formChange();
       e.preventDefault();
     }.bind(this)
   );
 
-  this.$form.find('input[type=search]').keypress(
-    function(e){
-      if(e.keyCode == 13) {
+  this.$form.find("input[type=search]").keypress(
+    function (e) {
+      if (e.keyCode == 13) {
         // 13 is the return key
         this.formChange();
         e.preventDefault();
@@ -66,24 +63,24 @@ var LiveSearch = function(formSelector, wrapperSelector, GTM){
     }.bind(this)
   );
 
-  this.$form.find('select').change(
-    function(e){
+  this.$form.find("select").change(
+    function (e) {
       this.formChange();
       e.preventDefault();
     }.bind(this)
   );
-}
+};
 
-LiveSearch.prototype.saveState = function saveState(state){
-  if(typeof state === 'undefined'){
+LiveSearch.prototype.saveState = function saveState(state) {
+  if (typeof state === "undefined") {
     state = this.$form.serializeArray();
   }
   this.previousState = this.state;
   this.state = state;
 };
 
-LiveSearch.prototype.popState = function popState(event){
-  if(event.originalEvent.state){
+LiveSearch.prototype.popState = function popState(event) {
+  if (event.originalEvent.state) {
     this.saveState(event.originalEvent.state);
   } else {
     this.saveState(this.originalState);
@@ -95,35 +92,41 @@ LiveSearch.prototype.popState = function popState(event){
   this.updateResults();
 };
 
-LiveSearch.prototype.formChange = function formChange(e){
+LiveSearch.prototype.formChange = function formChange(e) {
   var pageUpdated;
-  if(this.isNewState()){
+  if (this.isNewState()) {
     this.saveState();
     pageUpdated = this.updateResults();
     pageUpdated.done(
-      function(){
-        if (typeof(this.GTM) !== 'undefined') {this.GTM.pushSearchEvent();}
+      function () {
+        if (typeof this.GTM !== "undefined") {
+          this.GTM.pushSearchEvent();
+        }
 
-        var newPath = window.location.origin + this.$form.attr('action') + "?" + $.param(this.state);
-        history.pushState(this.state, '', newPath);
+        var newPath =
+          window.location.origin +
+          this.$form.attr("action") +
+          "?" +
+          $.param(this.state);
+        history.pushState(this.state, "", newPath);
       }.bind(this)
     );
   }
 };
 
 LiveSearch.prototype.cache = function cache(slug, data) {
-  if(typeof data === 'undefined'){
+  if (typeof data === "undefined") {
     return this.resultsCache[slug];
   } else {
     this.resultsCache[slug] = data;
   }
 };
 
-LiveSearch.prototype.isNewState = function isNewState(){
+LiveSearch.prototype.isNewState = function isNewState() {
   return $.param(this.state) !== this.$form.serialize();
 };
 
-LiveSearch.prototype.updateResults = function updateResults(){
+LiveSearch.prototype.updateResults = function updateResults() {
   this.showLoadingIndicators();
 
   var self = this;
@@ -131,17 +134,19 @@ LiveSearch.prototype.updateResults = function updateResults(){
   var liveState = this.$form.serializeArray();
   var cachedResultData = this.cache(searchState);
 
-  if(typeof(cachedResultData) === 'undefined') {
+  if (typeof cachedResultData === "undefined") {
     return $.ajax({
-      url: this.$form.attr('action'),
+      url: this.$form.attr("action"),
       data: $.param(liveState),
-      searchState: searchState
-    }).done(function(response){
-      self.cache(this.searchState, response);
-      self.displayFilterResults(response, this.searchState);
-    }).fail(function(response){
-      self.showErrorIndicator();
-    });
+      searchState: searchState,
+    })
+      .done(function (response) {
+        self.cache(this.searchState, response);
+        self.displayFilterResults(response, this.searchState);
+      })
+      .fail(function (response) {
+        self.showErrorIndicator();
+      });
   } else {
     this.displayFilterResults(cachedResultData, searchState);
     var out = new $.Deferred();
@@ -150,75 +155,135 @@ LiveSearch.prototype.updateResults = function updateResults(){
 };
 
 LiveSearch.prototype.showLoadingIndicators = function showLoadingIndicators() {
-  this.$wrapper.css('opacity', '0.25')
-}
-
-LiveSearch.prototype.showErrorIndicator = function showErrorIndicator() {
-  this.$wrapper.text('Error. Please try modifying your search and trying again.');
-}
-
-LiveSearch.prototype.displayFilterResults = function displayFilterResults(response, state) {
-  if(state == $.param(this.state) && state !== "") {
-    this.replaceBlock(this.wrapperSelector, $(response).find(this.wrapperSelector).html());
-  }
-
-  this.$wrapper.css('opacity', '1')
-
-  if (window.installFilterShowMore !== undefined) {
-      // Hook into app-filter-show-more-v2.js to un-hide the "show more" button on search filters.
-      window.installFilterShowMore();
-  }
-}
-
-LiveSearch.prototype.replaceBlock = function replaceBlock(selector, html) {
-  var currentActiveElement = document.activeElement ? document.activeElement.id : null;
-  $(selector).html(html);
-  if (currentActiveElement !== null && document.getElementById(currentActiveElement) !== null) {
-    document.getElementById(currentActiveElement).focus();
-  }
-}
-
-LiveSearch.prototype.restoreBooleans = function restoreBooleans(){
-  var that = this;
-  this.$form.find('input[type=checkbox], input[type=radio]').each(function(i, el){
-    var $el = $(el);
-    $el.prop('checked', that.isBooleanSelected($el.attr('name'), $el.attr('value')));
-  });
+  this.$wrapper.css("opacity", "0.25");
 };
 
-LiveSearch.prototype.isBooleanSelected = function isBooleanSelected(name, value){
+LiveSearch.prototype.showErrorIndicator = function showErrorIndicator() {
+  this.$wrapper.text(
+    "Error. Please try modifying your search and trying again."
+  );
+};
+
+LiveSearch.prototype.displayFilterResults = function displayFilterResults(
+  response,
+  state
+) {
+  if (state == $.param(this.state) && state !== "") {
+    this.replaceBlock(
+      this.wrapperSelector,
+      $(response).find(this.wrapperSelector).html()
+    );
+  }
+
+  this.$wrapper.css("opacity", "1");
+
+  if (window.installFilterShowMore !== undefined) {
+    // Hook into app-filter-show-more-v2.js to un-hide the "show more" button on search filters.
+    window.installFilterShowMore();
+  }
+
+  if (typeof window.installFilterTextSearch === "function") {
+    window.installFilterTextSearch();
+  }
+};
+
+LiveSearch.prototype.replaceBlock = function replaceBlock(selector, html) {
+  var currentActiveElement = document.activeElement
+    ? document.activeElement.id
+    : null;
+  $(selector).html(html);
+  if (
+    currentActiveElement !== null &&
+    document.getElementById(currentActiveElement) !== null
+  ) {
+    document.getElementById(currentActiveElement).focus();
+  }
+};
+
+LiveSearch.prototype.restoreBooleans = function restoreBooleans() {
+  var that = this;
+  this.$form
+    .find("input[type=checkbox], input[type=radio]")
+    .each(function (i, el) {
+      var $el = $(el);
+      $el.prop(
+        "checked",
+        that.isBooleanSelected($el.attr("name"), $el.attr("value"))
+      );
+    });
+};
+
+LiveSearch.prototype.isBooleanSelected = function isBooleanSelected(
+  name,
+  value
+) {
   var i, _i;
-  for(i=0,_i=this.state.length; i<_i; i++){
-    if(this.state[i].name === name && this.state[i].value === value){
+  for (i = 0, _i = this.state.length; i < _i; i++) {
+    if (this.state[i].name === name && this.state[i].value === value) {
       return true;
     }
   }
   return false;
 };
 
-LiveSearch.prototype.restoreSearchInputs = function restoreSearchInputs(){
+LiveSearch.prototype.restoreSearchInputs = function restoreSearchInputs() {
   var that = this;
-  this.$form.find('input[type=search]').each(function(i, el){
+  this.$form.find("input[type=search]").each(function (i, el) {
     var $el = $(el);
-    $el.val(that.getTextInputValue($el.attr('name')));
+    $el.val(that.getTextInputValue($el.attr("name")));
   });
 };
 
-LiveSearch.prototype.restoreSortSelect = function restoreSortSelect(){
+LiveSearch.prototype.restoreSortSelect = function restoreSortSelect() {
   var that = this;
-  this.$form.find('select').each(function(i, el){
+  this.$form.find("select").each(function (i, el) {
     var $el = $(el);
-    $el.val(that.getTextInputValue($el.attr('name')));
+    $el.val(that.getTextInputValue($el.attr("name")));
   });
 };
 
-LiveSearch.prototype.getTextInputValue = function getTextInputValue(name){
+LiveSearch.prototype.getTextInputValue = function getTextInputValue(name) {
   var i, _i;
-  for(i=0,_i=this.state.length; i<_i; i++){
-    if(this.state[i].name === name){
-      return this.state[i].value
+  for (i = 0, _i = this.state.length; i < _i; i++) {
+    if (this.state[i].name === name) {
+      return this.state[i].value;
     }
   }
-  return '';
+  return "";
+};
+
+function attachTextFilter($text) {
+  var targetId = $($text).attr("data-target");
+  var target = $("#" + targetId);
+
+  var $items = $(".search-target", target);
+
+  function filterOn(value) {
+    $($items).each(function (i, e) {
+      var searchText = $(e).attr("data-item-seach-text");
+      if (searchText.indexOf(value) >= 0) {
+        $(e).show();
+      } else {
+        $(e).hide();
+      }
+    });
+  }
+
+  $($text)
+    .on("keyup", function () {
+      var value = $(this).val().toLocaleLowerCase();
+      filterOn(value);
+    })
+    .on("search", function () {
+      var value = $(this).val().toLocaleLowerCase();
+      filterOn(value);
+    });
 }
-;
+
+function installFilterTextSearch() {
+  $("[data-module='filter-search']").each(function (i, e) {
+    attachTextFilter(e);
+  });
+}
+
+installFilterTextSearch();

--- a/dataworkspace/dataworkspace/templates/datasets/scrolling_filter.html
+++ b/dataworkspace/dataworkspace/templates/datasets/scrolling_filter.html
@@ -1,0 +1,37 @@
+{% with id=widget.attrs.id %}
+  <div class="filter-widget">
+    <div class="govuk-form-group">
+      <fieldset{% if id %} id="{{ id }}"{% endif %} class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          <h3 class="govuk-fieldset__heading">{{ widget.group_label }}</h3>
+        </legend>
+        {% if widget.hint_text %}
+          <span id="{{ id }}-hint" class="govuk-hint">
+        {{ widget.hint_text }}
+      </span>
+        {% endif %}
+        {% if widget.selected_count %}
+          <span id="{{ id }}-selected-count" class="govuk-hint">
+          {{ widget.selected_count }} selected</span>
+        {% endif %}
+
+        <div class="search-container govuk-!-margin-bottom-4">
+          <input class="govuk-input" type="search" id="filter_text_{{ id }}"
+                 data-target="filter_text_target_{{ id }}"
+                 data-module="filter-search" />
+        </div>
+
+        <div class="filter-container filter-container__scrolling">
+          <div class="govuk-checkboxes" id="filter_text_target_{{ id }}">
+            {% for group, options, index in widget.optgroups %}
+              {% for option in options %}
+                {% include option.template_name with widget=option hidden=False %}
+              {% endfor %}
+            {% endfor %}
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <hr class="govuk-section-break govuk-section-break--visible"/>
+  </div>
+{% endwith %}

--- a/dataworkspace/dataworkspace/templates/datasets/scrolling_filter_option.html
+++ b/dataworkspace/dataworkspace/templates/datasets/scrolling_filter_option.html
@@ -1,0 +1,7 @@
+<div class="search-target govuk-checkboxes__item {% if hidden %}app-js-hidden{% endif %}" data-item-seach-text="{{ widget.label.search_text }}">
+  <input class="govuk-checkboxes__input" name="{{ widget.name }}" type="checkbox" {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %}>
+
+  <label class="govuk-label govuk-checkboxes__label" for="{{ widget.attrs.id }}">
+    {{ widget.label.label }} ({{ widget.label.count }})
+  </label>
+</div>


### PR DESCRIPTION
### Description of change
- Changed source list on search page to a scrolling container.
- Fix to GTM client side dataLayer pushes. No longer sends the `(2)` part of the filter labels

![2021-11-07 15 48 39](https://user-images.githubusercontent.com/2064710/140774855-c4dd799b-61fa-4096-95a7-fa09ec592ccb.gif)


### Checklist

~* [ ] Have tests been added to cover any changes?~
