### PR TITLE
feat: add structure and data metadata to reference datasets

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1459,6 +1459,8 @@ class ReferenceDataset(DeletableTimestampedUserModel):
         self.get_record_by_internal_id(internal_id).delete()
         if self.external_database is not None:
             self.sync_to_external_database(self.external_database.memorable_name)
+        self.modified_date = datetime.utcnow()
+        self.save()
 
     @transaction.atomic
     def delete_all_records(self):
@@ -1470,6 +1472,8 @@ class ReferenceDataset(DeletableTimestampedUserModel):
         self.get_records().delete()
         if self.external_database is not None:
             self.sync_to_external_database(self.external_database.memorable_name)
+        self.modified_date = datetime.utcnow()
+        self.save()
 
     def sync_to_external_database(self, external_database):
         """

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -183,4 +183,10 @@ urlpatterns = [
         {"model_class": models.CustomDatasetQuery},
         name="custom_dataset_query_changelog",
     ),
+    path(
+        "reference/<uuid:dataset_uuid>/changelog/",
+        login_required(views.SourceChangelogView.as_view()),
+        {"model_class": models.ReferenceDataset},
+        name="reference_dataset_changelog",
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -748,8 +748,14 @@ def store_reference_dataset_metadata():
         logger.info(
             "Checking for metadata update for reference dataset '%s'", reference_dataset.name
         )
+
+        # Get the update date from reference dataset
+        latest_update_date = reference_dataset.modified_date
+
         # Get the latest modified date from this reference dataset's fields
-        latest_update_date = reference_dataset.fields.latest("modified_date").modified_date
+        latest_update_date = max(
+            reference_dataset.fields.latest("modified_date").modified_date, latest_update_date
+        )
 
         # Get the latest date the data in this dataset was updated
         data_updated = reference_dataset.data_last_updated

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -21,6 +21,7 @@ from dataworkspace.apps.datasets.models import (
     DataSetType,
     Notification,
     ReferenceDataset,
+    ReferenceDatasetField,
     SourceTable,
     UserNotification,
     VisualisationCatalogueItem,
@@ -590,6 +591,23 @@ def get_human_readable_custom_dataset_query_changelog(custom_dataset_query):
     return changelog
 
 
+def get_human_readable_reference_dataset_changelog(reference_dataset):
+    db_name, _ = list(settings.DATABASES_DATA.items())[0]
+    changelog = get_source_table_changelog(db_name, "public", reference_dataset.table_name)
+    for record in changelog:
+        if not record["previous_table_structure"] and not record["previous_data_hash"]:
+            record["change_type"] = ["Reference dataset creation"]
+        else:
+            record["change_type"] = []
+            if record["previous_table_structure"] != record["table_structure"]:
+                record["change_type"].append("Columns")
+                record["columns_added"], record["columns_removed"] = _get_column_diff(record)
+            if record["previous_data_hash"] != record["data_hash"]:
+                record["change_type"].append("Data")
+        record["change_type"] = " and ".join(record["change_type"])
+    return changelog
+
+
 @celery_app.task()
 def store_custom_dataset_query_table_structures():
     for query in CustomDatasetQuery.objects.filter(dataset__published=True):
@@ -722,3 +740,88 @@ def send_notification_emails():
         logger.error("Exception when creating notifications: %s", e)
     else:
         send_notifications()
+
+
+@celery_app.task()
+def store_reference_dataset_metadata():
+    for reference_dataset in ReferenceDataset.objects.filter(published=True):
+        logger.info(
+            "Checking for metadata update for reference dataset '%s'", reference_dataset.name
+        )
+        # Get the latest modified date from this reference dataset's fields
+        latest_update_date = reference_dataset.fields.latest("modified_date").modified_date
+
+        # Get the latest date the data in this dataset was updated
+        data_updated = reference_dataset.data_last_updated
+        if data_updated:
+            latest_update_date = max(latest_update_date, data_updated)
+
+        # Get the latest data updated dates for any linked reference datasets
+        linked_datasets_updated_dates = [
+            field.linked_reference_dataset_field.reference_dataset.data_last_updated
+            for field in reference_dataset.fields.filter(
+                data_type=ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
+            )
+        ]
+        if linked_datasets_updated_dates:
+            latest_update_date = max(latest_update_date, max(linked_datasets_updated_dates))
+
+        logger.info(
+            "Latest update date for reference dataset '%s' is %s",
+            reference_dataset.name,
+            latest_update_date,
+        )
+
+        # Get the latest metadata record
+        db_name, _ = list(settings.DATABASES_DATA.items())[0]
+        with connections[db_name].cursor() as cursor:
+            cursor.execute(
+                SQL(
+                    "SELECT DISTINCT ON(source_data_modified_utc)"
+                    "source_data_modified_utc::TIMESTAMP AT TIME ZONE 'UTC' "
+                    "FROM dataflow.metadata "
+                    "WHERE table_schema = 'public' "
+                    "AND table_name = {} "
+                    "ORDER BY source_data_modified_utc DESC"
+                ).format(Literal(reference_dataset.table_name))
+            )
+            metadata = cursor.fetchone()
+
+            # If the metadata record is older than our latest updated date write a new record
+            if not metadata or latest_update_date > metadata[0]:
+                logger.info(
+                    "Creating new metadata record for reference dataset '%s'",
+                    reference_dataset.name,
+                )
+
+                columns = [
+                    (field.column_name, field.get_postgres_datatype())
+                    for field in reference_dataset.fields.all()
+                ]
+                cursor.execute(
+                    SQL(
+                        """
+                        INSERT INTO dataflow.metadata (
+                            source_data_modified_utc,
+                            table_schema,
+                            table_name,
+                            table_structure,
+                            data_hash_v1,
+                            data_type
+                        )
+                        VALUES ({},'public', {}, {}, {}, {})
+                        """
+                    ).format(
+                        Literal(latest_update_date),
+                        Literal(reference_dataset.table_name),
+                        Literal(json.dumps(columns)),
+                        Literal(reference_dataset.get_metadata_table_hash()),
+                        Literal(int(DataSetType.REFERENCE)),
+                    )
+                )
+            else:
+                logger.info(
+                    "Not creating a metadata record for %s as the last updated date is before %s",
+                    reference_dataset.name,
+                    metadata[0],
+                )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -102,6 +102,7 @@ from dataworkspace.apps.datasets.utils import (
     get_code_snippets_for_query,
     get_code_snippets_for_reference_table,
     get_human_readable_custom_dataset_query_changelog,
+    get_human_readable_reference_dataset_changelog,
     get_human_readable_source_table_changelog,
 )
 from dataworkspace.apps.eventlog.models import EventLog
@@ -1585,9 +1586,17 @@ class SourceChangelogView(WaffleFlagMixin, DetailView):
             ctx["changelog"] = get_human_readable_source_table_changelog(self.get_object())
         elif self.kwargs["model_class"] == CustomDatasetQuery:
             ctx["changelog"] = get_human_readable_custom_dataset_query_changelog(self.get_object())
+        elif self.kwargs["model_class"] == ReferenceDataset:
+            ctx["changelog"] = get_human_readable_reference_dataset_changelog(self.get_object())
         return ctx
 
     def get_object(self, queryset=None):
+        if self.kwargs["model_class"] == ReferenceDataset:
+            return get_object_or_404(
+                self.kwargs["model_class"],
+                uuid=self.kwargs.get("dataset_uuid"),
+                **{"published": True} if not self.request.user.is_superuser else {},
+            )
         return get_object_or_404(
             self.kwargs["model_class"],
             dataset__id=self.kwargs.get("dataset_uuid"),

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -358,6 +358,11 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "schedule": 60 * 5,
             "args": (),
         },
+        "store-reference-dataset-metadata": {
+            "task": "dataworkspace.apps.datasets.utils.store_reference_dataset_metadata",
+            "schedule": 60 * 5,
+            "args": (),
+        },
     }
 
 CELERY_REDBEAT_REDIS_URL = env["REDIS_URL"]
@@ -659,6 +664,7 @@ DATA_GRID_REFERENCE_DATASET_FLAG = "DATA-GRID-REFERENCE-DATASET"
 CASE_STUDIES_FLAG = "CASE-STUDIES-FLAG"
 NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG = "NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG"
 NOTIFY_ON_DATACUT_CHANGE_FLAG = "NOTIFY_ON_DATACUT_CHANGE_FLAG"
+NOTIFY_ON_REFERENCE_DATASET_CHANGE_FLAG = "NOTIFY_ON_REFERENCE_DATASET_CHANGE_FLAG"
 DATASET_CHANGELOG_PAGE_FLAG = "DATASET_CHANGELOG_PAGE"
 
 DATASET_FINDER_SEARCH_RESULTS_PER_PAGE = 200

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -152,6 +152,9 @@
           <th class="govuk-table__header">Version</th>
           <th class="govuk-table__header">Last updated</th>
           <th class="govuk-table__header">Action</th>
+          {% flag DATASET_CHANGELOG_PAGE_FLAG %}
+            <th class="govuk-table__header">History</th>
+          {% endflag %}
         </tr>
         </thead>
         <tbody>
@@ -169,6 +172,14 @@
               View/Download
             </a>
           </td>
+          {% flag DATASET_CHANGELOG_PAGE_FLAG %}
+            <td class="govuk-table__cell app-table_cell--no-border">
+              <a class="govuk-link govuk-link--no-visited-state"
+                 href="{% url 'datasets:reference_dataset_changelog' dataset_uuid=model.uuid %}">
+                Changelog
+              </a>
+            </td>
+          {% endflag %}
         </tr>
         </tbody>
       </table>

--- a/dataworkspace/dataworkspace/templates/datasets/source_changelog.html
+++ b/dataworkspace/dataworkspace/templates/datasets/source_changelog.html
@@ -4,8 +4,9 @@
 {% block page_title %}Changelog for {{ dataset.name }} - {{ block.super }}{% endblock %}
 
 {% block go_back %}
-  <a class="govuk-back-link"
-     href="{% url "datasets:dataset_detail" dataset_uuid=source.dataset.id %}#{{ dataset.slug }}">
+  <a
+    class="govuk-back-link"
+    href="{% if source.dataset %}{{ source.dataset.get_absolute_url }}{% else %}{{ source.get_absolute_url }}{% endif %}">
     Back
   </a>
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/conftest.py
+++ b/dataworkspace/dataworkspace/tests/conftest.py
@@ -152,7 +152,8 @@ def metadata_db(db):
                 table_structure JSONB,
                 data_id INTEGER,
                 data_type INTEGER NOT NULL,
-                data_hash_v1 TEXT
+                data_hash_v1 TEXT,
+                primary_keys TEXT[]
             );
             TRUNCATE TABLE dataflow.metadata;
             INSERT INTO dataflow.metadata (table_schema, table_name, source_data_modified_utc, table_structure, data_type)


### PR DESCRIPTION
### Description of change

- Adds a new celery task to save data and structure changes to the metadata table for reference datasets
- Adds a new changelog page to reference datasets to match master/datacuts

### Checklist

* [x] Have tests been added to cover any changes?
