### PR TITLE
fix: only check for pipeline statuses if pipelines exist locally

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -81,6 +81,9 @@ class PipelineListView(ListView, IsAdminMixin):
 
     def get_context_data(self, *args, **kwargs):
         context = super().get_context_data(*args, **kwargs)
+        if not context["object_list"].exists():
+            return context
+
         derived_dags = {}
         try:
             derived_dags = list_pipelines()


### PR DESCRIPTION
### Description of change

If no pipelines exist locally there is no point hitting the airflow api to fetch statues.

### Checklist

* [ ] Have tests been added to cover any changes?
