### PR TITLE
fix: incorrect case for SSO_USER_ID on catalogue index page

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/utils.py
+++ b/dataworkspace/dataworkspace/apps/accounts/utils.py
@@ -91,4 +91,4 @@ def _process_user_access_profile(user, access_profile_name, func):
         response.raise_for_status()
     except Exception as e:
         logger.exception(e)
-        raise SSOApiException
+        raise SSOApiException from None

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -17,7 +17,7 @@
   <script nonce="{{ request.csp_nonce }}">
     dataLayer.push(
       {
-        "userId": "{{ sso_user_id }}",
+        "userId": "{{ SSO_USER_ID }}",
         "event": "filter",
         "searchTerms": "{{ query }}",
         "resultsReturned": {{ datasets.paginator.count }},


### PR DESCRIPTION
### Description of change
- Updated catalogue index page to use the correct case for `SSO_USER_ID`

### Checklist

~* [ ] Have tests been added to cover any changes?~
