### PR TITLE
fix: avoid exception in Java programs when hostname is not resolvable

### DIFF
--- a/tools/jupyterlab-python/start.sh
+++ b/tools/jupyterlab-python/start.sh
@@ -5,6 +5,9 @@ chown -R jovyan:jovyan /home/jovyan
 
 set -e
 
+# Java programs can error if $HOSTNAME is not resolvable
+echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+
 sudo -E -H -u jovyan jupyter \
 	lab \
 	--config=/etc/jupyter/jupyter_notebook_config.py \

--- a/tools/theia/Dockerfile
+++ b/tools/theia/Dockerfile
@@ -30,6 +30,8 @@ RUN \
 		build-essential \
 		git \
 		curl \
+		python2.7 \
+		python2.7-dev \
 		python3 \
 		python3-dev \
 		python3-pip \
@@ -44,7 +46,7 @@ RUN \
 
 RUN \
 	update-alternatives --install /usr/bin/python python /usr/bin/python3 2 && \
-	update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+	update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
 
 COPY requirements.txt python-setup.sh /root/
 

--- a/tools/theia/start.sh
+++ b/tools/theia/start.sh
@@ -5,6 +5,9 @@ chown -R theia:theia /home/theia
 
 set -e
 
+# Java programs can error if $HOSTNAME is not resolvable
+echo "127.0.0.1 $HOSTNAME" >> /etc/hosts
+
 sudo -E -H -u theia yarn theia start /home/theia \
 	--plugins=local-dir:/root/plugins \
 	--hostname=0.0.0.0 \


### PR DESCRIPTION
### Description of change

This is to get pyspark working, which uses Java under the hood, which raises an exception if $HOSTNAME is not resolvable, which is the case in tools

### Checklist

* [ ] Have tests been added to cover any changes?
