### PR TITLE
fix: remove import of apps-tabs-css for data explorer

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/share.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/share.html
@@ -10,7 +10,6 @@
 
 {% block styles %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'app-tabs.css' %}">
   <link rel="stylesheet" href="{% static 'assets/vendor/highlight/styles/a11y-light.css' %}">
 {% endblock styles %}
 {% block content %}


### PR DESCRIPTION
### Description of change
Removed the import of apps-tabs.css to fix error on sharing query page for Data Explorer

### Checklist

~* [ ] Have tests been added to cover any changes?~
