### PR TITLE
feature: send notifications when source tables get renamed

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -35,6 +35,7 @@ from dataworkspace.datasets_db import (
     extract_queried_tables_from_sql_query,
     get_custom_dataset_query_changelog,
     get_data_hash,
+    get_reference_dataset_changelog,
     get_source_table_changelog,
     get_tables_last_updated_date,
 )
@@ -553,6 +554,8 @@ def _get_detailed_changelog(changelog, initial_change_type):
     for record in changelog:
         if not record["previous_table_structure"] and not record["previous_data_hash"]:
             record["summary"] = initial_change_type
+        elif record["previous_table_name"] != record["table_name"]:
+            record["summary"] = f"Table renamed from {record['previous_table_name']}"
         elif record["previous_table_structure"] != record["table_structure"]:
             column_names = [c[0] for c in record["table_structure"]]
             previous_column_names = [c[0] for c in record["previous_table_structure"]]
@@ -585,22 +588,17 @@ def _get_detailed_changelog(changelog, initial_change_type):
 def get_detailed_changelog(related_object):
     if isinstance(related_object, SourceTable):
         return _get_detailed_changelog(
-            get_source_table_changelog(
-                related_object.database.memorable_name, related_object.schema, related_object.table
-            ),
+            get_source_table_changelog(related_object),
             "Table creation",
         )
     elif isinstance(related_object, CustomDatasetQuery):
         return _get_detailed_changelog(
-            get_custom_dataset_query_changelog(
-                related_object.database.memorable_name, related_object
-            ),
+            get_custom_dataset_query_changelog(related_object),
             "Query creation",
         )
     elif isinstance(related_object, ReferenceDataset):
-        db_name = list(settings.DATABASES_DATA.items())[0][0]
         return _get_detailed_changelog(
-            get_source_table_changelog(db_name, "public", related_object.table_name),
+            get_reference_dataset_changelog(related_object),
             "Reference dataset creation",
         )
     return []
@@ -615,7 +613,35 @@ def get_change_item(related_object, change_id):
 
 
 @celery_app.task()
-def store_custom_dataset_query_table_structures():
+def update_metadata_with_source_table_id():
+    database_name = list(settings.DATABASES_DATA.items())[0][0]
+    with connections[database_name].cursor() as cursor:
+        cursor.execute(
+            SQL(
+                "SELECT id,table_schema,table_name "
+                "FROM dataflow.metadata "
+                "WHERE data_type={} "
+                "AND data_ids IS NULL"
+            ).format(Literal(DataSetType.MASTER))
+        )
+        metadata = cursor.fetchall()
+
+        for metadata_id, schema, table in metadata:
+            source_tables = list(
+                SourceTable.objects.filter(schema=schema, table=table).values_list("id", flat=True)
+            )
+            if not source_tables:
+                continue
+            cursor.execute(
+                SQL("UPDATE dataflow.metadata SET data_ids ={} WHERE id={}").format(
+                    Literal(source_tables),
+                    Literal(metadata_id),
+                )
+            )
+
+
+@celery_app.task()
+def store_custom_dataset_query_metadata():
     for query in CustomDatasetQuery.objects.filter(dataset__published=True):
         sql = query.query.rstrip().rstrip(";")
 
@@ -633,9 +659,16 @@ def store_custom_dataset_query_table_structures():
         with connections[query.database.memorable_name].cursor() as cursor:
             cursor.execute(
                 SQL(
-                    "SELECT DISTINCT ON(source_data_modified_utc) source_data_modified_utc::TIMESTAMP AT TIME ZONE 'UTC' "
-                    "FROM dataflow.metadata WHERE data_id={} ORDER BY source_data_modified_utc DESC"
-                ).format(Literal(query.id))
+                    "SELECT DISTINCT ON(source_data_modified_utc) "
+                    "source_data_modified_utc::TIMESTAMP AT TIME ZONE 'UTC' "
+                    "FROM dataflow.metadata "
+                    "WHERE {} =ANY(data_ids) "
+                    "AND data_type = {} "
+                    "ORDER BY source_data_modified_utc DESC"
+                ).format(
+                    Literal(str(query.id)),
+                    Literal(int(DataSetType.DATACUT)),
+                )
             )
             metadata = cursor.fetchone()
             if not metadata or last_updated_date != metadata[0]:
