### PR TITLE
feat: run query with limit 0 before saving

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
@@ -1,5 +1,7 @@
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+from django.db import connections
 
 from dataworkspace.apps.datasets.models import Pipeline
 from dataworkspace.forms import (
@@ -53,16 +55,16 @@ class PipelineCreateForm(GOVUKDesignSystemModelForm):
     )
 
     def clean_sql_query(self):
-        import psqlparse
+        import psqlparse  # pylint: disable=import-outside-toplevel
 
         try:
             statements = psqlparse.parse(self.cleaned_data["sql_query"])
         except psqlparse.exceptions.PSqlParseError as e:
-            raise ValidationError(e)
+            raise ValidationError(e) from e
         else:
             if len(statements) > 1:
                 raise ValidationError("Enter a single statement")
-            if type(statements[0]) == dict:
+            if isinstance(statements[0], dict):
                 if "CreateStmt" in statements[0]:
                     raise ValidationError("CREATE statements are not supported")
                 if "DropStmt" in statements[0]:
@@ -70,6 +72,16 @@ class PipelineCreateForm(GOVUKDesignSystemModelForm):
             columns = [t.name for t in statements[0].target_list]
             if len(columns) != len(set(columns)):
                 raise ValidationError("Duplicate column names found")
+
+        # Check that the query runs
+        with connections[list(settings.DATABASES_DATA.items())[0][0]].cursor() as cursor:
+            try:
+                cursor.execute(f"SELECT * FROM ({self.cleaned_data['sql_query']}) sq LIMIT 0")
+            except Exception as e:  # pylint: disable=broad-except
+                raise ValidationError(
+                    "Error running query. Please check the query runs successfully before saving."
+                ) from e
+
         return self.cleaned_data["sql_query"]
 
 

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/forms.py
@@ -1,3 +1,5 @@
+import psqlparse
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -55,8 +57,6 @@ class PipelineCreateForm(GOVUKDesignSystemModelForm):
     )
 
     def clean_sql_query(self):
-        import psqlparse  # pylint: disable=import-outside-toplevel
-
         try:
             statements = psqlparse.parse(self.cleaned_data["sql_query"])
         except psqlparse.exceptions.PSqlParseError as e:

--- a/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_pipelines.py
@@ -182,3 +182,14 @@ def test_pipeline_log_failure(staff_client, mocker):
         follow=True,
     )
     assert "There is a problem" in resp.content.decode(resp.charset)
+
+
+@mock.patch("dataworkspace.apps.datasets.pipelines.views.save_pipeline_to_dataflow")
+def test_query_fails_to_run(mock_sync, staff_client):
+    staff_client.post(reverse("admin:index"), follow=True)
+    resp = staff_client.post(
+        reverse("pipelines:create"),
+        data={"table_name": "test", "sql_query": "SELECT * from doesnt_exist;"},
+        follow=True,
+    )
+    assert b"Error running query" in resp.content


### PR DESCRIPTION
### Description of change

Ensure a derived query runs before sending to airflow. We need to validate on the data workspace side as the derived pipeline api airflow plugin does not have a connection to the datasets db to validate it itself.

### Checklist

* [x] Have tests been added to cover any changes?
