### PR TITLE
changes published date for cloned master datasets to time of cloning

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -410,6 +410,9 @@ class DataSet(DeletableTimestampedUserModel):
         New dataset is unpublished and has a name prefixed with
         "Copy of <original dataset name>".
 
+        The new datasets published_at date is set to the moment
+        that it was copied.
+
         Related objects (excluding user permissions) are duplicated
         for the new dataset.
 
@@ -422,6 +425,7 @@ class DataSet(DeletableTimestampedUserModel):
         clone.slug = ""
         clone.number_of_downloads = 0
         clone.published = False
+        clone.published_at = timezone.now()
         clone.save()
 
         for obj in self.related_objects():

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -425,7 +425,7 @@ class DataSet(DeletableTimestampedUserModel):
         clone.slug = ""
         clone.number_of_downloads = 0
         clone.published = False
-        clone.published_at = timezone.now()
+        clone.published_at = None
         clone.save()
 
         for obj in self.related_objects():

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -411,7 +411,7 @@ class DataSet(DeletableTimestampedUserModel):
         "Copy of <original dataset name>".
 
         The new datasets published_at date is set to the moment
-        that it was copied.
+        that it is published.
 
         Related objects (excluding user permissions) are duplicated
         for the new dataset.

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -1,6 +1,7 @@
 import io
 from collections import OrderedDict
 from datetime import datetime
+from django.utils import timezone
 
 import botocore
 import mock
@@ -23,6 +24,13 @@ def test_clone_dataset(db):
     assert clone.number_of_downloads == 0
     assert clone.name == f"Copy of {ds.name}"
     assert not clone.published
+
+    # Ensure published date is set to time of cloning, cant just use timezone.now()
+    # due to millisecond difference in .now() at point of cloning and assertion
+    assert (
+        clone.published_at > timezone.now() - timezone.timedelta(hours=1)
+        and clone.published_at <= timezone.now()
+    )
 
 
 def test_clone_dataset_copies_related_objects(db):

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -23,6 +23,7 @@ def test_clone_dataset(db):
     assert clone.slug == ""
     assert clone.number_of_downloads == 0
     assert clone.name == f"Copy of {ds.name}"
+    assert clone.published_at = None
     assert not clone.published
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -25,13 +25,6 @@ def test_clone_dataset(db):
     assert clone.name == f"Copy of {ds.name}"
     assert not clone.published
 
-    # Ensure published date is set to time of cloning, cant just use timezone.now()
-    # due to millisecond difference in .now() at point of cloning and assertion
-    assert (
-        clone.published_at > timezone.now() - timezone.timedelta(hours=1)
-        and clone.published_at <= timezone.now()
-    )
-
 
 def test_clone_dataset_copies_related_objects(db):
     ds = factories.DataSetFactory.create(published=True)

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -23,7 +23,7 @@ def test_clone_dataset(db):
     assert clone.slug == ""
     assert clone.number_of_downloads == 0
     assert clone.name == f"Copy of {ds.name}"
-    assert clone.published_at == None
+    assert clone.published_at is None
     assert not clone.published
 
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -1,7 +1,6 @@
 import io
 from collections import OrderedDict
 from datetime import datetime
-from django.utils import timezone
 
 import botocore
 import mock

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -23,7 +23,7 @@ def test_clone_dataset(db):
     assert clone.slug == ""
     assert clone.number_of_downloads == 0
     assert clone.name == f"Copy of {ds.name}"
-    assert clone.published_at = None
+    assert clone.published_at == None
     assert not clone.published
 
 


### PR DESCRIPTION
### Description of change

cloned master datasets now get their published_at date at the time of cloning rather than inheriting it from the previous dataset 

### Checklist

* [ ] Have tests been added to cover any changes?
