### PR TITLE
fix: ignore swap tables when generating user schemas

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/schema.py
+++ b/dataworkspace/dataworkspace/apps/explorer/schema.py
@@ -99,8 +99,8 @@ def build_schema_info(user, connection_alias):
               INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
             WHERE
               pg_namespace.nspname NOT IN ('information_schema', 'pg_catalog', 'pg_toast') AND
-              pg_namespace.nspname NOT LIKE 'pg_temp_%' AND
-              pg_namespace.nspname NOT LIKE 'pg_toast_temp_%' AND
+              pg_namespace.nspname NOT SIMILAR TO 'pg_temp_%|pg_toast_temp_%' AND
+              pg_class.relname NOT SIMILAR TO '%_swap|%_idx' AND
               has_schema_privilege(pg_namespace.nspname, 'USAGE') AND
               has_table_privilege(
                 quote_ident(pg_namespace.nspname) || '.' || quote_ident(pg_class.relname),


### PR DESCRIPTION
### Description of change

Hide tables ending with `_swap` and `_idx` from users in data explorer

### Checklist

* [ ] Have tests been added to cover any changes?
