### PR TITLE
Revert "feat: shorter session timeout for security reasons"

### DIFF
--- a/dataworkspace/proxy_session.py
+++ b/dataworkspace/proxy_session.py
@@ -34,10 +34,10 @@ import time
 from aiohttp import web
 
 
-COOKIE_MAX_AGE = 60 * 30
+COOKIE_MAX_AGE = 60 * 60 * 10
 
 REDIS_KEY_PREFIX = "data_workspace_session___cookie"
-REDIS_MAX_AGE = 60 * 25
+REDIS_MAX_AGE = 60 * 60 * 9
 
 SESSION_KEY = "SESSION"
 


### PR DESCRIPTION
### Description of change

This reverts commit 6511d8f0e32cbb989a15b609ec6e9e2d6d4e2b6d.

We've had the ok to bump up the session length - for both CSP and CORS reasons, redirects to SSO and and back essentially don't work for Ajax and Websockets requests from tools.

### Checklist

* [ ] Have tests been added to cover any changes?
