### PR TITLE
fix: gtm searchType should depend on whether user has entered a query

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -583,6 +583,7 @@ def find_datasets(request):
             "data_type": dict(data_types),
             "show_admin_filters": has_unpublished_dataset_access(request.user),
             "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
+            "search_type": "searchBar" if query else "noSearch",
         },
     )
 

--- a/dataworkspace/dataworkspace/static/gtm-support.js
+++ b/dataworkspace/dataworkspace/static/gtm-support.js
@@ -19,8 +19,7 @@ GTMDatasetSearchSupport.prototype.pushSearchResultClick =
 GTMDatasetSearchSupport.prototype.pushSearchResultClickEvent =
   function pushSearchResultClickEvent(data) {
     if (typeof dataLayer == "undefined") return;
-    console.log("push to dataLayer", data);
-    var result = dataLayer.push(data);
+    dataLayer.push(data);
   };
 
 GTMDatasetSearchSupport.prototype.pushSearchEvent = function pushSearchEvent() {

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -96,7 +96,7 @@
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
           <h3 class="govuk-heading-m">
-            {% include "partials/gtm_dataset_link.html" with event_type="searchResultClick" search_page_number=datasets.number search_result_rank=forloop.counter search_type="search_bar" dataset=dataset %}
+            {% include "partials/gtm_dataset_link.html" with event_type="searchResultClick" search_page_number=datasets.number search_result_rank=forloop.counter search_type=search_type dataset=dataset %}
           </h3>
           {% if not dataset.published %}
             <div class="govuk-!-display-inline-block" style="float: right">


### PR DESCRIPTION
### Description of change
Make `searchType` depend on whether the user has typed a search term on the datasets page
Removed console.log from javascript

### Checklist

~* [ ] Have tests been added to cover any changes?~
