### PR TITLE
fix: bump psycopg2 in anticipation of M1 compatible changes

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -323,7 +323,7 @@ psycogreen==1.0.2
     # via
     #   -r requirements.txt
     #   django-db-geventpool
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.2
     # via
     #   -r requirements.txt
     #   aiopg

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,7 @@ psycogreen==1.0.2
     # via
     #   -r requirements.in
     #   django-db-geventpool
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.2
     # via -r requirements.in
 pycparser==2.20
     # via cffi


### PR DESCRIPTION
### Description of change
minor version update to psycopg2-binary. Doing this in advance of making changes to containers and packages for Apple M1 compatibility 

### Checklist

~* [ ] Have tests been added to cover any changes?~
