### PR TITLE
fix: change data update message in changelog

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -575,8 +575,8 @@ def _get_detailed_changelog(changelog, initial_change_type):
                     else ""
                 )
             )
-        elif record["previous_data_hash"] != record["table_hash"]:
-            record["summary"] = "Data was updated"
+        elif record["previous_data_hash"] != record["data_hash"]:
+            record["summary"] = "Records in the dataset changed"
         else:
             record["summary"] = "N/A"
     return changelog

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -575,6 +575,8 @@ def _get_detailed_changelog(changelog, initial_change_type):
                     else ""
                 )
             )
+        elif record["previous_data_hash"] != record["table_hash"]:
+            record["summary"] = "Data was updated"
         else:
             record["summary"] = "N/A"
     return changelog

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -1201,7 +1201,7 @@ class TestSendNotificationEmails:
                     "dataset_name": ds.name,
                     "dataset_url": f"dataworkspace.test:8000{ds.get_absolute_url()}",
                     "manage_subscriptions_url": "dataworkspace.test:8000/datasets/email_preferences",
-                    "summary": "N/A",
+                    "summary": "Records in the dataset changed",
                 },
             )
         ]


### PR DESCRIPTION
### Description of change

- Changelog message changed from 'N/A' to 'Records in the dataset changed' for reference datasets, datacuts and master datasets when there is a data change. 
- Test updated in``` test_utils.py```

### Checklist

* [X] Have tests been added to cover any changes?
