### PR TITLE
feat: add searchResultClick event to Google tag manager

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
@@ -55,7 +55,7 @@
                 </style>
                 <![endif]-->
         {% endblock styles %}
-        {% if not debug and gtm_container_id %}
+        {% if GTM_ENABLED %}
           {% block initialGTMDataLayer %}
             <script nonce="{{ request.csp_nonce }}">
               window.dataLayer = window.dataLayer || [];

--- a/dataworkspace/dataworkspace/context_processors.py
+++ b/dataworkspace/dataworkspace/context_processors.py
@@ -12,10 +12,15 @@ def common(request):
     # database query.
     can_see_visualisations_tab = False
 
+    # handle this here instead of in multiple places in templates
+    # which makes it easier to debug locally
+    gtm_enabled = settings.GTM_CONTAINER_ID and not settings.DEBUG
+
     return {
         "root_href": f"{request.scheme}://{settings.APPLICATION_ROOT_DOMAIN}/",
         "can_see_visualisations_tab": can_see_visualisations_tab,
         "gtm_container_id": settings.GTM_CONTAINER_ID,
+        "GTM_ENABLED": gtm_enabled,
         "gtm_container_environment_params": settings.GTM_CONTAINER_ENVIRONMENT_PARAMS,
         "CASE_STUDIES_FLAG": settings.CASE_STUDIES_FLAG,
         "NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG": settings.NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG,

--- a/dataworkspace/dataworkspace/static/gtm-support.js
+++ b/dataworkspace/dataworkspace/static/gtm-support.js
@@ -4,6 +4,25 @@ function capitalizeFirstLetter(string) {
 
 var GTMDatasetSearchSupport = function () {};
 
+GTMDatasetSearchSupport.prototype.pushSearchResultClick =
+  function pushSearchResultClick(link) {
+    // search results are stored as data-* attributes on the link
+    // jQuery helpfully decodes these into our required object
+    var data = $(link).data();
+    try {
+      this.pushSearchResultClickEvent(data);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+GTMDatasetSearchSupport.prototype.pushSearchResultClickEvent =
+  function pushSearchResultClickEvent(data) {
+    if (typeof dataLayer == "undefined") return;
+    console.log("push to dataLayer", data);
+    var result = dataLayer.push(data);
+  };
+
 GTMDatasetSearchSupport.prototype.pushSearchEvent = function pushSearchEvent() {
   if (typeof dataLayer !== "undefined") {
     var update = {

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -25,7 +25,7 @@ var ToggleInputClassOnFocus = function ($el) {
   }
 };
 
-var LiveSearch = function (formSelector, wrapperSelector, GTM) {
+var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector) {
   this.wrapperSelector = wrapperSelector;
   this.$wrapper = $(wrapperSelector);
   this.$form = $(formSelector);
@@ -37,6 +37,10 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM) {
 
   this.originalState = this.$form.serializeArray();
   this.saveState();
+
+  this.$wrapper.on("click", linkSelector, function(e){
+    self.GTM.pushSearchResultClick(e.target);
+  });
 
   this.$form.on(
     "change",

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -22,7 +22,7 @@
   <link rel="stylesheet" href="{% static 'data-workspace.css' %}">
 
   
-  {% if gtm_container_id %}
+  {% if GTM_ENABLED %}
     {% block initialGTMDataLayer %}
       <script nonce="{{ request.csp_nonce }}">
         window.dataLayer = window.dataLayer || [];

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -96,7 +96,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
           <h3 class="govuk-heading-m">
-            <a class="govuk-link" href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}</a>
+            {% include "partials/gtm_dataset_link.html" with event_type="searchResultClick" search_page_number=datasets.number search_result_rank=forloop.counter search_type="search_bar" dataset=dataset %}
           </h3>
           {% if not dataset.published %}
             <div class="govuk-!-display-inline-block" style="float: right">
@@ -204,7 +204,7 @@
   <script nonce="{{ request.csp_nonce }}" src="{% static 'search-v2.js' %}"></script>
   <script nonce="{{ request.csp_nonce }}">
     $(document).ready(function() {
-      var form = new LiveSearch('#live-search-form', '#live-search-wrapper', new GTMDatasetSearchSupport());
+      var form = new LiveSearch('#live-search-form', '#live-search-wrapper', new GTMDatasetSearchSupport(), ".dataset-link");
       var searchInput = new ToggleInputClassOnFocus($("#live-search-form"))
     });
   </script>

--- a/dataworkspace/dataworkspace/templates/explorer/_base.html
+++ b/dataworkspace/dataworkspace/templates/explorer/_base.html
@@ -20,7 +20,7 @@
   <link rel="apple-touch-icon" href="{% static 'assets/images/govuk-apple-touch-icon.png' %}">
   <link rel="stylesheet" href="{% static 'govuk-frontend-3.12.0-without-gds-transport.min.css' %}">
 
-  {% if not debug and gtm_container_id %}
+  {% if GTM_ENABLED %}
     {% block initialGTMDataLayer %}
       <script nonce="{{ request.csp_nonce }}">
         window.dataLayer = window.dataLayer || [];

--- a/dataworkspace/dataworkspace/templates/partials/gtm_body.html
+++ b/dataworkspace/dataworkspace/templates/partials/gtm_body.html
@@ -1,4 +1,4 @@
-{% if not debug and gtm_container_id %}
+{% if GTM_ENABLED %}
     <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ gtm_container_id }}{{ gtm_container_environment_params | safe }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->

--- a/dataworkspace/dataworkspace/templates/partials/gtm_dataset_link.html
+++ b/dataworkspace/dataworkspace/templates/partials/gtm_dataset_link.html
@@ -1,0 +1,6 @@
+<a class="govuk-link dataset-link" 
+     data-search-page-number="{{ search_page_number }}"
+     data-search-result-rank="{{ search_result_rank }}"
+     data-search-type="{{ search_type }}"
+     data-event="{{ event_type }}"
+     href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}#{{ dataset.slug }}">{{ dataset.name }}</a>

--- a/dataworkspace/dataworkspace/templates/partials/gtm_head.html
+++ b/dataworkspace/dataworkspace/templates/partials/gtm_head.html
@@ -1,4 +1,4 @@
-{% if not debug and gtm_container_id %}
+{% if GTM_ENABLED %}
     <!-- Google Tag Manager -->
     <script nonce="{{ request.csp_nonce }}">
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
### Description of change
Added a new javascript handler to send a custom `searchResultClick` event to GA via GTM.
Changed how the GTM tag is added to html by adding a new context variable `GTM_ENABLED`. This moves the logic to the backend instead of the inconsistent `if` statements in the templates. This is easier to change for local dev

### Checklist

~* [ ] Have tests been added to cover any changes?~
