### PR TITLE
bumps up cryptography version to help M1 mac users

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -102,7 +102,7 @@ click==7.1.2
     #   tabulator
 coverage==5.4
     # via pytest-cov
-cryptography==3.3.2
+cryptography==3.4.8
     # via -r requirements.txt
 debugpy==1.2.1
     # via -r requirements-dev.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ click==7.1.2
     # via
     #   tableschema
     #   tabulator
-cryptography==3.3.2
+cryptography==3.4.8
     # via -r requirements.in
 dj-database-url==0.5.0
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

Just bumps up the cryptography package from cryptography==3.3.2 to cryptography==3.4.8

This is because some M1 users were having difficulties installing requirements with the older cryptography version

### Checklist

* [ ] Have tests been added to cover any changes?
