### PR TITLE
feat: clear pipeline rather than triggering

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/utils.py
@@ -67,16 +67,11 @@ def delete_pipeline_from_dataflow(pipeline):
     return response.json()
 
 
-def run_pipeline(pipeline, run_by_user):
-    url = (
-        f"{settings.DATAFLOW_API_CONFIG['DATAFLOW_BASE_URL']}/api/experimental/"
-        f"dags/{pipeline.dag_id}/dag_runs"
-    )
+def run_pipeline(pipeline):
+    url = f"{API_URL}/dag/{pipeline.dag_id}/run"
     method = "POST"
     content_type = "application/json"
-    body = json.dumps(
-        {"replace_microseconds": "false", "conf": {"run_by_user": run_by_user.get_full_name()}}
-    )
+    body = ""
     header = Sender(
         HAWK_CREDS,
         url,

--- a/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/pipelines/views.py
@@ -122,7 +122,7 @@ class PipelineRunView(View, IsAdminMixin):
     def post(self, request, pk, *args, **kwargs):
         pipeline = get_object_or_404(Pipeline, pk=pk)
         try:
-            run_pipeline(pipeline, request.user)
+            run_pipeline(pipeline)
         except RequestException as e:
             messages.error(
                 self.request,


### PR DESCRIPTION
### Description of change

Call the derived api `run/` endpoint rather than airflow's own. This allows us to clear dag runs rather than trigger manually. Which means the schedule is unchanged by users manually running their pipelines

### Checklist

* [ ] Have tests been added to cover any changes?
