### PR TITLE
fix: allow for filtering the grid on array fields

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/constants.py
+++ b/dataworkspace/dataworkspace/apps/datasets/constants.py
@@ -18,6 +18,10 @@ GRID_DATA_TYPE_MAP = {
     "timestamp without time zone": "date",
     "date": "date",
     "boolean": "boolean",
+    "text[]": "array",
+    "varchar[]": "array",
+    "uuid[]": "array",
+    "integer[]": "array",
 }
 
 

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -117,7 +117,12 @@ function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, expo
     }
     else if (column.dataType === 'uuid') {
       column.filterParams = {
-        filterOptions: ['equals', 'notEquals']
+        filterOptions: ['equals', 'notEqual']
+      };
+    }
+    else if (column.dataType === 'array') {
+      column.filterParams = {
+        filterOptions: ['contains', 'notContains', 'equals', 'notEqual']
       };
     }
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -2945,13 +2945,14 @@ class TestGridDataView:
                     id UUID primary key,
                     name VARCHAR(255),
                     num NUMERIC,
-                    date DATE
+                    date DATE,
+                    an_array TEXT[]
                 );
                 TRUNCATE TABLE source_data_test;
                 INSERT INTO source_data_test
-                VALUES('896b4dde-f787-41be-a7bf-82be91805f24', 'the first record', 1, NULL);
+                VALUES('896b4dde-f787-41be-a7bf-82be91805f24', 'the first record', 1, NULL, '{abc, def}');
                 INSERT INTO source_data_test
-                VALUES('488d06b6-032b-467a-b2c5-2820610b0ca6', 'the second record', 2, '2019-01-01');
+                VALUES('488d06b6-032b-467a-b2c5-2820610b0ca6', 'the second record', 2, '2019-01-01', '{ghi, jkl}');
                 INSERT INTO source_data_test
                 VALUES('a41da88b-ffa3-4102-928c-b3937fa5b58f', 'the last record', NULL, '2020-01-01');
                 """
@@ -3041,6 +3042,7 @@ class TestGridDataView:
                     "num": None,
                     "date": "2020-01-01",
                     "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
+                    "an_array": None,
                 }
             ]
         }
@@ -3076,12 +3078,14 @@ class TestGridDataView:
                     "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
                     "name": "the second record",
                     "num": "2",
+                    "an_array": ["ghi", "jkl"],
                 },
                 {
                     "date": None,
                     "id": "896b4dde-f787-41be-a7bf-82be91805f24",
                     "name": "the first record",
                     "num": "1",
+                    "an_array": ["abc", "def"],
                 },
             ]
         }
@@ -3117,6 +3121,7 @@ class TestGridDataView:
                     "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
                     "name": "the second record",
                     "num": "2",
+                    "an_array": ["ghi", "jkl"],
                 }
             ]
         }
@@ -3152,12 +3157,14 @@ class TestGridDataView:
                     "id": "896b4dde-f787-41be-a7bf-82be91805f24",
                     "name": "the first record",
                     "num": "1",
+                    "an_array": ["abc", "def"],
                 },
                 {
                     "date": "2020-01-01",
                     "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
                     "name": "the last record",
                     "num": None,
+                    "an_array": None,
                 },
             ]
         }
@@ -3192,6 +3199,7 @@ class TestGridDataView:
                     "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
                     "name": "the last record",
                     "num": None,
+                    "an_array": None,
                 }
             ]
         }
@@ -3226,6 +3234,7 @@ class TestGridDataView:
                     "id": "896b4dde-f787-41be-a7bf-82be91805f24",
                     "name": "the first record",
                     "num": "1",
+                    "an_array": ["abc", "def"],
                 }
             ]
         }
@@ -3261,6 +3270,7 @@ class TestGridDataView:
                     "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
                     "name": "the second record",
                     "num": "2",
+                    "an_array": ["ghi", "jkl"],
                 }
             ]
         }
@@ -3296,6 +3306,7 @@ class TestGridDataView:
                     "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
                     "name": "the second record",
                     "num": "2",
+                    "an_array": ["ghi", "jkl"],
                 }
             ]
         }
@@ -3331,7 +3342,166 @@ class TestGridDataView:
                     "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
                     "name": "the last record",
                     "num": None,
+                    "an_array": None,
                 }
+            ]
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "fixture_name, url_name",
+        (
+            ("source_table", "source_table_data"),
+            ("custom_query", "custom_dataset_query_data"),
+        ),
+    )
+    def test_array_contains_filter(self, client, fixture_name, url_name, request):
+        source = request.getfixturevalue(fixture_name)
+        response = client.post(
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            {
+                "filters": {
+                    "an_array": {
+                        "filter": "ghi",
+                        "filterType": "array",
+                        "type": "contains",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "records": [
+                {
+                    "date": "2019-01-01",
+                    "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
+                    "name": "the second record",
+                    "num": "2",
+                    "an_array": ["ghi", "jkl"],
+                }
+            ]
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "fixture_name, url_name",
+        (
+            ("source_table", "source_table_data"),
+            ("custom_query", "custom_dataset_query_data"),
+        ),
+    )
+    def test_array_not_contains_filter(self, client, fixture_name, url_name, request):
+        source = request.getfixturevalue(fixture_name)
+        response = client.post(
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            {
+                "filters": {
+                    "an_array": {
+                        "filter": "ghi",
+                        "filterType": "array",
+                        "type": "notContains",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "records": [
+                {
+                    "date": None,
+                    "id": "896b4dde-f787-41be-a7bf-82be91805f24",
+                    "name": "the first record",
+                    "num": "1",
+                    "an_array": ["abc", "def"],
+                },
+                {
+                    "date": "2020-01-01",
+                    "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
+                    "name": "the last record",
+                    "num": None,
+                    "an_array": None,
+                },
+            ]
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "fixture_name, url_name",
+        (
+            ("source_table", "source_table_data"),
+            ("custom_query", "custom_dataset_query_data"),
+        ),
+    )
+    def test_array_equals_filter(self, client, fixture_name, url_name, request):
+        source = request.getfixturevalue(fixture_name)
+        response = client.post(
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            {
+                "filters": {
+                    "an_array": {
+                        "filter": "ghi, jkl",
+                        "filterType": "array",
+                        "type": "equals",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "records": [
+                {
+                    "date": "2019-01-01",
+                    "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
+                    "name": "the second record",
+                    "num": "2",
+                    "an_array": ["ghi", "jkl"],
+                }
+            ]
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "fixture_name, url_name",
+        (
+            ("source_table", "source_table_data"),
+            ("custom_query", "custom_dataset_query_data"),
+        ),
+    )
+    def test_array_not_equals_filter(self, client, fixture_name, url_name, request):
+        source = request.getfixturevalue(fixture_name)
+        response = client.post(
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            {
+                "filters": {
+                    "an_array": {
+                        "filter": "abc, def",
+                        "filterType": "array",
+                        "type": "notEqual",
+                    }
+                },
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "records": [
+                {
+                    "date": "2019-01-01",
+                    "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
+                    "name": "the second record",
+                    "num": "2",
+                    "an_array": ["ghi", "jkl"],
+                },
+                {
+                    "date": "2020-01-01",
+                    "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
+                    "name": "the last record",
+                    "num": None,
+                    "an_array": None,
+                },
             ]
         }
 


### PR DESCRIPTION
### Description of change

Adds equal/not equal and contains/not contains filters for array fields

### Checklist

* [ ] Have tests been added to cover any changes?
