### PR TITLE
feat: limit number of displayed related dashboards and link to separate page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -378,3 +378,15 @@ class RelatedDataCutsSortForm(forms.Form):
         initial="query__dataset__name",
         widget=SortSelectWidget(label="Sort by"),
     )
+
+class RelatedVisualisationsSortForm(forms.Form):
+    sort = forms.ChoiceField(
+        required=False,
+        choices=[
+            ("name", "A to Z"),
+            ("name", "Z to A"),
+            ("published_at", "Recently published"),
+        ],
+        initial="name",
+        widget=SortSelectWidget(label="Sort by"),
+    )

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -379,6 +379,7 @@ class RelatedDataCutsSortForm(forms.Form):
         widget=SortSelectWidget(label="Sort by"),
     )
 
+
 class RelatedVisualisationsSortForm(forms.Form):
     sort = forms.ChoiceField(
         required=False,

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -72,6 +72,11 @@ urlpatterns = [
         name="related_data",
     ),
     path(
+        "<uuid:dataset_uuid>/related-visualisations",
+        login_required(views.RelatedVisualisationsView.as_view()),
+        name="related_visualisations",
+    ),
+    path(
         "<uuid:dataset_uuid>/preview/<int:object_id>",
         login_required(views.DataCutPreviewView.as_view()),
         {"model_class": models.CustomDatasetQuery},

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -79,6 +79,7 @@ from dataworkspace.apps.datasets.forms import (
     EligibilityCriteriaForm,
     RelatedMastersSortForm,
     RelatedDataCutsSortForm,
+    RelatedVisualisationsSortForm,
 )
 from dataworkspace.apps.datasets.models import (
     CustomDatasetQuery,
@@ -1277,6 +1278,33 @@ class RelatedDataView(View):
                 context={
                     "dataset": dataset,
                     "related_data": related_datasets,
+                    "form": form,
+                },
+            )
+
+        return HttpResponse(status=500)
+
+
+class RelatedVisualisationsView(View):
+    def get(self, request, dataset_uuid):
+        try:
+            dataset = DataSet.objects.get(id=dataset_uuid)
+        except DataSet.DoesNotExist:
+            return HttpResponse(status=404)
+        
+        form = RelatedVisualisationsSortForm(request.GET)
+
+        if form.is_valid():
+            related_visualisations = dataset.related_visualisations.order_by(
+                form.cleaned_data.get("sort") or form.fields["sort"].initial
+            )
+
+            return render(
+                request,
+                "datasets/related_visualisations.html",
+                context={
+                    "dataset": dataset,
+                    "related_visualisations": related_visualisations,
                     "form": form,
                 },
             )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1291,7 +1291,7 @@ class RelatedVisualisationsView(View):
             dataset = DataSet.objects.get(id=dataset_uuid)
         except DataSet.DoesNotExist:
             return HttpResponse(status=404)
-        
+
         form = RelatedVisualisationsSortForm(request.GET)
 
         if form.is_valid():

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Tuple
 
-# import psqlparse
+import psqlparse
 import psycopg2
 from psycopg2.sql import SQL
 import pytz
@@ -122,7 +122,7 @@ def get_custom_dataset_query_changelog(database_name: str, query):
 
 
 def get_data_hash(cursor, sql):
-    # statements = psqlparse.parse(sql)
+    statements = psqlparse.parse(sql)
     if statements[0].sort_clause:
         hashed_data = hashlib.md5()
         cursor.execute(SQL(f"SELECT t.*::TEXT FROM ({sql}) as t"))

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -3,7 +3,7 @@ import json
 import logging
 from typing import Tuple
 
-import psqlparse
+# import psqlparse
 import psycopg2
 from psycopg2.sql import SQL
 import pytz
@@ -122,7 +122,7 @@ def get_custom_dataset_query_changelog(database_name: str, query):
 
 
 def get_data_hash(cursor, sql):
-    statements = psqlparse.parse(sql)
+    # statements = psqlparse.parse(sql)
     if statements[0].sort_clause:
         hashed_data = hashlib.md5()
         cursor.execute(SQL(f"SELECT t.*::TEXT FROM ({sql}) as t"))

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -106,11 +106,19 @@
             <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related dashboards</h3>
             <nav role="navigation">
               <ul class="govuk-list">
-                {% for master in related_visualisations %}
+                {% for master in related_visualisations|slice:":4" %}
                   <li>
                   {% include "partials/related_data_link.html" with dataset=master css_classname="related-dashboard" %}
                 {% endfor %}
                 </li>
+                {% if related_visualiations|length > 4 %}
+                <li class="govuk-!-margin-top-4">
+                  <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
+                     class="govuk-link govuk-link--no-visited-state">
+                    Show all related dashboards
+                  </a>
+                </li>
+                {% endif %}
               </ul>
             </nav>
           {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -115,11 +115,20 @@
           </h3>
           <nav role="navigation" aria-labelledby="subsection-title">
             <ul class="govuk-list">
-              {% for dataset in related_visualisations %}
+              {% for dataset in related_visualisations|slice:":4" %}
                 <li>
                   {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
                 </li>
               {% endfor %}
+
+              {% if related_visualisations|length > 4 %}
+                <li class="govuk-!-margin-top-4">
+                  <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
+                     class="govuk-link govuk-link--no-visited-state">
+                    Show all related dashboards
+                  </a>
+                </li>
+                {% endif %}
             </ul>
           </nav>
       {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/related_visualisations.html
+++ b/dataworkspace/dataworkspace/templates/datasets/related_visualisations.html
@@ -1,0 +1,49 @@
+{% extends '_main.html' %}
+{% load static core_tags %}
+
+{% block page_title %}Related dashboards for {{ dataset.name }} - Data Workspace{% endblock %}
+
+{% block go_back %}
+  <a class="govuk-back-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">
+    Back
+  </a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Related dashboards for {{ dataset.name }}</h1>
+      <form id="sort-form" method="GET">
+        {{ form.sort }}
+      </form>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    {% for dataset in related_visualisations %}
+      {% include "partials/related_data.html" with dataset=dataset css="related-dashboard" %}
+      {% if forloop.counter|divisibleby:2 %}
+        </div>
+        <div class="govuk-grid-row">
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="{{ request.path }}#body">
+    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+    </svg>
+    Back to top
+  </a>
+{% endblock %}
+
+{% block footer_scripts %}
+  <script nonce="{{ request.csp_nonce }}">
+    let sort_by = document.getElementById('{{ form.sort.id_for_label }}');
+    if (sort_by !== null) {
+      sort_by.addEventListener('change', function (e) {
+        console.log('changed');
+        document.getElementById('sort-form').submit();
+      });
+    }
+  </script>
+{% endblock %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1174,7 +1174,6 @@ class DatasetsCommon:
 
         for i in range(num):
             visualisation = factories.VisualisationDatasetFactory.create(
-                published=True,
                 type=DataSetType.VISUALISATION,
                 name=f"Dashboard {i}",
                 user_access_type=user_access_type,

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2384,16 +2384,19 @@ class TestRelatedDataView:
         return datacuts
 
     def _create_related_visualisations(self, master, num=1):
+        master_dataset = factories.DataSetFactory.create(
+            type=DataSetType.MASTER,
+            published=True,
+            user_access_type=access_type,
+        )
         visualisations = []
 
         for i in range(num):
             visualisation = factories.VisualisationDatasetFactory.create(
-                published=True,
-                type=DataSetType.VISUALISATION,
-                name=f"Visualisation {i}",
-                user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+                dataset=master_dataset, gds_phase_name=expected_gds_phase_name
             )
-            query = factories.VisualisationCatalogueItemFactory.create(
+
+            query = factories.CustomDatasetQueryFactory.create(
                 dataset=visualisation,
                 database=self._get_database(),
                 query="SELECT * FROM test_dataset order by id desc limit 10",

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1179,10 +1179,6 @@ class DatasetsCommon:
                 name=f"Dashboard {i}",
                 user_access_type=user_access_type,
             )
-            query = factories.VisualisationCatalogueItemFactory.create(
-                dataset=visualisation,
-                database=self._get_database(),
-            )
             visualisations.append(visualisation)
 
         return visualisations

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2377,7 +2377,6 @@ class TestRelatedDataView:
 
         return datacuts
 
-
     def test_view_shows_all_related_data_cuts(self, staff_client):
         master = self._create_master()
         datacuts = self._create_related_data_cuts(master, num=5)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2394,7 +2394,6 @@ class TestRelatedDataView:
             visualisation = factories.VisualisationCatalogueItemFactory.create(
                 dataset=master_dataset,
                 published=True,
-                type=DataSetType.VISUALISATION,
                 name=f"Visualisation {i}",
                 user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
             )

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1163,6 +1163,30 @@ class DatasetsCommon:
 
         return datacuts
 
+    def _create_related_visualisations(
+        self,
+        schema="public",
+        table="test_visualisations",
+        num=1,
+        user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+    ):
+        visualisations = []
+
+        for i in range(num): 
+            visualisation = factories.VisualisationDatasetFactory.create(
+                published=True,
+                type=DataSetType.VISUALISATION,
+                name=f"Dashboard {i}",
+                user_access_type=user_access_type,
+            )
+            query = factories.VisualisationCatalogueItemFactory.create(
+                dataset=visualisation,
+                database=self._get_database(),
+            )
+            visualisations.append(visualisation)
+
+        return visualisations
+
 
 class TestDatasetVisualisations:
     @pytest.mark.django_db
@@ -1265,6 +1289,15 @@ class TestMasterDatasetDetailView(DatasetsCommon):
         response = staff_client.get(url)
         assert response.status_code == 200
         assert len(response.context["related_data"]) == 2
+    
+    def test_master_dataset_detail_page_shows_related_visualisations(self, staff_client, metadata_db):
+        master = self._create_master()
+        self._create_related_visualisations(num=2)
+
+        url = reverse("datasets:dataset_detail", args=(master.id,))
+        response = staff_client.get(url)
+        assert response.status_code == 200
+        assert len(response.context["related_visualisations"]) == 2
 
     @pytest.mark.django_db
     def test_master_dataset_detail_page_shows_link_to_related_data_cuts_if_more_than_four(
@@ -1278,6 +1311,18 @@ class TestMasterDatasetDetailView(DatasetsCommon):
         assert response.status_code == 200
         assert len(response.context["related_data"]) == 5
         assert "Show all related data" in response.content.decode(response.charset)
+    
+    def test_master_dataset_detail_page_shows_link_to_related_visualisations_if_more_than_four(
+        self, staff_client, metadata_db
+    ):
+        master = self._create_master()
+        self._create_related_visualisations(num=5)
+
+        url = reverse("datasets:dataset_detail", args=(master.id,))
+        response = staff_client.get(url)
+        assert response.status_code == 200
+        assert len(response.context["related_visualisations"]) == 5
+        assert "Show all related dashboards" in response.content.decode(response.charset)
 
     @pytest.mark.django_db
     def test_master_dataset_subscription(self):
@@ -2340,6 +2385,29 @@ class TestRelatedDataView:
             datacuts.append(datacut)
 
         return datacuts
+    
+    def _create_related_visualisations(self, master, num=1):
+        visualisations = []
+
+        for i in range(num):
+            visualisation = factories.VisualisationDatasetFactory.create(
+                published=True,
+                type=DataSetType.VISUALISATION,
+                name=f"Visualisation {i}",
+                user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+            )
+            query = factories.VisualisationCatalogueItemFactory.create(
+                dataset=visualisation,
+                database=self._get_database(),
+                query="SELECT * FROM test_dataset order by id desc limit 10",
+            )
+            factories.CustomDatasetQueryTableFactory.create(
+                query=query, schema="public", table="test_dataset"
+            )
+            visualisations.append(visualisation)
+
+        return visualisations
+        
 
     def test_view_shows_all_related_data_cuts(self, staff_client):
         master = self._create_master()
@@ -2351,6 +2419,18 @@ class TestRelatedDataView:
         assert response.status_code == 200
         assert len(response.context["related_data"]) == 5
         assert all(datacut.name in body for datacut in datacuts)
+
+    
+    def test_view_shows_all_related_visualisations(self, staff_client):
+        master = self._create_master()
+        visualisations = self._create_related_visualisations(master, num=5)
+
+        url = reverse("datasets:related_visualisations", args=(master.id,))
+        response = staff_client.get(url)
+        body = response.content.decode(response.charset)
+        assert response.status_code == 200
+        assert len(response.context["related_visualisations"]) == 5
+        assert all(visualisation.name in body for visualisation in visualisations)
 
 
 class TestDatasetUsageHistory:

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2392,6 +2392,7 @@ class TestRelatedDataView:
 
         for i in range(num):
             visualisation = factories.VisualisationCatalogueItemFactory.create(
+                dataset = master_dataset,
                 published=True,
                 type=DataSetType.VISUALISATION,
                 name=f"Visualisation {i}",

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2391,15 +2391,19 @@ class TestRelatedDataView:
         visualisations = []
 
         for i in range(num):
-            visualisation = factories.VisualisationDatasetFactory.create(dataset=master_dataset)
-
+            visualisation = factories.VisualisationCatalogueItemFactory.create(
+                published=True,
+                type=DataSetType.VISUALISATION,
+                name=f"Visualisation {i}",
+                user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+            )
             query = factories.CustomDatasetQueryFactory.create(
                 dataset=visualisation,
                 database=self._get_database(),
                 query="SELECT * FROM test_dataset order by id desc limit 10",
             )
             factories.CustomDatasetQueryTableFactory.create(
-                query=query, schema="public", table="test_dataset"
+                query=query, schema="public", table="test_visualisation"
             )
             visualisations.append(visualisation)
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1172,7 +1172,7 @@ class DatasetsCommon:
     ):
         visualisations = []
 
-        for i in range(num): 
+        for i in range(num):
             visualisation = factories.VisualisationDatasetFactory.create(
                 published=True,
                 type=DataSetType.VISUALISATION,
@@ -1289,8 +1289,10 @@ class TestMasterDatasetDetailView(DatasetsCommon):
         response = staff_client.get(url)
         assert response.status_code == 200
         assert len(response.context["related_data"]) == 2
-    
-    def test_master_dataset_detail_page_shows_related_visualisations(self, staff_client, metadata_db):
+
+    def test_master_dataset_detail_page_shows_related_visualisations(
+        self, staff_client, metadata_db
+    ):
         master = self._create_master()
         self._create_related_visualisations(num=2)
 
@@ -1311,7 +1313,7 @@ class TestMasterDatasetDetailView(DatasetsCommon):
         assert response.status_code == 200
         assert len(response.context["related_data"]) == 5
         assert "Show all related data" in response.content.decode(response.charset)
-    
+
     def test_master_dataset_detail_page_shows_link_to_related_visualisations_if_more_than_four(
         self, staff_client, metadata_db
     ):
@@ -2385,7 +2387,7 @@ class TestRelatedDataView:
             datacuts.append(datacut)
 
         return datacuts
-    
+
     def _create_related_visualisations(self, master, num=1):
         visualisations = []
 
@@ -2407,7 +2409,6 @@ class TestRelatedDataView:
             visualisations.append(visualisation)
 
         return visualisations
-        
 
     def test_view_shows_all_related_data_cuts(self, staff_client):
         master = self._create_master()
@@ -2420,7 +2421,6 @@ class TestRelatedDataView:
         assert len(response.context["related_data"]) == 5
         assert all(datacut.name in body for datacut in datacuts)
 
-    
     def test_view_shows_all_related_visualisations(self, staff_client):
         master = self._create_master()
         visualisations = self._create_related_visualisations(master, num=5)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2392,7 +2392,7 @@ class TestRelatedDataView:
 
         for i in range(num):
             visualisation = factories.VisualisationCatalogueItemFactory.create(
-                dataset = master_dataset,
+                dataset=master_dataset,
                 published=True,
                 type=DataSetType.VISUALISATION,
                 name=f"Visualisation {i}",

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2387,14 +2387,11 @@ class TestRelatedDataView:
         master_dataset = factories.DataSetFactory.create(
             type=DataSetType.MASTER,
             published=True,
-            user_access_type=access_type,
         )
         visualisations = []
 
         for i in range(num):
-            visualisation = factories.VisualisationDatasetFactory.create(
-                dataset=master_dataset, gds_phase_name=expected_gds_phase_name
-            )
+            visualisation = factories.VisualisationDatasetFactory.create(dataset=master_dataset)
 
             query = factories.CustomDatasetQueryFactory.create(
                 dataset=visualisation,


### PR DESCRIPTION
### Description of change

- ```RelatedVisualisationsSortForm``` added to ```forms.py```
- ```RelatedVisualisationsView``` added to ```views.py```
- Changes made to ```master_dataset.html``` and ```data_cut_dataset.html``` to limit number of displayed dashboards 
- Separate page made for full list of related dashboards at ```related_visualisations.html```
- Tests added to ```test_views.py```

### Checklist

* [X] Have tests been added to cover any changes?