@@ -646,15 +679,116 @@ def store_custom_dataset_query_table_structures():
                 cursor.execute(
                     SQL(
                         "INSERT INTO dataflow.metadata"
-                        "(source_data_modified_utc, table_structure, data_hash_v1, data_id, data_type)"
+                        "(source_data_modified_utc, table_structure, data_hash_v1, data_ids, data_type)"
                         "VALUES ({},{},{},{},{})"
                     ).format(
                         Literal(last_updated_date),
                         Literal(json.dumps(columns)),
                         Literal(data_hash),
-                        Literal(query.id),
+                        Literal([str(query.id)]),
                         Literal(int(DataSetType.DATACUT)),
                     )
+                )
+
+
+@celery_app.task()
+def store_reference_dataset_metadata():
+    for reference_dataset in ReferenceDataset.objects.live().filter(published=True):
+        logger.info(
+            "Checking for metadata update for reference dataset '%s'", reference_dataset.name
+        )
+
+        # Get the update date from reference dataset
+        latest_update_date = reference_dataset.modified_date
+
+        # Get the latest modified date from this reference dataset's fields
+        latest_update_date = max(
+            reference_dataset.fields.latest("modified_date").modified_date, latest_update_date
+        )
+
+        # Get the latest date the data in this dataset was updated
+        data_updated = reference_dataset.data_last_updated
+        if data_updated:
+            latest_update_date = max(latest_update_date, data_updated)
+
+        # Get the latest data updated dates for any linked reference datasets
+        linked_datasets_updated_dates = [
+            field.linked_reference_dataset_field.reference_dataset.data_last_updated
+            for field in reference_dataset.fields.filter(
+                data_type=ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
+            )
+        ]
+        if linked_datasets_updated_dates:
+            latest_update_date = max(latest_update_date, max(linked_datasets_updated_dates))
+
+        logger.info(
+            "Latest update date for reference dataset '%s' is %s",
+            reference_dataset.name,
+            latest_update_date,
+        )
+
+        # Get the latest metadata record
+        db_name = list(settings.DATABASES_DATA.items())[0][0]
+        with connections[db_name].cursor() as cursor:
+            cursor.execute(
+                SQL(
+                    "SELECT DISTINCT ON(source_data_modified_utc)"
+                    "source_data_modified_utc::TIMESTAMP AT TIME ZONE 'UTC' "
+                    "FROM dataflow.metadata "
+                    "WHERE {} = any(data_ids) "
+                    "AND data_type = {} "
+                    "ORDER BY source_data_modified_utc DESC"
+                ).format(
+                    Literal(str(reference_dataset.id)),
+                    Literal(int(DataSetType.REFERENCE)),
+                )
+            )
+            metadata = cursor.fetchone()
+
+            # If the metadata record is older than our latest updated date write a new record
+            if not metadata or latest_update_date > metadata[0]:
+                logger.info(
+                    "Creating new metadata record for reference dataset '%s'",
+                    reference_dataset.name,
+                )
+
+                columns = [
+                    (
+                        field.relationship_name
+                        if field.data_type == ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
+                        else field.column_name,
+                        field.get_postgres_datatype(),
+                    )
+                    for field in reference_dataset.fields.all()
+                ]
+                cursor.execute(
+                    SQL(
+                        """
+                        INSERT INTO dataflow.metadata (
+                            source_data_modified_utc,
+                            table_schema,
+                            table_name,
+                            table_structure,
+                            data_hash_v1,
+                            data_type,
+                            data_ids
+                        )
+                        VALUES ({},'public', {}, {}, {}, {}, {})
+                        """
+                    ).format(
+                        Literal(latest_update_date),
+                        Literal(reference_dataset.table_name),
+                        Literal(json.dumps(columns)),
+                        Literal(reference_dataset.get_metadata_table_hash()),
+                        Literal(int(DataSetType.REFERENCE)),
+                        Literal([reference_dataset.id]),
+                    )
+                )
+            else:
+                logger.info(
+                    "Not creating a metadata record for %s as the last updated date is before %s",
+                    reference_dataset.name,
+                    metadata[0],
                 )
 
 
