### PR TITLE
feat: use prefixed cookies

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -210,7 +210,7 @@ CACHES = {
 # login, which mitigates the risk of session fixation attack. Using the same
 # cookie also means there are fewer cases to consider in terms of cookie
 # expiration.
-SESSION_COOKIE_NAME = "data_workspace_session"
+SESSION_COOKIE_NAME = ("__Secure-" if not LOCAL else "") + "data_workspace_session"
 root_domain_no_port, _, _ = env["APPLICATION_ROOT_DOMAIN"].partition(":")
 SESSION_COOKIE_DOMAIN = root_domain_no_port
 SESSION_COOKIE_SECURE = not LOCAL
@@ -218,7 +218,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
 CSRF_COOKIE_SECURE = not LOCAL
-CSRF_COOKIE_NAME = "data_workspace_csrf"
+CSRF_COOKIE_NAME = ("__Secure-" if not LOCAL else "") + "data_workspace_csrf"
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -34,7 +34,6 @@ import time
 from aiohttp import web
 
 
-COOKIE_NAME = "data_workspace_session"
 COOKIE_MAX_AGE = 60 * 30
 
 REDIS_KEY_PREFIX = "data_workspace_session___cookie"
@@ -43,13 +42,13 @@ REDIS_MAX_AGE = 60 * 25
 SESSION_KEY = "SESSION"
 
 
-def redis_session_middleware(redis_pool, root_domain_no_port, embed_path):
+def redis_session_middleware(cookie_name, redis_pool, root_domain_no_port, embed_path):
     def get_secret_cookie_value():
         return secrets.token_urlsafe(64)
 
     @web.middleware
     async def _redis_session_middleware(request, handler):
-        cookie_value = request.cookies.get(COOKIE_NAME)
+        cookie_value = request.cookies.get(cookie_name)
         to_set = {}
 
         async def get_value(key):
@@ -104,7 +103,7 @@ def redis_session_middleware(redis_pool, root_domain_no_port, embed_path):
             # aiohttp's set_cookie doesn't seem to support the SameSite attribute
             response.headers.add(
                 "set-cookie",
-                f"{COOKIE_NAME}={cookie_value}; domain={root_domain_no_port}; expires={expires}; "
+                f"{cookie_name}={cookie_value}; domain={root_domain_no_port}; expires={expires}; "
                 f"Max-Age={COOKIE_MAX_AGE}; HttpOnly; Path={path}; SameSite={same_site}{secure}",
             )
             return response


### PR DESCRIPTION
### Description of change

This prevents vulnerabilities mostly related to before a user has visited the site on HTTPS, and they initially get to an attacker's HTTP site

Potentially down the line "__Host-" should be used, but that might need more testing and even work on SSO's side to allow a range of domains that can be redirected to.

### Checklist

* [ ] Have tests been added to cover any changes?
