### PR TITLE
feat: add error handling to message template

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/messages.html
+++ b/dataworkspace/dataworkspace/templates/partials/messages.html
@@ -1,6 +1,6 @@
 {% for message in messages %}
   {% if message.tags == 'error' %}
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" data-module="govuk-error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
       There is a problem
       </h2>

--- a/dataworkspace/dataworkspace/templates/partials/messages.html
+++ b/dataworkspace/dataworkspace/templates/partials/messages.html
@@ -1,7 +1,19 @@
 {% for message in messages %}
-<div class="govuk-panel govuk-panel--confirmation govuk-panel--confirmation--left govuk-!-padding-5 govuk-!-margin-bottom-7" role="alert" tabindex="-1" autofocus>
-  <h1 class="govuk-panel__title govuk-!-font-size-27">
-  {{ message }}
-  </h1>
-</div>
+  {% if message.tags == 'error' %}
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+          <a>{{ message }}</a>
+      </div>
+    </div>
+  {% endif %}
+  {% if message.tags == 'success' %}
+    <div class="govuk-panel govuk-panel--confirmation govuk-panel--confirmation--left govuk-!-padding-5 govuk-!-margin-bottom-7" role="alert" tabindex="-1" autofocus>
+      <h1 class="govuk-panel__title govuk-!-font-size-27">
+      {{ message }}
+      </h1>
+    </div>
+  {% endif %}
 {% endfor %}


### PR DESCRIPTION
### Description of change

- ```messages.html``` updated to reflect difference in 'success' and 'error' messages, and use different template

### Checklist

~* [ ] Have tests been added to cover any changes?~

![Screen Shot 2022-03-01 at 3 42 59 PM](https://user-images.githubusercontent.com/91138189/156352701-7de4448e-3eb0-450a-9c56-756d1a4b0249.png)

