### PR TITLE
fix: exclude data flow temp and swap tables when finding permissions

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -201,6 +201,7 @@ def new_private_database_credentials(
                     AND schemaname NOT LIKE 'pg_temp_%'
                     AND schemaname NOT LIKE 'pg_toast_temp_%'
                     AND schemaname NOT LIKE '_team_%'
+                    AND tablename !~ '_\\d{{8}}t\\d{{6}}'
                     AND has_table_privilege({role}, quote_ident(schemaname) || '.' ||
                         quote_ident(tablename), 'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') = true
                 UNION ALL


### PR DESCRIPTION
### Description of change

There seems to be a race condition finding permissions for a user in the `get_new_credentials` method. The potential race condition happens if a table gets deleted in between selecting all tables and checking if the user has privileges on each table. In order to prevent this, temp tables and swap tables can be excluded when getting the list of all tables.

Sentry error:
https://sentry.ci.uktrade.digital/organizations/dit/issues/56207

### Checklist

* [ ] Have tests been added to cover any changes?
