### PR TITLE
fix: remove GDPR training requirement from tools access requests

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
@@ -56,8 +56,8 @@
       </p>
       <p class="govuk-body">
         Join the <a target="_blank"
-        href="https://teams.microsoft.com/l/team/19%3ac1f08445f252403982e22a387b30b4ca%40thread.skyp[…]-22c152ea7cb9&tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86"
-        class="govuk-link">Data Workspace Community</a> for help, support and advice, 
+        href="{{ TEAMS_DATA_WORKSPACE_COMMUNITY_URL }}"
+        class="govuk-link">Data Workspace Community</a> for help, support and advice,
         or request to be added via the<a 
         class="govuk-link" 
         href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>
@@ -65,8 +65,7 @@
 
       <p class="govuk-body">
         Find out our latest dataset and improvements on our <a
-        href="https://data-services-help.trade.gov.uk/data-workspace/updates/roadmap/" 
-        class="govuk-link">roadmap</a>.
+        href="{{ DATA_WORKSPACE_ROADMAP_URL }}" class="govuk-link">roadmap</a>.
       </p>
 
       <p class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
@@ -56,13 +56,17 @@
       </p>
       <p class="govuk-body">
         Join the <a target="_blank"
-        href="{{ TEAMS_DATA_WORKSPACE_COMMUNITY_URL }}"
-        class="govuk-link">Data Workspace Community</a> for help, support and advice.
+        href="https://teams.microsoft.com/l/team/19%3ac1f08445f252403982e22a387b30b4ca%40thread.skyp[…]-22c152ea7cb9&tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86"
+        class="govuk-link">Data Workspace Community</a> for help, support and advice, 
+        or request to be added via the<a 
+        class="govuk-link" 
+        href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>
       </p>
 
       <p class="govuk-body">
         Find out our latest dataset and improvements on our <a
-        href="{{ DATA_WORKSPACE_ROADMAP_URL }}" class="govuk-link">roadmap</a>.
+        href="https://data-services-help.trade.gov.uk/data-workspace/updates/roadmap/" 
+        class="govuk-link">roadmap</a>.
       </p>
 
       <p class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/step_4_confirm.html
@@ -58,7 +58,7 @@
         Join the <a target="_blank"
         href="{{ TEAMS_DATA_WORKSPACE_COMMUNITY_URL }}"
         class="govuk-link">Data Workspace Community</a> for help, support and advice,
-        or request to be added via the<a 
+        or request to be added via the <a 
         class="govuk-link" 
         href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>
       </p>

--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
@@ -68,8 +68,8 @@
       </p>
       <p class="govuk-body">
         Join the <a
-        href="https://teams.microsoft.com/l/team/19%3ac1f08445f252403982e22a387b30b4ca%40thread.skyp[…]-22c152ea7cb9&tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86"
-        class="govuk-link">Data Workspace Community</a> for help, support and advice, 
+        href="https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fteam%2F19%3Ac1f08445f252403982e22a387b30b4ca%40thread.skype%2Fconversations%3FgroupId%3D748264d0-f2a0-4e13-afa0-22c152ea7cb9%26tenantId%3D8fa217ec-33aa-46fb-ad96-dfe68006bb86&amp;type=team&amp;deeplinkId=87aab110-11a4-4caf-860d-3610d220f5fa&amp;directDl=true&amp;msLaunch=true&amp;enableMobilePage=true&amp;suppressPrompt=true"
+        class="govuk-link">Data Workspace Community</a> for help, support and advice,
         or request to be added via the<a 
         class="govuk-link" 
         href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>

--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
@@ -70,7 +70,7 @@
         Join the <a
         href="https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fteam%2F19%3Ac1f08445f252403982e22a387b30b4ca%40thread.skype%2Fconversations%3FgroupId%3D748264d0-f2a0-4e13-afa0-22c152ea7cb9%26tenantId%3D8fa217ec-33aa-46fb-ad96-dfe68006bb86&amp;type=team&amp;deeplinkId=87aab110-11a4-4caf-860d-3610d220f5fa&amp;directDl=true&amp;msLaunch=true&amp;enableMobilePage=true&amp;suppressPrompt=true"
         class="govuk-link">Data Workspace Community</a> for help, support and advice,
-        or request to be added via the<a 
+        or request to be added via the <a 
         class="govuk-link" 
         href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>
       </p>

--- a/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
+++ b/dataworkspace/dataworkspace/templates/datasets/subscriptions/unsubscribe_confirm.html
@@ -68,8 +68,11 @@
       </p>
       <p class="govuk-body">
         Join the <a
-        href="https://teams.microsoft.com/dl/launcher/launcher.html?url=%2F_%23%2Fl%2Fteam%2F19%3Ac1f08445f252403982e22a387b30b4ca%40thread.skype%2Fconversations%3FgroupId%3D748264d0-f2a0-4e13-afa0-22c152ea7cb9%26tenantId%3D8fa217ec-33aa-46fb-ad96-dfe68006bb86&amp;type=team&amp;deeplinkId=87aab110-11a4-4caf-860d-3610d220f5fa&amp;directDl=true&amp;msLaunch=true&amp;enableMobilePage=true&amp;suppressPrompt=true"
-        class="govuk-link">Data Workspace Community</a> for help, support and advice.
+        href="https://teams.microsoft.com/l/team/19%3ac1f08445f252403982e22a387b30b4ca%40thread.skyp[…]-22c152ea7cb9&tenantId=8fa217ec-33aa-46fb-ad96-dfe68006bb86"
+        class="govuk-link">Data Workspace Community</a> for help, support and advice, 
+        or request to be added via the<a 
+        class="govuk-link" 
+        href="https://data.trade.gov.uk/support-and-feedback/">on-site support form.</a>
       </p>
 
       <p class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/request_access/tools_1.html
+++ b/dataworkspace/dataworkspace/templates/request_access/tools_1.html
@@ -28,20 +28,13 @@
             </p>
             
             <p class="govuk-body">
-                <strong>You must have completed within the last 12 months:</strong>
+                <strong>You must have completed the 
+                    <a href="https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g" class="govuk-link">Security and Data Protection</a> training on Civil Service Learning
+                    within the last 12 months.</strong>
             </p>
-            <ul class="govuk-list govuk-list--bullet">
-
-                <li><a href="https://learn.civilservice.gov.uk/courses/1bzxx1maReOyvnxFIYOP1g" class="govuk-link">Security and Data Protection</a> training on Civil Service Learning</li>
-
-                <li><a href="https://app.ihasco.co.uk/training/programme/3627" class="govuk-link">GDPR Essentials</a> training on iHASCO</li>
-
-            </ul>
             <p class="govuk-body">
-                These are <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/mandatory-training/" class="govuk-link">mandatory training</a> courses for DIT staff.
+                This is a <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/mandatory-training/" class="govuk-link">mandatory training</a> course for DIT staff.
             </p>
-
-            <p class="govuk-body">We will check you've completed the GDPR Essentials training course.</p>
 
             <p class="govuk-body">
                 <strong>If you are successful, you will be given access to:</strong>


### PR DESCRIPTION
### Description of change

- GDPR ihasco course requirement removed from ```tools_1.html```
- To only be merged and deployed on **April 1st 2022**

### Checklist

~* [ ] Have tests been added to cover any changes?~
