### PR TITLE
fix: ensure ref dataset grid columns have unique names

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1564,7 +1564,7 @@ class ReferenceDataset(DeletableTimestampedUserModel):
             column_name = (
                 field.column_name
                 if field.data_type != field.DATA_TYPE_FOREIGN_KEY
-                else field.linked_reference_dataset_field.column_name
+                else f"{field.relationship_name}_{field.linked_reference_dataset_field.column_name}"
             )
             data_type = (
                 field.data_type
@@ -1603,7 +1603,9 @@ class ReferenceDataset(DeletableTimestampedUserModel):
                         record_data[field.column_name] = record_data[field.column_name].isoformat()
                 else:
                     relationship = getattr(record, field.relationship_name)
-                    record_data[field.linked_reference_dataset_field.column_name] = (
+                    record_data[
+                        f"{field.relationship_name}_{field.linked_reference_dataset_field.column_name}"
+                    ] = (
                         getattr(
                             relationship,
                             field.linked_reference_dataset_field.column_name,

--- a/dataworkspace/dataworkspace/tests/test_models.py
+++ b/dataworkspace/dataworkspace/tests/test_models.py
@@ -721,7 +721,7 @@ class TestReferenceDatasets(ReferenceDatasetsMixin, BaseModelsTests):
             },
             {
                 "headerName": field4.name,
-                "field": field4.linked_reference_dataset_field.column_name,
+                "field": f"{field4.relationship_name}_{field4.linked_reference_dataset_field.column_name}",
                 "sortable": True,
                 "filter": "agNumberColumnFilter",
             },
@@ -797,15 +797,15 @@ class TestReferenceDatasets(ReferenceDatasetsMixin, BaseModelsTests):
                 field1.column_name: "Some text",
                 field2.column_name: 123,
                 field3.column_name: date(2020, 1, 1),
-                field4.linked_reference_dataset_field.column_name: None,
-                field5.linked_reference_dataset_field.column_name: None,
+                f"link1_{field4.linked_reference_dataset_field.column_name}": None,
+                f"link2_{field5.linked_reference_dataset_field.column_name}": None,
             },
             {
                 field1.column_name: "More text",
                 field2.column_name: 321,
                 field3.column_name: date(2019, 12, 31),
-                field4.linked_reference_dataset_field.column_name: 1,
-                field5.linked_reference_dataset_field.column_name: "a record",
+                f"link1_{field4.linked_reference_dataset_field.column_name}": 1,
+                f"link2_{field5.linked_reference_dataset_field.column_name}": "a record",
             },
         ]
 


### PR DESCRIPTION
### Description of change

Grid and downloads were broken when a reference dataset had linked to two or more datasets with the same field name. 

### Checklist

* [x] Have tests been added to cover any changes?