@@ -695,7 +829,9 @@ def send_notification_emails():
 
             # For now only notify about the most recent change
             change = changelog[0]
-            schema_change = change["previous_table_structure"] != change["table_structure"]
+            schema_change = (change["previous_table_structure"] != change["table_structure"]) or (
+                change["previous_table_name"] != change["table_name"]
+            )
             data_change = change["previous_data_hash"] != change["data_hash"]
 
             notification, created = Notification.objects.get_or_create(
@@ -753,7 +889,10 @@ def send_notification_emails():
                         user_notification.notification.changelog_id,
                     )
                     change_date = change["change_date"]
-                    if change["previous_table_structure"] != change["table_structure"]:
+
+                    if (change["previous_table_structure"] != change["table_structure"]) or (
+                        change["previous_table_name"] != change["table_name"]
+                    ):
                         template_id = settings.NOTIFY_DATASET_NOTIFICATIONS_COLUMNS_TEMPLATE_ID
                     elif change["previous_data_hash"] != change["data_hash"]:
                         template_id = settings.NOTIFY_DATASET_NOTIFICATIONS_ALL_DATA_TEMPLATE_ID
@@ -800,99 +939,3 @@ def send_notification_emails():
         logger.error("Exception when creating notifications: %s", e)
     else:
         send_notifications()
-
-
-@celery_app.task()
-def store_reference_dataset_metadata():
-    for reference_dataset in ReferenceDataset.objects.live().filter(published=True):
-        logger.info(
-            "Checking for metadata update for reference dataset '%s'", reference_dataset.name
-        )
-
-        # Get the update date from reference dataset
-        latest_update_date = reference_dataset.modified_date
-
-        # Get the latest modified date from this reference dataset's fields
-        latest_update_date = max(
-            reference_dataset.fields.latest("modified_date").modified_date, latest_update_date
-        )
-
-        # Get the latest date the data in this dataset was updated
-        data_updated = reference_dataset.data_last_updated
-        if data_updated:
-            latest_update_date = max(latest_update_date, data_updated)
-
-        # Get the latest data updated dates for any linked reference datasets
-        linked_datasets_updated_dates = [
-            field.linked_reference_dataset_field.reference_dataset.data_last_updated
-            for field in reference_dataset.fields.filter(
-                data_type=ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
-            )
-        ]
-        if linked_datasets_updated_dates:
-            latest_update_date = max(latest_update_date, max(linked_datasets_updated_dates))
-
-        logger.info(
-            "Latest update date for reference dataset '%s' is %s",
-            reference_dataset.name,
-            latest_update_date,
-        )
-
-        # Get the latest metadata record
-        db_name = list(settings.DATABASES_DATA.items())[0][0]
-        with connections[db_name].cursor() as cursor:
-            cursor.execute(
-                SQL(
-                    "SELECT DISTINCT ON(source_data_modified_utc)"
-                    "source_data_modified_utc::TIMESTAMP AT TIME ZONE 'UTC' "
-                    "FROM dataflow.metadata "
-                    "WHERE table_schema = 'public' "
-                    "AND table_name = {} "
-                    "ORDER BY source_data_modified_utc DESC"
-                ).format(Literal(reference_dataset.table_name))
-            )
-            metadata = cursor.fetchone()
-
-            # If the metadata record is older than our latest updated date write a new record
-            if not metadata or latest_update_date > metadata[0]:
-                logger.info(
-                    "Creating new metadata record for reference dataset '%s'",
-                    reference_dataset.name,
-                )
-
-                columns = [
-                    (
-                        field.relationship_name
-                        if field.data_type == ReferenceDatasetField.DATA_TYPE_FOREIGN_KEY
-                        else field.column_name,
-                        field.get_postgres_datatype(),
-                    )
-                    for field in reference_dataset.fields.all()
-                ]
-                cursor.execute(
-                    SQL(
-                        """
-                        INSERT INTO dataflow.metadata (
-                            source_data_modified_utc,
-                            table_schema,
-                            table_name,
-                            table_structure,
-                            data_hash_v1,
-                            data_type
-                        )
-                        VALUES ({},'public', {}, {}, {}, {})
-                        """
-                    ).format(
-                        Literal(latest_update_date),
-                        Literal(reference_dataset.table_name),
-                        Literal(json.dumps(columns)),
-                        Literal(reference_dataset.get_metadata_table_hash()),
-                        Literal(int(DataSetType.REFERENCE)),
-                    )
-                )
-            else:
-                logger.info(
-                    "Not creating a metadata record for %s as the last updated date is before %s",
-                    reference_dataset.name,
-                    metadata[0],
-                )

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -359,13 +359,13 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "schedule": 60 * 5,
             "args": (),
         },
