### PR TITLE
feat: always show list of schemas when creating table via your files

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -646,10 +646,6 @@ def create_new_schema(schema_name):
         )
 
 
-def is_user_in_teams(user):
-    return Team.objects.filter(member=user).exists()
-
-
 def source_tables_for_user(user):
     user_email_domain = user.email.split("@")[1]
 

--- a/dataworkspace/dataworkspace/apps/your_files/views.py
+++ b/dataworkspace/dataworkspace/apps/your_files/views.py
@@ -27,7 +27,6 @@ from dataworkspace.apps.core.utils import (
     get_random_data_sample,
     get_s3_prefix,
     get_team_schemas_for_user,
-    is_user_in_teams,
     new_private_database_credentials,
     postgres_user,
     source_tables_for_user,
@@ -91,7 +90,6 @@ class CreateTableView(RequiredParameterGetRequestMixin, TemplateView):
                 "path": path,
                 "filename": path.split("/")[-1],
                 "table_name": clean_db_identifier(path),
-                "show_schema": is_user_in_teams(self.request.user),
             }
         )
         return context
@@ -227,11 +225,6 @@ class CreateTableConfirmNameView(RequiredParameterGetRequestMixin, ValidateSchem
                 }
             )
         return initial
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context.update({"show_schema": is_user_in_teams(self.request.user)})
-        return context
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-name.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-name.html
@@ -3,11 +3,7 @@
 {% block page_title %}How do you want to name your table? - {{ block.super }}{% endblock page_title %}
 
 {% block go_back %}
-  {% if show_schema %}
     <a href="{% url 'your_files:create-table-confirm-schema' %}?{% remove_query_params 'overwrite' %}" class="govuk-back-link">Back</a>
-  {% else %}
-    <a href="{% url 'your_files:create-table-confirm' %}?{% remove_query_params 'overwrite' %}" class="govuk-back-link">Back</a>
-  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-confirm.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-confirm.html
@@ -23,15 +23,9 @@
           <li class="govuk-body-l">a team schema, where your team members all have access</li>
         </ul>
       </p>
-      {% if show_schema %}
       <a href="{% url 'your_files:create-table-confirm-schema' %}?{{ request.GET.urlencode }}&table_name={{ table_name }}" class="govuk-button">
         Continue
       </a>
-      {% else %}
-      <a href="{% url 'your_files:create-table-confirm-name' %}?{{ request.GET.urlencode }}&table_name={{ table_name }}" class="govuk-button">
-        Continue
-      </a>
-      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### Description of change

Originally discovered as a bug meaning admin users were unable to select a schema unless they were in a team but decided this should apply to all users to make it very clear where the table was going to end up from the start.

### Checklist

* [ ] Have tests been added to cover any changes?
