### PR TITLE
fix: add data_type to metadata test table

### DIFF
--- a/test/test_application.py
+++ b/test/test_application.py
@@ -2830,7 +2830,8 @@ async def create_metadata_table():
                 CREATE SCHEMA IF NOT EXISTS dataflow;
                 CREATE TABLE IF NOT EXISTS dataflow.metadata (
                     id int, table_schema text, table_name text,
-                    source_data_modified_utc timestamp, dataflow_swapped_tables_utc timestamp
+                    source_data_modified_utc timestamp, dataflow_swapped_tables_utc timestamp,
+                    data_type int
                 );
                 '''
             )


### PR DESCRIPTION
### Description of change

Fix failing integration test caused by missing `data_type` column in metadata db

### Checklist

* [ ] Have tests been added to cover any changes?
