### PR TITLE
feat: filter cookies to and from visualisations

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -171,6 +171,7 @@ def api_application_dict(application_instance):
         "wrap": application_instance.application_template.wrap,
         # Used by metrics to label the application
         "name": application_instance.application_template.nice_name,
+        "type": application_instance.application_template.application_type,
     }
 
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -842,8 +842,7 @@ async def async_main():
                     headers=CIMultiDict(
                         filter_headers(
                             upstream_response.headers,
-                            ["transfer-encoding"]
-                            + (["Cookie", "Set-Cookie"] if filter_cookies else []),
+                            ["transfer-encoding"] + (["Set-Cookie"] if filter_cookies else []),
                         )
                         + response_headers
                     ),

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -168,10 +168,7 @@ async def async_main():
         )
 
     def clear_cookie_header(headers: Union[CIMultiDict, CIMultiDictProxy]):
-        for key in list(headers.keys()):
-            if key.lower() == "cookie":
-                headers[key] = ""
-        return headers
+        return CIMultiDict(filter_headers(headers, ["cookie"]) + (("cookie", ""),))
 
     def admin_headers_request(downstream_request):
         # When we make a deliberate request to the admin application from the

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -12,6 +12,7 @@ import sys
 import string
 import uuid
 import urllib
+from typing import Union
 
 import aiohttp
 import ecs_logging
@@ -20,7 +21,7 @@ from aiohttp import web
 import aioredis
 from elasticapm.contrib.aiohttp import ElasticAPM
 from hawkserver import authenticate_hawk_header
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from sentry_sdk import set_user
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from yarl import URL
@@ -156,11 +157,14 @@ async def async_main():
     def get_random_context_logger():
         return ContextAdapter(logger, {"context": "".join(random.choices(CONTEXT_ALPHABET, k=8))})
 
-    def without_transfer_encoding(request_or_response):
+    def filter_headers(headers: Union[CIMultiDict, CIMultiDictProxy], exclude: list):
+        """
+        Return headers with any matches in `exclude` removed
+        """
         return tuple(
             (key, value)
-            for key, value in request_or_response.headers.items()
-            if key.lower() != "transfer-encoding"
+            for key, value in headers.items()
+            if key.lower() not in [x.lower() for x in exclude]
         )
 
     def admin_headers_request(downstream_request):
@@ -194,7 +198,7 @@ async def async_main():
 
     def application_headers(downstream_request):
         return (
-            without_transfer_encoding(downstream_request)
+            filter_headers(downstream_request.headers, ["transfer-encoding"])
             + (
                 (("x-scheme", downstream_request.headers["x-forwarded-proto"]),)
                 if "x-forwarded-proto" in downstream_request.headers
@@ -229,7 +233,7 @@ async def async_main():
             return "-".join([s.capitalize() for s in header.replace("_", "-").split("-")])
 
         return CIMultiDict(
-            without_transfer_encoding(downstream_request)
+            filter_headers(downstream_request.headers, ["transfer-encoding"])
             + (
                 tuple(
                     [(f"Credentials-{standardise_header(k)}", v) for k, v in credentials.items()]
@@ -461,9 +465,16 @@ async def async_main():
                 (("content-security-policy", csp_application_spawning),),
             )
 
+        is_visualisation = application["type"] == "VISUALISATION"
+
         if is_websocket:
             return await handle_application_websocket(
-                downstream_request, application["proxy_url"], path, query, port_override
+                downstream_request,
+                application["proxy_url"],
+                path,
+                query,
+                port_override,
+                is_visualisation,
             )
 
         if application["state"] == "SPAWNING":
@@ -495,16 +506,18 @@ async def async_main():
             application_upstream(application["proxy_url"], path, port_override),
             query,
             public_host,
+            is_visualisation,
         )
 
     async def handle_application_websocket(
-        downstream_request, proxy_url, path, query, port_override
+        downstream_request, proxy_url, path, query, port_override, is_visualisation
     ):
         upstream_url = application_upstream(proxy_url, path, port_override).with_query(query)
         return await handle_websocket(
             downstream_request,
             CIMultiDict(application_headers(downstream_request)),
             upstream_url,
+            filter_cookies=is_visualisation,
         )
 
     def application_upstream(proxy_url, path, port_override):
@@ -597,10 +610,14 @@ async def async_main():
         )
 
     async def handle_application_http_running_direct(
-        downstream_request, method, upstream_url, query, public_host
+        downstream_request,
+        method,
+        upstream_url,
+        query,
+        public_host,
+        is_visualisation,
     ):
         host = downstream_request.headers["host"]
-
         await send_to_google_analytics(downstream_request)
 
         return await handle_http(
@@ -617,6 +634,7 @@ async def async_main():
                     csp_application_running_direct(host, public_host),
                 ),
             ),
+            filter_cookies=is_visualisation,
         )
 
     async def handle_mirror(downstream_request, method, path):
