### PR TITLE
Feature/additional user data points

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
@@ -3,6 +3,28 @@ from rest_framework import serializers
 
 
 class UserSerializer(serializers.ModelSerializer):
+    user_permissions_subset = serializers.SerializerMethodField()
+    user_sso = serializers.SerializerMethodField("get_user_sso")
+
     class Meta:
         model = get_user_model()
-        fields = ("id", "email", "first_name", "last_name", "is_superuser", "is_staff")
+        fields = ("id", "email", "first_name", "last_name", "is_superuser", "is_staff", "user_permissions_subset", "user_sso")
+
+    def get_user_permissions_subset(self, user):
+        perms_to_check = ["develop_visualisations", "access_appstream", "access_quicksight", "start_all_applications"]
+        user_permissions_subset = user.user_permissions.filter(
+            codename__in=perms_to_check
+        )
+        output = {
+            perm: False
+            for perm in perms_to_check
+        }
+        for permission in user_permissions_subset:
+            codename = permission.codename
+            if codename in perms_to_check:
+                output[codename] = True
+        return output
+
+    def get_user_sso(self, user):
+        return user.profile.sso_id.hex
+

--- a/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
@@ -8,17 +8,28 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = get_user_model()
-        fields = ("id", "email", "first_name", "last_name", "is_superuser", "is_staff", "user_permissions_subset", "user_sso")
+        fields = (
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "is_superuser",
+            "is_staff",
+            "user_permissions_subset",
+            "user_sso",
+        )
 
     def get_user_permissions_subset(self, user):
-        perms_to_check = ["develop_visualisations", "access_appstream", "access_quicksight", "start_all_applications"]
+        perms_to_check = [
+            "develop_visualisations",
+            "access_appstream",
+            "access_quicksight",
+            "start_all_applications",
+        ]
         user_permissions_subset = user.user_permissions.filter(
             codename__in=perms_to_check
         )
-        output = {
-            perm: False
-            for perm in perms_to_check
-        }
+        output = {perm: False for perm in perms_to_check}
         for permission in user_permissions_subset:
             codename = permission.codename
             if codename in perms_to_check:

--- a/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
@@ -26,9 +26,7 @@ class UserSerializer(serializers.ModelSerializer):
             "access_quicksight",
             "start_all_applications",
         ]
-        user_permissions_subset = user.user_permissions.filter(
-            codename__in=perms_to_check
-        )
+        user_permissions_subset = user.user_permissions.filter(codename__in=perms_to_check)
         output = {perm: False for perm in perms_to_check}
         for permission in user_permissions_subset:
             codename = permission.codename

--- a/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/accounts/serializers.py
@@ -27,4 +27,3 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_user_sso(self, user):
         return user.profile.sso_id.hex
-

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
@@ -1,7 +1,6 @@
 import pytest
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from rest_framework.serializers import Serializer
 
 from dataworkspace.tests import factories
 from dataworkspace.apps.api_v1.accounts.serializers import UserSerializer
@@ -39,4 +38,3 @@ class TestUserSerializer:
             "start_all_applications": False,
             "access_appstream": True,
         }
-

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
@@ -1,0 +1,45 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.serializers import Serializer
+
+from dataworkspace.tests import factories
+from dataworkspace.apps.api_v1.accounts.serializers import UserSerializer
+from dataworkspace.apps.applications.models import ApplicationInstance
+
+
+@pytest.mark.django_db
+class TestUserSerializer:
+    factory = factories.UserFactory
+
+    def test_permissions_subset_is_all_false(self):
+        user = self.factory()
+        serializer = UserSerializer(user)
+        serialized_data = serializer.data
+        user_permissions_subset = serialized_data["user_permissions_subset"]
+        assert user_permissions_subset == {
+            "develop_visualisations": False,
+            "access_quicksight": False,
+            "start_all_applications": False,
+            "access_appstream": False,
+        }
+
+    def test_permissions_subset_can_access_appstream(self):
+        user = self.factory()
+        permission = Permission.objects.create(
+            codename="access_appstream",
+            content_type=ContentType.objects.get_for_model(user),
+        )
+        user.user_permissions.add(permission)
+        serializer = UserSerializer(user)
+        serialized_data = serializer.data
+        user_permissions_subset = serialized_data["user_permissions_subset"]
+        assert user_permissions_subset == {
+            "develop_visualisations": False,
+            "access_quicksight": False,
+            "start_all_applications": False,
+            "access_appstream": True,
+        }
+
+    def test_user_sso(self):
+        user = self.factory()

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_serializers.py
@@ -5,7 +5,6 @@ from rest_framework.serializers import Serializer
 
 from dataworkspace.tests import factories
 from dataworkspace.apps.api_v1.accounts.serializers import UserSerializer
-from dataworkspace.apps.applications.models import ApplicationInstance
 
 
 @pytest.mark.django_db
@@ -41,5 +40,3 @@ class TestUserSerializer:
             "access_appstream": True,
         }
 
-    def test_user_sso(self):
-        user = self.factory()

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
@@ -10,9 +10,7 @@ from dataworkspace.tests.api_v1.base import BaseAPIViewTest
 class TestUserAPIView(BaseAPIViewTest):
     url = reverse("api-v1:account:users")
     factory = factories.UserFactory
-    pagination_class = (
-        "dataworkspace.apps.api_v1.accounts.views.UserCursorPagination.page_size"
-    )
+    pagination_class = "dataworkspace.apps.api_v1.accounts.views.UserCursorPagination.page_size"
 
     def expected_response(self, user):
         return {

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
@@ -10,7 +10,9 @@ from dataworkspace.tests.api_v1.base import BaseAPIViewTest
 class TestUserAPIView(BaseAPIViewTest):
     url = reverse("api-v1:account:users")
     factory = factories.UserFactory
-    pagination_class = "dataworkspace.apps.api_v1.accounts.views.UserCursorPagination.page_size"
+    pagination_class = (
+        "dataworkspace.apps.api_v1.accounts.views.UserCursorPagination.page_size"
+    )
 
     def expected_response(self, user):
         return {

--- a/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/accounts/test_views.py
@@ -20,6 +20,13 @@ class TestUserAPIView(BaseAPIViewTest):
             "last_name": user.last_name,
             "is_staff": user.is_staff,
             "is_superuser": user.is_superuser,
+            "user_permissions_subset": {
+                "develop_visualisations": False,
+                "access_appstream": False,
+                "access_quicksight": False,
+                "start_all_applications": False,
+            },
+            "user_sso": user.profile.sso_id.hex,
         }
 
     def test_success(self, unauthenticated_client):


### PR DESCRIPTION
### Description of change

[Link to trello ticket](https://trello.com/c/72lKECMW/728-data-workspace-users-dataset-additional-data-points)

- adds four user permissions to the UserSerializer class: develop visualisations, access appstream, access quicksight and start all applications (aka in the trello ticket: can a user start all local tools).

- also adds a user's sso uuid to the serializer in hex format.

### Checklist

* [x] Have tests been added to cover any changes?

- test_views.py has been updated with the new expected response.
- A new test_serializer file contains unit tests for the user permissions serialization
