### PR TITLE
Revert "feat: filter cookies to and from visualisations (#1757)"

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -171,7 +171,6 @@ def api_application_dict(application_instance):
         "wrap": application_instance.application_template.wrap,
         # Used by metrics to label the application
         "name": application_instance.application_template.nice_name,
-        "type": application_instance.application_template.application_type,
     }
 
 

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -12,7 +12,6 @@ import sys
 import string
 import uuid
 import urllib
-from typing import Union
 
 import aiohttp
 import ecs_logging
@@ -21,7 +20,7 @@ from aiohttp import web
 import aioredis
 from elasticapm.contrib.aiohttp import ElasticAPM
 from hawkserver import authenticate_hawk_header
-from multidict import CIMultiDict, CIMultiDictProxy
+from multidict import CIMultiDict
 from sentry_sdk import set_user
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from yarl import URL
@@ -159,14 +158,11 @@ async def async_main():
     def get_random_context_logger():
         return ContextAdapter(logger, {"context": "".join(random.choices(CONTEXT_ALPHABET, k=8))})
 
-    def filter_headers(headers: Union[CIMultiDict, CIMultiDictProxy], exclude: list):
-        """
-        Return headers with any matches in `exclude` removed
-        """
+    def without_transfer_encoding(request_or_response):
         return tuple(
             (key, value)
-            for key, value in headers.items()
-            if key.lower() not in [x.lower() for x in exclude]
+            for key, value in request_or_response.headers.items()
+            if key.lower() != "transfer-encoding"
         )
 
     def admin_headers_request(downstream_request):
@@ -192,11 +188,15 @@ async def async_main():
         )
 
     def mirror_headers(downstream_request):
-        return filter_headers(downstream_request.headers, ["host", "transfer-encoding"])
+        return tuple(
+            (key, value)
+            for key, value in downstream_request.headers.items()
+            if key.lower() not in ["host", "transfer-encoding"]
+        )
 
     def application_headers(downstream_request):
         return (
-            filter_headers(downstream_request.headers, ["transfer-encoding"])
+            without_transfer_encoding(downstream_request)
             + (
                 (("x-scheme", downstream_request.headers["x-forwarded-proto"]),)
                 if "x-forwarded-proto" in downstream_request.headers
@@ -231,7 +231,7 @@ async def async_main():
             return "-".join([s.capitalize() for s in header.replace("_", "-").split("-")])
 
         return CIMultiDict(
-            filter_headers(downstream_request.headers, ["transfer-encoding"])
+            without_transfer_encoding(downstream_request)
             + (
                 tuple(
                     [(f"Credentials-{standardise_header(k)}", v) for k, v in credentials.items()]
@@ -463,16 +463,9 @@ async def async_main():
                 (("content-security-policy", csp_application_spawning),),
             )
 
-        is_visualisation = application["type"] == "VISUALISATION"
-
         if is_websocket:
             return await handle_application_websocket(
-                downstream_request,
-                application["proxy_url"],
-                path,
-                query,
-                port_override,
-                is_visualisation,
+                downstream_request, application["proxy_url"], path, query, port_override
             )
 
         if application["state"] == "SPAWNING":
@@ -504,18 +497,16 @@ async def async_main():
             application_upstream(application["proxy_url"], path, port_override),
             query,
             public_host,
-            is_visualisation,
         )
 
     async def handle_application_websocket(
-        downstream_request, proxy_url, path, query, port_override, is_visualisation
+        downstream_request, proxy_url, path, query, port_override
     ):
         upstream_url = application_upstream(proxy_url, path, port_override).with_query(query)
         return await handle_websocket(
             downstream_request,
             CIMultiDict(application_headers(downstream_request)),
             upstream_url,
-            filter_cookies=is_visualisation,
         )
 
     def application_upstream(proxy_url, path, port_override):
@@ -608,14 +599,10 @@ async def async_main():
         )
 
     async def handle_application_http_running_direct(
-        downstream_request,
-        method,
-        upstream_url,
-        query,
-        public_host,
-        is_visualisation,
+        downstream_request, method, upstream_url, query, public_host
     ):
         host = downstream_request.headers["host"]
+
         await send_to_google_analytics(downstream_request)
 
         return await handle_http(
@@ -632,7 +619,6 @@ async def async_main():
                     csp_application_running_direct(host, public_host),
                 ),
             ),
-            filter_cookies=is_visualisation,
         )
 
     async def handle_mirror(downstream_request, method, path):
@@ -679,9 +665,7 @@ async def async_main():
             default_http_timeout,
         )
 
-    async def handle_websocket(
-        downstream_request, upstream_headers, upstream_url, filter_cookies=False
-    ):
+    async def handle_websocket(downstream_request, upstream_headers, upstream_url):
         protocol = downstream_request.headers.get("Sec-WebSocket-Protocol")
         protocols = (protocol,) if protocol else ()
 
