### PR TITLE
fix: ensure the correct name is used for related fields

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -859,7 +859,12 @@ def store_reference_dataset_metadata():
                 )
 
                 columns = [
-                    (field.column_name, field.get_postgres_datatype())
+                    (
+                        field.relationship_name
+                        if field.data_type == ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
+                        else field.column_name,
+                        field.get_postgres_datatype(),
+                    )
                     for field in reference_dataset.fields.all()
                 ]
                 cursor.execute(


### PR DESCRIPTION
### Description of change

Use the related name as the column name for reference dataset linked fields when storing table structure metadata

### Checklist

* [ ] Have tests been added to cover any changes?
