### PR TITLE
feat:return dataflow_swapped_tables when source_date_modified is null

### DIFF
--- a/dataworkspace/dataworkspace/tests/conftest.py
+++ b/dataworkspace/dataworkspace/tests/conftest.py
@@ -156,12 +156,14 @@ def metadata_db(db):
                 primary_keys TEXT[]
             );
             TRUNCATE TABLE dataflow.metadata;
-            INSERT INTO dataflow.metadata (table_schema, table_name, source_data_modified_utc, table_structure, data_type)
+            INSERT INTO dataflow.metadata (
+                table_schema, table_name, source_data_modified_utc, dataflow_swapped_tables_utc, table_structure, data_type
+            )
             VALUES
-                ('public', 'table1', '2020-09-02 00:01:00.0', '{"field1":"int","field2":"varchar"}', 1),
-                ('public', 'table2', '2020-09-01 00:01:00.0', NULL, 1),
-                ('public', 'table1', '2020-01-01 00:01:00.0', NULL, 1),
-                ('public', 'table4', NULL, NULL, 1);
+                ('public','table1','2020-09-02 00:01:00.0','2020-09-02 00:01:00.0','{"field1":"int","field2":"varchar"}',1),
+                ('public','table2','2020-09-01 00:01:00.0','2020-09-02 00:01:00.0',NULL,1),
+                ('public','table1','2020-01-01 00:01:00.0','2020-09-02 00:01:00.0',NULL,1),
+                ('public','table4', NULL,'2021-12-01 00:00:00.0',NULL,1);
             """
         )
         conn.commit()

--- a/dataworkspace/dataworkspace/tests/test_datasets_db.py
+++ b/dataworkspace/dataworkspace/tests/test_datasets_db.py
@@ -1,6 +1,12 @@
-import pytest
+import datetime
 
-from dataworkspace.datasets_db import extract_queried_tables_from_sql_query
+import pytest
+import pytz
+
+from dataworkspace.datasets_db import (
+    extract_queried_tables_from_sql_query,
+    get_tables_last_updated_date,
+)
 
 
 @pytest.mark.parametrize(
@@ -25,3 +31,17 @@ from dataworkspace.datasets_db import extract_queried_tables_from_sql_query
 def test_sql_query_tables_extracted_correctly(query, expected_tables):
     tables = extract_queried_tables_from_sql_query("test_external_db", query)
     assert tables == expected_tables
+
+
+@pytest.mark.django_db
+def test_get_table_last_updated_date_with_source_data_modified_metadata(metadata_db):
+    assert get_tables_last_updated_date(
+        "my_database", (("public", "table2"),)
+    ) == datetime.datetime(2020, 9, 1, 0, 1).replace(tzinfo=pytz.UTC)
+
+
+@pytest.mark.django_db
+def test_get_table_last_updated_date_with_dataflow_swapped_table_metadata(metadata_db):
+    assert get_tables_last_updated_date(
+        "my_database", (("public", "table4"),)
+    ) == datetime.datetime(2021, 12, 1, 0, 0).replace(tzinfo=pytz.UTC)

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2829,7 +2829,8 @@ async def create_metadata_table():
                 '''
                 CREATE SCHEMA IF NOT EXISTS dataflow;
                 CREATE TABLE IF NOT EXISTS dataflow.metadata (
-                    id int, table_schema text, table_name text, source_data_modified_utc timestamp
+                    id int, table_schema text, table_name text,
+                    source_data_modified_utc timestamp, dataflow_swapped_tables_utc timestamp
                 );
                 '''
             )


### PR DESCRIPTION
This ensures that tables uploaded via Data Uploader always have a last updated date set
