### PR TITLE
fix: speed up team admin page by making user field autocomplete

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/admin.py
+++ b/dataworkspace/dataworkspace/apps/core/admin.py
@@ -41,6 +41,7 @@ class DeletableTimeStampedUserAdmin(TimeStampedUserAdmin):
 class TeamMembershipAdmin(admin.TabularInline):
     model = TeamMembership
     extra = 1
+    autocomplete_fields = ("user",)
 
 
 @admin.register(Team)


### PR DESCRIPTION
### Description of change

For every user in a team the admin page displays a select element with ~3000 options. Which makes the page very slow to render. Remedy this by making the user selectors autocomplete. 

### Checklist

* [ ] Have tests been added to cover any changes?
