### PR TITLE
fix: ensure pipeline is deleted if dag doesn't exist on data-flow

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -89,9 +89,11 @@ class PipelineDeleteView(DeleteView, UserPassesTestMixin):
             delete_pipeline_from_dataflow(self.get_object())
         except RequestException as e:
             # If the pipeline doesn't exist on airflow, do not raise an error
-            if e.response.status_code != 404:
+            if e.response is None or e.response.status_code != 404:
                 messages.error(
-                    self.request, "Unable to sync pipeline to data flow. Please try deleting again"
+                    self.request,
+                    "There was a problem deleting the pipeline. If the issue persists please "
+                    "contact our support team.",
                 )
                 logger.exception(e)
                 return HttpResponseRedirect(reverse("pipelines:index"))

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -88,10 +88,12 @@ class PipelineDeleteView(DeleteView, UserPassesTestMixin):
         try:
             delete_pipeline_from_dataflow(self.get_object())
         except RequestException as e:
-            messages.error(
-                self.request, "Unable to sync pipeline to data flow. Please try deleting again"
-            )
-            logger.exception(e)
-            return HttpResponseRedirect(reverse("pipelines:index"))
+            # If the pipeline doesn't exist on airflow, do not raise an error
+            if e.response.status_code != 404:
+                messages.error(
+                    self.request, "Unable to sync pipeline to data flow. Please try deleting again"
+                )
+                logger.exception(e)
+                return HttpResponseRedirect(reverse("pipelines:index"))
         messages.success(self.request, "Pipeline deleted successfully.")
         return super().delete(request, *args, **kwargs)


### PR DESCRIPTION
### Description of change

Fix the issue where deleting a pipeline failed if it didn't exist on data-flow. We should allow this incase the two systems get out of sync.

### Checklist

* [ ] Have tests been added to cover any changes?
