### PR TITLE
feat: replace any cookie set from Django, rather than adding to it

### DIFF
--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -101,10 +101,9 @@ def redis_session_middleware(cookie_name, redis_pool, root_domain_no_port, embed
             path, same_site = (embed_path, "None") if is_embed else ("/", "Lax")
 
             # aiohttp's set_cookie doesn't seem to support the SameSite attribute
-            response.headers.add(
-                "set-cookie",
+            response.headers["set-cookie"] = (
                 f"{cookie_name}={cookie_value}; domain={root_domain_no_port}; expires={expires}; "
-                f"Max-Age={COOKIE_MAX_AGE}; HttpOnly; Path={path}; SameSite={same_site}{secure}",
+                f"Max-Age={COOKIE_MAX_AGE}; HttpOnly; Path={path}; SameSite={same_site}{secure}"
             )
             return response
 


### PR DESCRIPTION
### Description of change

On staging, it's observed that _multiple_ set-cookie headers are received by the browser, and it's suspected that the first is set by Django. I'm not really sure why this hasn't been seen in prod. However, the cookies should be completely controlled by the proxy - any cookie set from Django should not make it back to the browser.

### Checklist

* [ ] Have tests been added to cover any changes?
