### PR TITLE
feature:replace finder results data explorer button with download csv

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -699,11 +699,15 @@ class SourceTable(BaseSource):
 
     @property
     def data_grid_download_enabled(self):
-        return self.data_grid_column_config.get("download_enabled", False)
+        if self.data_grid_column_config:
+            return self.data_grid_column_config.get("download_enabled", False)
+        return False
 
     @property
     def data_grid_download_limit(self):
-        return self.data_grid_column_config.get("download_limit", 5000)
+        if self.data_grid_column_config:
+            return self.data_grid_column_config.get("download_limit", 5000)
+        return 5000
 
     def get_column_details_url(self):
         return reverse(

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -98,7 +98,7 @@ function createInputFormField(name, value) {
   field.setAttribute('value', value);
   return field;
 }
-function initDataGrid(columnConfig, dataEndpoint, records, exportFileName) {
+function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, exportFileName) {
   for (var i=0; i<columnConfig.length; i++) {
     var column = columnConfig[i];
     // Try to determine filter types from the column config.
@@ -235,7 +235,7 @@ function initDataGrid(columnConfig, dataEndpoint, records, exportFileName) {
       if (dataEndpoint) {
         // Download a csv via the backend using current sort/filter options.
         var form = document.createElement('form');
-        form.action = dataEndpoint + '?download=1'
+        form.action = dataEndpoint + downloadSegment;
         form.method = 'POST';
         form.enctype = 'application/x-www-form-urlencoded';
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -18,6 +18,7 @@
     window.initDataGrid(
       JSON.parse(document.getElementById('column_data').textContent),
       '{{ object.get_grid_data_url }}',
+      '?download=1',
       null,
       '{{ object.name }}-custom-export.csv'
     );

--- a/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
+++ b/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
@@ -18,6 +18,7 @@
     window.initDataGrid(
         JSON.parse(document.getElementById('column_data').textContent),
         null,
+        null,
         JSON.parse(document.getElementById('grid_data').textContent),
         '{{ model.slug }}-{{ model.published_version }}-custom-export.csv'
     );

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -20,6 +20,7 @@
       window.initDataGrid(
         JSON.parse(document.getElementById('column_data').textContent),
         null,
+        null,
         JSON.parse(document.getElementById('grid_data').textContent),
         '{{ model.slug }}-{{ model.published_version }}-custom-export.csv'
       );

--- a/dataworkspace/dataworkspace/templates/finder/results.html
+++ b/dataworkspace/dataworkspace/templates/finder/results.html
@@ -1,5 +1,5 @@
 {% extends '_main.html' %}
-{% load static datasets_tags explorer_tags %}
+{% load static core_tags datasets_tags explorer_tags humanize %}
 
 {% block go_back %}
   {% if backlink %}
@@ -17,8 +17,9 @@
     window.initDataGrid(
         JSON.parse(document.getElementById('column_data').textContent),
         '{% url 'finder:data_grid_results' source_table.schema source_table.table %}?{{ request.GET.urlencode }}',
+        '&download=1',
         null,
-        null
+        '{{ source_table.name }}-{{ search_term }}-custom-export.csv'
     );
   </script>
 {% endblock footer_scripts %}
@@ -65,9 +66,10 @@
       {% if total_results > 0 %}
         <div id="data-grid" class="ag-theme-alpine"></div>
         <div class="govuk-!-margin-top-4">
-          <a class="govuk-button govuk-button--primary" target="_blank" href="{% query_table_in_explorer_link source_table.schema source_table.table %}">
-            Open in Data Explorer
-          </a>
+          <button class="govuk-button" data-module="govuk-button" id="data-grid-download">
+            Download this data{% if object.data_grid_download_limit %} (max
+            {{ object.data_grid_download_limit|intcomma }} rows){% endif %}
+          </button>
           <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-reset-filters">
             Reset filters
           </button>


### PR DESCRIPTION
### Description of change

https://trello.com/c/q8oVdl0X/2261-dataset-finder-open-in-data-explorer-button-removed-and-download-option-added

### Checklist

* [ ] Have tests been added to cover any changes?
