### PR TITLE
fix: pass datetime object in isoformat to send_email function

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -652,7 +652,7 @@ def send_notification_emails():
                             email_address,
                             personalisation={
                                 "dataset_name": dataset_name,
-                                "change_date": change_date,
+                                "change_date": change_date.isoformat(),
                             },
                         )
                     except EmailSendFailureException:

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -916,7 +916,9 @@ class TestSendNotificationEmails:
                 "frank.exampleson@test.com",
                 personalisation={
                     "dataset_name": ds.name,
-                    "change_date": datetime.datetime(2021, 1, 1, 0, 0).replace(tzinfo=pytz.UTC),
+                    "change_date": datetime.datetime(2021, 1, 1, 0, 0)
+                    .replace(tzinfo=pytz.UTC)
+                    .isoformat(),
                 },
             )
         ]
@@ -959,7 +961,9 @@ class TestSendNotificationEmails:
                 "frank.exampleson@test.com",
                 personalisation={
                     "dataset_name": ds.name,
-                    "change_date": datetime.datetime(2021, 1, 1, 0, 0).replace(tzinfo=pytz.UTC),
+                    "change_date": datetime.datetime(2021, 1, 1, 0, 0)
+                    .replace(tzinfo=pytz.UTC)
+                    .isoformat(),
                 },
             )
         ]
@@ -1010,7 +1014,9 @@ class TestSendNotificationEmails:
                 "frank.exampleson@test.com",
                 personalisation={
                     "dataset_name": ds.name,
-                    "change_date": datetime.datetime(2021, 1, 1, 1, 0).replace(tzinfo=pytz.UTC),
+                    "change_date": datetime.datetime(2021, 1, 1, 1, 0)
+                    .replace(tzinfo=pytz.UTC)
+                    .isoformat(),
                 },
             ),
         ]
@@ -1137,7 +1143,9 @@ class TestSendNotificationEmails:
                 "frank.exampleson@test.com",
                 personalisation={
                     "dataset_name": ds.name,
-                    "change_date": datetime.datetime(2021, 1, 1, 1, 0).replace(tzinfo=pytz.UTC),
+                    "change_date": datetime.datetime(2021, 1, 1, 1, 0)
+                    .replace(tzinfo=pytz.UTC)
+                    .isoformat(),
                 },
             )
         ]


### PR DESCRIPTION
### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
