### PR TITLE
fix: update form and cleanup templates for pipelines

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
@@ -37,7 +37,7 @@ class PipelineCreateForm(GOVUKDesignSystemModelForm):
         validators=(
             RegexValidator(
                 message="Table name must be in the format <schema>.<table name>",
-                regex=r"^[a-zA-Z][a-zA-Z0-9_]*.[a-zA-Z][a-zA-Z0-9_]*$",
+                regex=r"^[a-zA-Z_][a-zA-Z0-9_]*.[a-zA-Z_][a-zA-Z0-9_]*$",
             ),
             validate_schema_and_table,
         ),

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
@@ -24,6 +24,7 @@ def save_pipeline_to_dataflow(pipeline, method):
             "schema_name": schema_name,
             "table_name": table_name,
             "type": "sql",
+            "enabled": True,
             "config": {
                 "sql": pipeline.sql_query,
             },

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
@@ -6,7 +6,7 @@ from mohawk import Sender
 from django.conf import settings
 
 
-API_URL = f"{settings.DATAFLOW_API_CONFIG['DATAFLOW_BASE_URL']}/api/derived-dags/dag"
+API_URL = f"{settings.DATAFLOW_API_CONFIG['DATAFLOW_BASE_URL']}/api/experimental/derived-dags/dag"
 HAWK_CREDS = {
     "id": settings.DATAFLOW_API_CONFIG["DATAFLOW_HAWK_ID"],
     "key": settings.DATAFLOW_API_CONFIG["DATAFLOW_HAWK_KEY"],
@@ -17,9 +17,10 @@ HAWK_CREDS = {
 def save_pipeline_to_dataflow(pipeline, method):
     url = f"{API_URL}/{pipeline.dag_id}"
     content_type = "application/json"
-    table_name, schema_name = pipeline.table_name.split(".")
+    schema_name, table_name = pipeline.table_name.split(".")
     body = json.dumps(
         {
+            "schedule": "@daily",
             "schema_name": schema_name,
             "table_name": table_name,
             "type": "sql",

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -29,7 +29,6 @@ class PipelineCreateView(CreateView):
 
     def form_valid(self, form):
         form.instance.created_by = self.request.user
-        form.instance.save()
         try:
             save_pipeline_to_dataflow(form.instance, "POST")
         except RequestException as e:
@@ -37,7 +36,7 @@ class PipelineCreateView(CreateView):
                 self.request, "Unable to sync pipeline to data flow. Please try saving again"
             )
             logger.exception(e)
-            return HttpResponseRedirect(form.instance.get_absolute_url())
+            return self.form_invalid(form)
 
         messages.success(self.request, "Pipeline created successfully.")
         return super().form_valid(form)
@@ -56,7 +55,6 @@ class PipelineUpdateView(UpdateView, UserPassesTestMixin):
 
     def form_valid(self, form):
         form.instance.updated_by = self.request.user
-        form.instance.save()
         try:
             save_pipeline_to_dataflow(form.instance, "PUT")
         except RequestException as e:
@@ -64,7 +62,7 @@ class PipelineUpdateView(UpdateView, UserPassesTestMixin):
                 self.request, "Unable to sync pipeline to data flow. Please try saving again"
             )
             logger.exception(e)
-            return HttpResponseRedirect(form.instance.get_absolute_url())
+            return self.form_invalid(form)
 
         messages.success(self.request, "Pipeline updated successfully.")
         return super().form_valid(form)

--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/delete.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/delete.html
@@ -1,5 +1,5 @@
 {% extends '_main.html' %}
-{% block page_title %}Check your answers before sending your request - {{ block.super }}{% endblock page_title %}
+{% block page_title %}Confirm deletion - {{ block.super }}{% endblock page_title %}
 {% block breadcrumbs %}
 <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">

--- a/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
+++ b/dataworkspace/dataworkspace/templates/datasets/pipelines/list.html
@@ -1,5 +1,5 @@
 {% extends '_main.html' %}
-{% block page_title %}Check your answers before sending your request - {{ block.super }}{% endblock page_title %}
+{% block page_title %}Pipelines - {{ block.super }}{% endblock page_title %}
 {% block breadcrumbs %}
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">


### PR DESCRIPTION
### Description of change

- use the correct url for the data flow api
- Do not save the pipeline if the airflow api call fails on put or post
- clean up template wording
- allow underscores in schema/tables

### Checklist

* [ ] Have tests been added to cover any changes?
