### PR TITLE
feat: store CSRF token in session, not cookie

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -217,8 +217,7 @@ SESSION_COOKIE_SECURE = not LOCAL
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_CACHE_ALIAS = "default"
 
-CSRF_COOKIE_SECURE = not LOCAL
-CSRF_COOKIE_NAME = ("__Secure-" if not LOCAL else "") + "data_workspace_csrf"
+CSRF_USE_SESSIONS = True
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -101,10 +101,9 @@ def redis_session_middleware(cookie_name, redis_pool, root_domain_no_port, embed
             path, same_site = (embed_path, "None") if is_embed else ("/", "Lax")
 
             # aiohttp's set_cookie doesn't seem to support the SameSite attribute
-            response.headers.add(
-                "set-cookie",
+            response.headers["set-cookie"] = (
                 f"{cookie_name}={cookie_value}; domain={root_domain_no_port}; expires={expires}; "
-                f"Max-Age={COOKIE_MAX_AGE}; HttpOnly; Path={path}; SameSite={same_site}{secure}",
+                f"Max-Age={COOKIE_MAX_AGE}; HttpOnly; Path={path}; SameSite={same_site}{secure}"
             )
             return response
 


### PR DESCRIPTION
### Description of change

It looks like we're already not accessing it from Javascript, e.g. https://github.com/uktrade/data-workspace/blob/4c87b39dbd4d327d80f86d04e6a6ea221947c04f/dataworkspace/dataworkspace/static/data-grid.js#L1

No actual attack is known, but it can come up that we shouldn't have non HttpOnly cookies, so avoids having to justify it

### Checklist

* [ ] Have tests been added to cover any changes?
