### PR TITLE
feat: shorter session timeout for security reasons

### DIFF
--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -35,10 +35,10 @@ from aiohttp import web
 
 
 COOKIE_NAME = "data_workspace_session"
-COOKIE_MAX_AGE = 60 * 60 * 10
+COOKIE_MAX_AGE = 60 * 30
 
 REDIS_KEY_PREFIX = "data_workspace_session___cookie"
-REDIS_MAX_AGE = 60 * 60 * 9
+REDIS_MAX_AGE = 60 * 25
 
 SESSION_KEY = "SESSION"
 


### PR DESCRIPTION
### Description of change

Browsers now won't attempt to use the cookie after 30 minutes it was initially set, so it looks you have 30 minutes to make a request to Data Workspace without getting redirected to SSO and back.

However, sessions would are really only 25 minutes long: they are removed from Redis after 25 minutes. This is...

- Consistent with existing behaviour in terms of deleting from Redis _before_ the expiry from the browser's point of view.

- To make really sure the session is _definitely_ less than 30 minutes. Say we have a check to see if someone can use what "should" be an expired session. They should never be able to do this. Don't want a pen test to say "we used a session cookie that was 30 minutes and 2 seconds old".

- To make sure that things work fine if the browser sends a cookie that is no longer in Redis, to repeatedly handle a sort of Redis delete. So if we decide to delete everything from Redis (say, bump version to one without any data in it) we can be fairly sure that other than a redirect to SSO and back, users won't be affected, since "in use" sessions ("in use, from the browser's point of view) would have been repeatedly deleted from Redis day in, day out, before then.


### Checklist

* [ ] Have tests been added to cover any changes?
