### PR TITLE
fix: change host ports for minio to avoid overlap with data-flow

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -70,8 +70,8 @@ services:
       MINIO_ROOT_PASSWORD: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbb
       MINIO_REGION: eu-west-2
     ports:
-      - "9001:9001"
-      - "9000:9000"
+      - "19001:9001"
+      - "19000:9000"
     volumes:
       - ".local/minio/data:/data"
     entrypoint: sh


### PR DESCRIPTION
### Description of change
There is a conflict of ports for minio when running data-flow and data-workspace simultaneously.
This fix changes the host ports for data-workspace.

### Checklist

~* [ ] Have tests been added to cover any changes?~