@@ -663,7 +681,9 @@ async def async_main():
             default_http_timeout,
         )
 
-    async def handle_websocket(downstream_request, upstream_headers, upstream_url):
+    async def handle_websocket(
+        downstream_request, upstream_headers, upstream_url, filter_cookies=False
+    ):
         protocol = downstream_request.headers.get("Sec-WebSocket-Protocol")
         protocols = (protocol,) if protocol else ()
 
@@ -683,7 +703,13 @@ async def async_main():
         async def upstream():
             try:
                 async with client_session.ws_connect(
-                    str(upstream_url), headers=upstream_headers, protocols=protocols
+                    str(upstream_url),
+                    headers=(
+                        filter_headers(upstream_headers, ["Cookie", "Set-Cookie"])
+                        if filter_cookies
+                        else upstream_headers
+                    ),
+                    protocols=protocols,
                 ) as upstream_ws:
                     upstream_connection.set_result(upstream_ws)
                     downstream_ws = await downstream_connection
@@ -797,23 +823,32 @@ async def async_main():
         upstream_data,
         timeout,
         response_headers=tuple(),
+        filter_cookies=False,
     ):
         async with client_session.request(
             upstream_method,
             str(upstream_url),
             params=upstream_query,
-            headers=upstream_headers,
+            headers=(
+                filter_headers(upstream_headers, ["Cookie", "Set-Cookie"])
+                if filter_cookies
+                else upstream_headers
+            ),
             data=upstream_data,
             allow_redirects=False,
             timeout=timeout,
         ) as upstream_response:
-
             _, _, _, with_session_cookie = downstream_request[SESSION_KEY]
             downstream_response = await with_session_cookie(
                 web.StreamResponse(
                     status=upstream_response.status,
                     headers=CIMultiDict(
-                        without_transfer_encoding(upstream_response) + response_headers
+                        filter_headers(
+                            upstream_response.headers,
+                            ["transfer-encoding"]
+                            + (["Cookie", "Set-Cookie"] if filter_cookies else []),
+                        )
+                        + response_headers
                     ),
                 )
             )

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -167,9 +167,6 @@ async def async_main():
             if key.lower() not in [x.lower() for x in exclude]
         )
 
-    def clear_cookie_header(headers: Union[CIMultiDict, CIMultiDictProxy]):
-        return CIMultiDict(filter_headers(headers, ["cookie"]) + (("cookie", ""),))
-
     def admin_headers_request(downstream_request):
         # When we make a deliberate request to the admin application from the
         # proxy we don't want to proxy content-length or content-type
