### PR TITLE
feature:add sso user id to google analytics

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -592,7 +592,7 @@ def find_datasets(request):
             "data_type": dict(data_types),
             "show_admin_filters": has_unpublished_dataset_access(request.user),
             "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
-            "sso_user_id": request.META['HTTP_SSO_PROFILE_USER_ID']
+            "sso_user_id": request.META['HTTP_SSO_PROFILE_USER_ID'],
         },
     )
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -592,6 +592,7 @@ def find_datasets(request):
             "data_type": dict(data_types),
             "show_admin_filters": has_unpublished_dataset_access(request.user),
             "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
+            "sso_user_id": request.META['HTTP_SSO_PROFILE_USER_ID']
         },
     )
 

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -17,6 +17,7 @@
   <script nonce="{{ request.csp_nonce }}">
     dataLayer.push(
       {
+        "UserId": "{{ sso_user_id }}",
         "event": "filter",
         "searchTerms": "{{ query }}",
         "resultsReturned": {{ datasets.paginator.count }},

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -17,7 +17,7 @@
   <script nonce="{{ request.csp_nonce }}">
     dataLayer.push(
       {
-        "UserId": "{{ sso_user_id }}",
+        "userId": "{{ sso_user_id }}",
         "event": "filter",
         "searchTerms": "{{ query }}",
         "resultsReturned": {{ datasets.paginator.count }},


### PR DESCRIPTION
add sso user id to google analytics. This is to track new users of data workspace and the actions they complete, so we can track value for money for the comms and engagement campaign. 

### Checklist

* [ ] ~Have tests been added to cover any changes?~