-        "store-custom-dataset-query-table-structures": {
-            "task": "dataworkspace.apps.datasets.utils.store_custom_dataset_query_table_structures",
+        "update-metadata-with-source-table-id": {
+            "task": "dataworkspace.apps.datasets.utils.update_metadata_with_source_table_id",
             "schedule": 60 * 5,
             "args": (),
         },
-        "send-notification-emails": {
-            "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
+        "store-custom-dataset-query-metadata": {
+            "task": "dataworkspace.apps.datasets.utils.store_custom_dataset_query_metadata",
             "schedule": 60 * 5,
             "args": (),
         },
@@ -377,6 +377,11 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
         "refresh-published-chart-data": {
             "task": "dataworkspace.apps.explorer.tasks.refresh_published_chart_data",
             "schedule": crontab(minute=0, hour=6),
+            "args": (),
+        },
+        "send-notification-emails": {
+            "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
+            "schedule": 60 * 5,
             "args": (),
         },
     }

--- a/dataworkspace/dataworkspace/tests/conftest.py
+++ b/dataworkspace/dataworkspace/tests/conftest.py
@@ -150,7 +150,7 @@ def metadata_db(db):
                 source_data_modified_utc TIMESTAMP WITHOUT TIME ZONE,
                 dataflow_swapped_tables_utc TIMESTAMP WITHOUT TIME ZONE,
                 table_structure JSONB,
-                data_id INTEGER,
+                data_ids TEXT[],
                 data_type INTEGER NOT NULL,
                 data_hash_v1 TEXT,
                 primary_keys TEXT[]
@@ -188,7 +188,7 @@ def test_dataset(db):
                 source_data_modified_utc TIMESTAMP WITHOUT TIME ZONE,
                 dataflow_swapped_tables_utc TIMESTAMP WITHOUT TIME ZONE,
                 table_structure JSONB,
-                data_id INTEGER,
+                data_ids TEXT[],
                 data_type INTEGER NOT NULL,
                 data_hash_v1 TEXT
             );


### PR DESCRIPTION
### Description of change

https://trello.com/c/tPQap2hk/2440-notifications-master-dataset-and-data-cuts-updates

This adds a celery task that iterates over metadata records inserted by dataflow and sets their data_ids to the SourceTable object ids.

This required changing the dataflow.metadata data_id column to text array in order to handle multiple source tables with the same schema and table name.

Related DataFlow PR: https://github.com/uktrade/data-flow/pull/1224

<img width="1013" alt="Screenshot 2022-03-08 at 14 43 32" src="https://user-images.githubusercontent.com/915598/157260923-e1296d8f-29e7-454d-a6cf-826e63c69dac.png">



### Checklist

* [ ] Have tests been added to cover any changes?
