### PR TITLE
feat: pre-register QuickSight users when they launch QuickSight

### DIFF
--- a/dataworkspace/dataworkspace/apps/accounts/admin.py
+++ b/dataworkspace/dataworkspace/apps/accounts/admin.py
@@ -1,8 +1,6 @@
 import logging
 
 from django import forms
-
-
 from django.contrib import admin, messages
 from django.contrib.admin.widgets import (
     AdminTextInputWidget,

--- a/dataworkspace/dataworkspace/tests/applications/test_views.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_views.py
@@ -271,7 +271,8 @@ class TestDataVisualisationUIApprovalPage:
 class TestQuickSightPollAndRedirect:
     @pytest.mark.django_db
     @override_settings(QUICKSIGHT_SSO_URL="https://sso.quicksight")
-    def test_view_redirects_to_quicksight_sso_url(self):
+    @mock.patch("dataworkspace.apps.applications.views.boto3.client")
+    def test_view_redirects_to_quicksight_sso_url(self, mock_boto_client):
         user = get_user_model().objects.create(is_staff=True, is_superuser=True)
 
         # Login to admin site
@@ -284,7 +285,8 @@ class TestQuickSightPollAndRedirect:
         assert resp["Location"] == "https://sso.quicksight"
 
     @pytest.mark.django_db
-    def test_view_starts_celery_polling_job(self):
+    @mock.patch("dataworkspace.apps.applications.views.boto3.client")
+    def test_view_starts_celery_polling_job(self, mock_boto_client):
         user = get_user_model().objects.create(is_staff=True, is_superuser=True)
 
         # Login to admin site


### PR DESCRIPTION
### Description of change

This is the recommended way to avoid users having to enter their email address when they first access QuickSight. It also avoids a race condition that can happen when a new user launches QuickSight via tools and doesn't complete the sign up: 

https://sentry.ci.uktrade.digital/organizations/dit/issues/53864

### Checklist

* [ ] Have tests been added to cover any changes?
