### PR TITLE
feat: new management commands to create datasets and tags for local dev

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_dataset.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_dataset.py
@@ -1,0 +1,71 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from dataworkspace.apps.datasets.constants import DataSetType
+from dataworkspace.apps.datasets.management.commands._create_utils import (
+    create_fake_dataset,
+    create_fake_visualisation_dataset,
+    create_fake_reference_dataset,
+    get_random_tag,
+)
+
+
+class Command(BaseCommand):
+    help = "Creates a dataset. Will use fake values and create users if needed"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "type",
+            type=str,
+            help="Which type of dataset to create - [MASTER, REFERENCE, DATACUT, VISUALISATION]",
+        )
+
+        parser.add_argument(
+            "count",
+            type=int,
+            nargs="?",
+            default=1,
+            help="The number of datasets to create (default 1)",
+        )
+
+        parser.add_argument(
+            "-t",
+            "--tag",
+            action="store_true",
+            help="Assign the dataset to a random tag if any exist",
+        )
+
+    def handle(self, *args, **options):
+
+        dataset_type_text = options["type"].upper()
+
+        if dataset_type_text not in DataSetType.__members__:
+            self.stderr.write(
+                self.style.ERROR(f"{options['type']} is not a valid DataSetType")
+            )
+            self.print_help("manage.py", "create_fake_dataset")
+            sys.exit(1)
+
+        dataset_type = DataSetType[dataset_type_text]
+        count = options["count"]
+        should_add_tag = options["tag"]
+
+        for x in range(count):
+            if dataset_type is DataSetType.VISUALISATION:
+                catalogue_item = create_fake_visualisation_dataset()
+            elif dataset_type is DataSetType.REFERENCE:
+                catalogue_item = create_fake_reference_dataset()
+            else:
+                catalogue_item = create_fake_dataset(dataset_type=dataset_type)
+
+            if should_add_tag:
+                tag = get_random_tag()
+                catalogue_item.tags.add(tag)
+                catalogue_item.save()
+
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"{x+1:02}: created new {dataset_type.name} dataset {catalogue_item.name} {catalogue_item.id}"
+                )
+            )

--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_dataset.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_dataset.py
@@ -59,13 +59,16 @@ class Command(BaseCommand):
             else:
                 catalogue_item = create_fake_dataset(dataset_type=dataset_type)
 
+            tag_msg = ""
+
             if should_add_tag:
                 tag = get_random_tag()
                 catalogue_item.tags.add(tag)
                 catalogue_item.save()
+                tag_msg = f" using tag {tag.name}"
 
             self.stdout.write(
                 self.style.SUCCESS(
-                    f"{x+1:02}: created new {dataset_type.name} dataset {catalogue_item.name} {catalogue_item.id}"
+                    f"{x + 1:02}: created new {dataset_type.name} dataset {catalogue_item.name} {catalogue_item.id}{tag_msg}"
                 )
             )

--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_tag.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/create_fake_tag.py
@@ -1,0 +1,50 @@
+import sys
+from faker import Faker  # noqa
+from django.core.management.base import BaseCommand
+
+from dataworkspace.apps.datasets.constants import TagType
+from dataworkspace.apps.datasets.models import Tag
+
+fake = Faker("en-GB")
+
+
+class Command(BaseCommand):
+    help = "Creates a tag using fake data"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "type", type=str, help="Which type of tag to create - [SOURCE, TOPIC]",
+        )
+
+        parser.add_argument(
+            "count",
+            type=int,
+            nargs="?",
+            default=1,
+            help="The number of tags to create (default 1)",
+        )
+
+    def handle(self, *args, **options):
+        tag_type_text = options["type"].upper()
+
+        if tag_type_text not in TagType.__members__:
+            self.stderr.write(
+                self.style.ERROR(f"{options['type']} is not a valid TagType")
+            )
+            self.print_help("manage.py", "create_fake_dataset")
+            sys.exit(1)
+
+        tag_type = TagType[tag_type_text]
+        count = options["count"]
+
+        for x in range(count):
+            name = fake.company()
+
+            tag, created = Tag.objects.get_or_create(name=name, type=tag_type)
+
+            if created:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"{x+1:02}: created new {tag_type.name} tag {name} {tag.id}"
+                    )
+                )


### PR DESCRIPTION
### Description of change
2 new management commands for use with local development
`create_fake_dataset` will create a dataset using fake data
`create_fake_tag` creates a tag. Again with fake data

Use the `--help` command line option to see usage.

### Checklist

~* [ ] Have tests been added to cover any changes?~