@@ -704,7 +701,7 @@ async def async_main():
                 async with client_session.ws_connect(
                     str(upstream_url),
                     headers=(
-                        clear_cookie_header(upstream_headers)
+                        CIMultiDict(filter_headers(upstream_headers, ["cookie"]))
                         if filter_cookies
                         else upstream_headers
                     ),
@@ -829,7 +826,9 @@ async def async_main():
             str(upstream_url),
             params=upstream_query,
             headers=(
-                clear_cookie_header(upstream_headers) if filter_cookies else upstream_headers
+                CIMultiDict(filter_headers(upstream_headers, ["cookie"]))
+                if filter_cookies
+                else upstream_headers
             ),
             data=upstream_data,
             allow_redirects=False,

--- a/test/echo_server.py
+++ b/test/echo_server.py
@@ -22,7 +22,12 @@ async def async_main():
             "headers": dict(request.headers),
         }
         return web.json_response(
-            data, status=405, headers={"from-upstream": "upstream-header-value"}
+            data,
+            status=405,
+            headers={
+                "from-upstream": "upstream-header-value",
+                "Set-Cookie": "test-set-cookie",
+            },
         )
 
     async def handle_websockets(request):

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -494,6 +494,8 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_content["headers"]["sso-profile-email"], "test@test.com")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        # Assert that cookies were removed from the request and the response
+        self.assertEqual(received_content["headers"]["Cookie"], "")
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
@@ -528,6 +530,8 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        # Assert that cookies were removed from the request and the response
+        self.assertEqual(received_content["headers"]["Cookie"], "")
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
@@ -633,6 +637,9 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        # Assert that cookies were removed from the request and the response
+        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
         async with session.request(
@@ -647,6 +654,9 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        # Assert that cookies were removed from the request and the response
+        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
     @async_test

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -495,7 +495,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["sso-profile-email"], "test@test.com")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
         # Assert that cookies were removed from the request and the response
-        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotIn("Cookie", received_content["headers"])
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
@@ -531,7 +531,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
         # Assert that cookies were removed from the request and the response
-        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotIn("Cookie", received_content["headers"])
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -638,7 +638,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
         # Assert that cookies were removed from the request and the response
-        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotIn("Cookie", received_content["headers"])
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 
@@ -655,7 +655,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
         # Assert that cookies were removed from the request and the response
-        self.assertEqual(received_content["headers"]["Cookie"], "")
+        self.assertNotIn("Cookie", received_content["headers"])
         self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
         self.assertNotIn("Cookie", received_headers)
 

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -477,7 +477,10 @@ class TestApplication(unittest.TestCase):
 
         await until_non_202(session, "http://testvisualisation.dataworkspace.test:8000/")
 
-        sent_headers = {"from-downstream": "downstream-header-value"}
+        sent_headers = {
+            "from-downstream": "downstream-header-value",
+            "Cookie": "test-cookie",
+        }
         async with session.request(
             "GET",
             "http://testvisualisation.dataworkspace.test:8000/http",
@@ -491,6 +494,8 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_content["headers"]["sso-profile-email"], "test@test.com")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
+        self.assertNotIn("Cookie", received_headers)
 
         stdout, stderr, code = await set_visualisation_wrap(
             "testvisualisation", "FULL_HEIGHT_IFRAME"
@@ -523,6 +528,8 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
+        self.assertNotIn("Cookie", received_headers)
 
     @async_test
     async def test_visualisation_commit_shows_content_if_authorized(self):
@@ -613,7 +620,7 @@ class TestApplication(unittest.TestCase):
 
         await until_non_202(session, "http://testvisualisation--11372717.dataworkspace.test:8000/")
 
-        sent_headers = {"from-downstream": "downstream-header-value"}
+        sent_headers = {"from-downstream": "downstream-header-value", "Cookie": "a-test-cookie"}
         async with session.request(
             "GET",
             "http://testvisualisation--11372717.dataworkspace.test:8000/http",
@@ -626,6 +633,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        self.assertNotIn("Cookie", received_headers)
 
         async with session.request(
             "GET",
@@ -639,6 +647,7 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
+        self.assertNotIn("Cookie", received_headers)
 
     @async_test
     async def test_visualisation_shows_dataset_if_authorised(self):


### PR DESCRIPTION
- Add generic `filter_headers()` function to replace `without_transfer_encoding`
- Set cookie headers to an empty string before forwarding requests to visualisations
- Filter out `Cookie` and `Set-Cookie` headers received from visualisations
