### PR TITLE
feat: allow data-uris for scripts and styles in tools and visualisations

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -140,8 +140,8 @@ async def async_main():
             f"frame-ancestors 'self' {root_domain} {public_host}.{root_domain};"
             "img-src 'self' data: blob:;"
             # Both JupyterLab and RStudio need `unsafe-eval`
-            "script-src 'unsafe-inline' 'unsafe-eval' 'self';"
-            "style-src 'unsafe-inline' 'self';"
+            "script-src 'unsafe-inline' 'unsafe-eval' 'self' data:;"
+            "style-src 'unsafe-inline' 'self' data:;"
             "worker-src 'self' blob:;"
         )
 


### PR DESCRIPTION
### Description of change

We already allow unsafe-inline, so I don't think this meaningfully decreases security. And the main purpose the the CSP for tools and visualisations is to forbid connections to external sites, which this doesn't make any more possible.

### Checklist

* [ ] Have tests been added to cover any changes?
