### PR TITLE
fix: add numeric to your files data types map

### DIFF
--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -23,6 +23,7 @@ SCHEMA_POSTGRES_DATA_TYPE_MAP = {
     "date": PostgresDataTypes.DATE,
     "datetime": PostgresDataTypes.TIMESTAMP,
     "number": PostgresDataTypes.NUMERIC,
+    "numeric": PostgresDataTypes.NUMERIC,
     "text": PostgresDataTypes.TEXT,
     "uuid": PostgresDataTypes.UUID,
 }


### PR DESCRIPTION
### Description of change

Data type name should be "numeric" rather than "number" when mapping postgres data types to sqlalchemy

### Checklist

* [ ] Have tests been added to cover any changes?