@@ -701,13 +685,7 @@ async def async_main():
         async def upstream():
             try:
                 async with client_session.ws_connect(
-                    str(upstream_url),
-                    headers=(
-                        CIMultiDict(filter_headers(upstream_headers, ["cookie"]))
-                        if filter_cookies
-                        else upstream_headers
-                    ),
-                    protocols=protocols,
+                    str(upstream_url), headers=upstream_headers, protocols=protocols
                 ) as upstream_ws:
                     upstream_connection.set_result(upstream_ws)
                     downstream_ws = await downstream_connection
@@ -821,31 +799,23 @@ async def async_main():
         upstream_data,
         timeout,
         response_headers=tuple(),
-        filter_cookies=False,
     ):
         async with client_session.request(
             upstream_method,
             str(upstream_url),
             params=upstream_query,
-            headers=(
-                CIMultiDict(filter_headers(upstream_headers, ["cookie"]))
-                if filter_cookies
-                else upstream_headers
-            ),
+            headers=upstream_headers,
             data=upstream_data,
             allow_redirects=False,
             timeout=timeout,
         ) as upstream_response:
+
             _, _, _, with_session_cookie = downstream_request[SESSION_KEY]
             downstream_response = await with_session_cookie(
                 web.StreamResponse(
                     status=upstream_response.status,
                     headers=CIMultiDict(
-                        filter_headers(
-                            upstream_response.headers,
-                            ["transfer-encoding"] + (["Set-Cookie"] if filter_cookies else []),
-                        )
-                        + response_headers
+                        without_transfer_encoding(upstream_response) + response_headers
                     ),
                 )
             )

--- a/test/echo_server.py
+++ b/test/echo_server.py
@@ -22,12 +22,7 @@ async def async_main():
             "headers": dict(request.headers),
         }
         return web.json_response(
-            data,
-            status=405,
-            headers={
-                "from-upstream": "upstream-header-value",
-                "Set-Cookie": "test-set-cookie",
-            },
+            data, status=405, headers={"from-upstream": "upstream-header-value"}
         )
 
     async def handle_websockets(request):

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -477,10 +477,7 @@ class TestApplication(unittest.TestCase):
 
         await until_non_202(session, "http://testvisualisation.dataworkspace.test:8000/")
 
-        sent_headers = {
-            "from-downstream": "downstream-header-value",
-            "Cookie": "test-cookie",
-        }
+        sent_headers = {"from-downstream": "downstream-header-value"}
         async with session.request(
             "GET",
             "http://testvisualisation.dataworkspace.test:8000/http",
@@ -494,10 +491,6 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_content["headers"]["sso-profile-email"], "test@test.com")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
-        # Assert that cookies were removed from the request and the response
-        self.assertNotIn("Cookie", received_content["headers"])
-        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
-        self.assertNotIn("Cookie", received_headers)
 
         stdout, stderr, code = await set_visualisation_wrap(
             "testvisualisation", "FULL_HEIGHT_IFRAME"
@@ -530,10 +523,6 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
-        # Assert that cookies were removed from the request and the response
-        self.assertNotIn("Cookie", received_content["headers"])
-        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
-        self.assertNotIn("Cookie", received_headers)
 
     @async_test
     async def test_visualisation_commit_shows_content_if_authorized(self):
@@ -624,7 +613,7 @@ class TestApplication(unittest.TestCase):
 
         await until_non_202(session, "http://testvisualisation--11372717.dataworkspace.test:8000/")
 
-        sent_headers = {"from-downstream": "downstream-header-value", "Cookie": "a-test-cookie"}
+        sent_headers = {"from-downstream": "downstream-header-value"}
         async with session.request(
             "GET",
             "http://testvisualisation--11372717.dataworkspace.test:8000/http",
@@ -637,10 +626,6 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
-        # Assert that cookies were removed from the request and the response
-        self.assertNotIn("Cookie", received_content["headers"])
-        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
-        self.assertNotIn("Cookie", received_headers)
 
         async with session.request(
             "GET",
@@ -654,10 +639,6 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["method"], "GET")
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
-        # Assert that cookies were removed from the request and the response
-        self.assertNotIn("Cookie", received_content["headers"])
-        self.assertNotEqual(received_headers["Set-Cookie"], "test-set-cookie")
-        self.assertNotIn("Cookie", received_headers)
 
     @async_test
     async def test_visualisation_shows_dataset_if_authorised(self):


### PR DESCRIPTION
### Description of change

This reverts commit c1453aef837dbb5cf5c8a2cc4403d2aa4479055a.

This is slightly speculative - there are disconnections from tools happening, some of them giving websocket-related errors, and this change touched that code. However, looking at the change, no mechanism at how it could have broken things is known.

### Checklist

* [ ] Have tests been added to cover any changes?
