### PR TITLE
fix: don't use _ variable when loading db name as creds end up in _

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/admin.py
+++ b/dataworkspace/dataworkspace/apps/datasets/admin.py
@@ -703,7 +703,7 @@ class VisualisationLinkAdmin(admin.ModelAdmin):
         user = quicksight_client.describe_user(
             AwsAccountId=account_id, UserName=new_data_source_owner, Namespace="default"
         )["User"]
-        db_name, _ = list(settings.DATABASES_DATA.items())[0]
+        db_name = list(settings.DATABASES_DATA.items())[0][0]
         replacement_datasource_arn = (
             f"arn:aws:quicksight:{user_region}:{account_id}:datasource/"
             + get_data_source_id(db_name, user["Arn"])

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -238,7 +238,7 @@ def process_quicksight_dashboard_visualisations():
             )
             last_updated_dates = []
             tables = []
-            database_name, _ = list(settings.DATABASES_DATA.items())[0]
+            database_name = list(settings.DATABASES_DATA.items())[0][0]
 
             for data_set_arn in data_set_arns:
                 try:
@@ -372,7 +372,7 @@ def link_superset_visualisations_to_related_datasets():
 
     jwt_access_token = login_response.json()["access_token"]
 
-    database_name, _ = list(settings.DATABASES_DATA.items())[0]
+    database_name = list(settings.DATABASES_DATA.items())[0][0]
 
     for visualisation_link in VisualisationLink.objects.filter(
         visualisation_type="SUPERSET", visualisation_catalogue_item__deleted=False
@@ -598,7 +598,7 @@ def get_detailed_changelog(related_object):
             "Query creation",
         )
     elif isinstance(related_object, ReferenceDataset):
-        db_name, _ = list(settings.DATABASES_DATA.items())[0]
+        db_name = list(settings.DATABASES_DATA.items())[0][0]
         return _get_detailed_changelog(
             get_source_table_changelog(db_name, "public", related_object.table_name),
             "Reference dataset creation",
@@ -839,7 +839,7 @@ def store_reference_dataset_metadata():
         )
 
         # Get the latest metadata record
-        db_name, _ = list(settings.DATABASES_DATA.items())[0]
+        db_name = list(settings.DATABASES_DATA.items())[0][0]
         with connections[db_name].cursor() as cursor:
             cursor.execute(
                 SQL(


### PR DESCRIPTION
### Description of change

This ensures db creds aren't shown in the Sentry stack trace variables

### Checklist

* [ ] Have tests been added to cover any changes?
