### PR TITLE
fix: remove GDPR training requirement from tools access requests

### DIFF
--- a/dataworkspace/dataworkspace/templates/request_access/tools_1.html
+++ b/dataworkspace/dataworkspace/templates/request_access/tools_1.html
@@ -28,20 +28,14 @@
             </p>
             
             <p class="govuk-body">
-                <strong>You must have completed within the last 12 months:</strong>
+                <strong>You must have completed the 
+                <a href="https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g" class="govuk-link">Security and Data Protection</a> training on Civil Service Learning
+                within the last 12 months:</strong>
             </p>
-            <ul class="govuk-list govuk-list--bullet">
-
-                <li><a href="https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g" class="govuk-link">Security and Data Protection</a> training on Civil Service Learning</li>
-
-                <li><a href="https://app.ihasco.co.uk/training/programme/3627" class="govuk-link">GDPR Essentials</a> training on iHASCO</li>
-
-            </ul>
             <p class="govuk-body">
-                These are <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/mandatory-training/" class="govuk-link">mandatory training</a> courses for DIT staff.
+                This is a <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/mandatory-training/" class="govuk-link">mandatory training</a> course for DIT staff.
             </p>
 
-            <p class="govuk-body">We will check you've completed the GDPR Essentials training course.</p>
 
             <p class="govuk-body">
                 <strong>If you are successful, you will be given access to:</strong>

--- a/dataworkspace/dataworkspace/templates/request_access/tools_1.html
+++ b/dataworkspace/dataworkspace/templates/request_access/tools_1.html
@@ -30,7 +30,7 @@
             <p class="govuk-body">
                 <strong>You must have completed the 
                 <a href="https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g" class="govuk-link">Security and Data Protection</a> training on Civil Service Learning
-                within the last 12 months:</strong>
+                within the last 12 months.</strong>
             </p>
             <p class="govuk-body">
                 This is a <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/mandatory-training/" class="govuk-link">mandatory training</a> course for DIT staff.


### PR DESCRIPTION
### Description of change

- GDPR ihasco course requirement removed from ```tools_1.html```
- To only be merged and deployed on **April 1st 2022**

### Checklist

~* [ ] Have tests been added to cover any changes?~
