### PR TITLE
fix: ensure only files prefixed with sourcelink are deleted from s3

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -779,7 +779,7 @@ class SourceLink(ReferenceNumberedDatasetSource):
         return True
 
     def _delete_s3_file(self):
-        if self.local_file_is_accessible():
+        if self.url.startswith("s3://sourcelink") and self.local_file_is_accessible():
             client = boto3.client("s3")
             client.delete_object(Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url)
 

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2587,7 +2587,7 @@ class TestDatasetAdmin(BaseAdminTestCase):
                 "sourcelink_set-0-id": source_link.id,
                 "sourcelink_set-0-dataset": dataset.id,
                 "sourcelink_set-0-name": "test",
-                "sourcelink_set-0-url": "http://test.com",
+                "sourcelink_set-0-url": "s3://sourcelink/a-file.txt",
                 "sourcelink_set-0-format": "test",
                 "sourcelink_set-0-frequency": "test",
                 "sourcelink_set-0-DELETE": "on",
@@ -2633,7 +2633,7 @@ class TestDatasetAdmin(BaseAdminTestCase):
                 "sourcelink_set-0-id": source_link.id,
                 "sourcelink_set-0-dataset": dataset.id,
                 "sourcelink_set-0-name": "test",
-                "sourcelink_set-0-url": "http://test.com",
+                "sourcelink_set-0-url": "s3://sourcelink/a-file.txt",
                 "sourcelink_set-0-format": "test",
                 "sourcelink_set-0-frequency": "test",
                 "sourcelink_set-0-DELETE": "on",
@@ -2657,7 +2657,7 @@ class TestDatasetAdmin(BaseAdminTestCase):
         self.assertContains(response, "was changed successfully")
         self.assertEqual(dataset.sourcelink_set.count(), link_count - 1)
         mock_client().delete_object.assert_called_once_with(
-            Bucket=settings.AWS_UPLOADS_BUCKET, Key="http://test.com"
+            Bucket=settings.AWS_UPLOADS_BUCKET, Key="s3://sourcelink/a-file.txt"
         )
 
 


### PR DESCRIPTION
### Description of change

Fixes issue where files created by data flow could potentially be deleted by users via the admin pages. 

This fix ensures only files uploaded via the admin site are able to be deleted via the admin site.

### Checklist

* [ ] Have tests been added to cover any changes?
