### PR TITLE
Fix/various cves

### DIFF
--- a/tools/requirements.in
+++ b/tools/requirements.in
@@ -20,5 +20,5 @@ seaborn==0.9.0
 spacy==2.1.8
 sentry-sdk==0.9.0
 SQLAlchemy==1.3.20
-tensorflow==2.5.2
+tensorflow
 tornado

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -140,14 +140,16 @@ jupyterlab-server==1.2.0
     # via jupyterlab
 jupyterlab==2.2.10
     # via -r requirements.in
-keras-nightly==2.5.0.dev2021032900
-    # via tensorflow
 keras-preprocessing==1.1.2
+    # via tensorflow
+keras==2.7.0
     # via tensorflow
 kiwisolver==1.3.1
     # via matplotlib
 lazy-object-proxy==1.4.3
     # via astroid
+libclang==12.0.0
+    # via tensorflow
 markdown==3.3.3
     # via tensorboard
 markupsafe==1.1.1
@@ -351,11 +353,13 @@ tensorboard-data-server==0.6.1
     # via tensorboard
 tensorboard-plugin-wit==1.8.0
     # via tensorboard
-tensorboard==2.5.0
+tensorboard==2.7.0
     # via tensorflow
-tensorflow-estimator==2.5.0
+tensorflow-estimator==2.7.0
     # via tensorflow
-tensorflow==2.5.2
+tensorflow-io-gcs-filesystem==0.23.1
+    # via tensorflow
+tensorflow==2.7.0
     # via -r requirements.in
 termcolor==1.1.0
     # via tensorflow

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -187,7 +187,7 @@ notebook==6.4.3
     #   jupyterlab
     #   jupyterlab-server
     #   widgetsnbextension
-numpy==1.19.5
+numpy==1.22.1
     # via
     #   -r requirements.in
     #   blis

--- a/tools/requirements_v3.in
+++ b/tools/requirements_v3.in
@@ -20,5 +20,5 @@ seaborn==0.9.0
 spacy==2.1.8
 sentry-sdk==0.9.0
 SQLAlchemy==1.3.20
-tensorflow==2.5.2
+tensorflow
 tornado==6.1.0

--- a/tools/requirements_v3.txt
+++ b/tools/requirements_v3.txt
@@ -210,7 +210,7 @@ notebook==6.4.3
     #   -r requirements_v3.in
     #   nbclassic
     #   widgetsnbextension
-numpy==1.19.5
+numpy==1.22.1
     # via
     #   -r requirements_v3.in
     #   blis

--- a/tools/requirements_v3.txt
+++ b/tools/requirements_v3.txt
@@ -159,14 +159,16 @@ jupyterlab-widgets==1.0.0
     # via -r requirements_v3.in
 jupyterlab==3.1.7
     # via -r requirements_v3.in
-keras-nightly==2.5.0.dev2021032900
-    # via tensorflow
 keras-preprocessing==1.1.2
+    # via tensorflow
+keras==2.7.0
     # via tensorflow
 kiwisolver==1.3.1
     # via matplotlib
 lazy-object-proxy==1.4.3
     # via astroid
+libclang==12.0.0
+    # via tensorflow
 markdown==3.3.3
     # via tensorboard
 markupsafe==1.1.1
@@ -384,11 +386,13 @@ tensorboard-data-server==0.6.1
     # via tensorboard
 tensorboard-plugin-wit==1.8.0
     # via tensorboard
-tensorboard==2.5.0
+tensorboard==2.7.0
     # via tensorflow
-tensorflow-estimator==2.5.0
+tensorflow-estimator==2.7.0
     # via tensorflow
-tensorflow==2.5.2
+tensorflow-io-gcs-filesystem==0.23.1
+    # via tensorflow
+tensorflow==2.7.0
     # via -r requirements_v3.in
 termcolor==1.1.0
     # via tensorflow

--- a/tools/requirements_v3.txt
+++ b/tools/requirements_v3.txt
@@ -32,7 +32,7 @@ blis==0.2.4
     # via
     #   spacy
     #   thinc
-bokeh==2.3.0
+bokeh==2.4.2
     # via -r requirements_v3.in
 cachetools==4.2.2
     # via google-auth
@@ -249,7 +249,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==8.3.2
+pillow==9.0.0
     # via bokeh
 plac==0.9.6
     # via
@@ -300,7 +300,6 @@ pyrsistent==0.17.3
     # via jsonschema
 python-dateutil==2.8.1
     # via
-    #   bokeh
     #   jupyter-client
     #   matplotlib
     #   pandas
@@ -432,7 +431,7 @@ traitlets==5.0.5
     #   nbconvert
     #   nbformat
     #   notebook
-typing-extensions==3.7.4.3
+typing-extensions==4.0.1
     # via
     #   bokeh
     #   tensorflow


### PR DESCRIPTION
### Description of change

- Upgrade tensorflow to allow upgrade of vulnerable dependencies
- Upgrade numpy to fix CVE-2021-33430
- Upgrade pillow to fix CVE-2022-22817, CVE-2022-22816 and CVE-2022-22815

### Checklist

* [ ] Have tests been added to cover any changes?
