### PR TITLE
refactor: consolidate boto3 s3 calls to enable local endpoints

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/boto3_client.py
+++ b/dataworkspace/dataworkspace/apps/core/boto3_client.py
@@ -1,0 +1,14 @@
+import logging
+
+import boto3
+from django.conf import settings
+
+logger = logging.getLogger("app")
+
+
+def get_s3_client():
+    if settings.S3_LOCAL_ENDPOINT_URL:
+        logger.debug("using local S3 endpoint %s", settings.S3_LOCAL_ENDPOINT_URL)
+        return boto3.client("s3", endpoint_url=settings.S3_LOCAL_ENDPOINT_URL)
+
+    return boto3.client("s3")

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -12,14 +12,14 @@ from typing import Tuple
 
 from timeit import default_timer as timer
 
+import boto3
+
 import gevent
 import gevent.queue
 
 import psycopg2
 from psycopg2 import connect, sql
 from psycopg2.sql import SQL
-
-import boto3
 
 
 from django.contrib.auth import get_user_model
@@ -29,6 +29,7 @@ from django.db import connections, connection
 from django.db.models import Q
 from django.conf import settings
 
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.models import Database, DatabaseUser, Team
 from dataworkspace.apps.datasets.constants import UserAccessType
 from dataworkspace.apps.datasets.models import DataSet, SourceTable, ReferenceDataset
@@ -551,7 +552,7 @@ def write_credentials_to_bucket(user, creds):
     logger.info("settings.NOTEBOOKS_BUCKET %s", settings.NOTEBOOKS_BUCKET)
     if settings.NOTEBOOKS_BUCKET is not None:
         bucket = settings.NOTEBOOKS_BUCKET
-        s3_client = boto3.client("s3")
+        s3_client = get_s3_client()
         s3_prefix = (
             "user/federated/"
             + stable_identification_suffix(str(user.profile.sso_id), short=False)

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import boto3
 from botocore.exceptions import ClientError
 from django.http import (
     HttpResponse,
@@ -17,6 +16,7 @@ from django.urls import reverse
 from django.views import View
 from django.views.generic import FormView
 
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.forms import (
     SupportForm,
     TechnicalSupportForm,
@@ -196,7 +196,7 @@ class ServeS3UploadedFileView(View):
         if not path.startswith(file_storage.base_prefix):
             return HttpResponseNotFound()
 
-        client = boto3.client("s3")
+        client = get_s3_client()
         try:
             file_object = client.get_object(Bucket=file_storage.bucket, Key=path)
         except ClientError as ex:

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -15,7 +15,6 @@ from typing import Optional, List
 
 from psycopg2 import sql
 
-import boto3
 from botocore.exceptions import ClientError
 from ckeditor.fields import RichTextField
 
@@ -44,6 +43,7 @@ from django.utils.text import slugify
 from django.utils import timezone
 
 from dataworkspace import datasets_db
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.models import (
     TimeStampedModel,
     DeletableTimestampedUserModel,
@@ -783,7 +783,7 @@ class SourceLink(ReferenceNumberedDatasetSource):
         Check whether we can access the file on s3
         :return:
         """
-        client = boto3.client("s3")
+        client = get_s3_client()
         try:
             client.head_object(Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url)
         except ClientError:
@@ -792,7 +792,7 @@ class SourceLink(ReferenceNumberedDatasetSource):
 
     def _delete_s3_file(self):
         if self.url.startswith("s3://sourcelink") and self.local_file_is_accessible():
-            client = boto3.client("s3")
+            client = get_s3_client()
             client.delete_object(Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url)
 
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
@@ -839,7 +839,7 @@ class SourceLink(ReferenceNumberedDatasetSource):
     def get_data_last_updated_date(self):
         if self.link_type == self.TYPE_LOCAL:
             try:
-                metadata = boto3.client("s3").head_object(
+                metadata = get_s3_client().head_object(
                     Bucket=settings.AWS_UPLOADS_BUCKET, Key=self.url
                 )
                 return metadata.get("LastModified")
@@ -861,7 +861,7 @@ class SourceLink(ReferenceNumberedDatasetSource):
         ):
             return None, []
 
-        client = boto3.client("s3")
+        client = get_s3_client()
 
         # Only read a maximum of 100Kb in for preview purposes. This should stop us getting
         # denial-of-service'd by files with a massive amount of data in the first few columns

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -9,7 +9,6 @@ from contextlib import closing
 from itertools import chain
 from typing import Set
 
-import boto3
 import psycopg2
 from botocore.exceptions import ClientError
 from csp.decorators import csp_update
@@ -53,6 +52,7 @@ from waffle.mixins import WaffleFlagMixin
 from dataworkspace import datasets_db
 from dataworkspace.apps.api_v1.core.views import invalidate_superset_user_cached_credentials
 from dataworkspace.apps.applications.models import ApplicationInstance
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.errors import DatasetPermissionDenied, DatasetPreviewDisabledError
 from dataworkspace.apps.core.utils import (
     StreamingHttpResponseWithoutDjangoDbConnection,
@@ -614,7 +614,7 @@ class SourceLinkDownloadView(DetailView):
         if source_link.link_type == source_link.TYPE_EXTERNAL:
             return HttpResponseRedirect(source_link.url)
 
-        client = boto3.client("s3")
+        client = get_s3_client()
         try:
             file_object = client.get_object(
                 Bucket=settings.AWS_UPLOADS_BUCKET, Key=source_link.url

--- a/dataworkspace/dataworkspace/apps/dw_admin/views.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/views.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import boto3
 
 from botocore.exceptions import ClientError
 
@@ -15,6 +14,7 @@ from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.views.generic import FormView, CreateView
 
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.datasets.models import (
     ReferenceDataset,
     ReferenceDatasetField,
@@ -368,7 +368,7 @@ class SourceLinkUploadView(UserPassesTestMixin, CreateView):  # pylint: disable=
         source_link.url = os.path.join(
             "s3://", "sourcelink", str(source_link.id), form.cleaned_data["file"].name
         )
-        client = boto3.client("s3")
+        client = get_s3_client()
         try:
             client.put_object(
                 Body=form.cleaned_data["file"],

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -1,10 +1,10 @@
-import boto3
 from botocore.exceptions import ClientError
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, MaxLengthValidator
 
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.utils import get_all_schemas, get_s3_prefix
 from dataworkspace.apps.your_files.utils import SCHEMA_POSTGRES_DATA_TYPE_MAP
 from dataworkspace.forms import (
@@ -49,7 +49,7 @@ class CreateTableForm(GOVUKDesignSystemForm):
 
     def clean_path(self):
         path = self.cleaned_data["path"]
-        client = boto3.client("s3")
+        client = get_s3_client()
 
         if not path.startswith(get_s3_prefix(str(self.user.profile.sso_id))):
             raise ValidationError("You don't have permission to access this file")

--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -4,13 +4,13 @@ import os
 import re
 from io import StringIO
 
-import boto3
 import requests
 
 from django.conf import settings
 from mohawk import Sender
 from tableschema import Schema
 
+from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.utils import (
     USER_SCHEMA_STEM,
     db_role_schema_suffix_for_user,
@@ -32,7 +32,7 @@ TABLESCHEMA_FIELD_TYPE_MAP = {
 
 
 def get_s3_csv_column_types(path):
-    client = boto3.client("s3")
+    client = get_s3_client()
 
     # Let's just read the first 100KiB of the file and assume that will give us enough lines to make reasonable
     # assumptions about data types. This is an alternative to reading the first ~10 lines, in which case the first line
@@ -115,7 +115,7 @@ def clean_db_identifier(identifier):
 
 
 def copy_file_to_uploads_bucket(from_path, to_path):
-    client = boto3.client("s3")
+    client = get_s3_client()
     client.copy_object(
         CopySource={"Bucket": settings.NOTEBOOKS_BUCKET, "Key": from_path},
         Bucket=settings.AWS_UPLOADS_BUCKET,

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -68,7 +68,7 @@ class TestDeleteUnusedDatasetsUsers:
 class TestSyncQuickSightPermissions:
     @pytest.mark.django_db
     @mock.patch("dataworkspace.apps.core.utils.new_private_database_credentials")
-    @mock.patch("dataworkspace.apps.applications.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_create_new_data_source(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
@@ -157,7 +157,7 @@ class TestSyncQuickSightPermissions:
 
     @pytest.mark.django_db
     @mock.patch("dataworkspace.apps.core.utils.new_private_database_credentials")
-    @mock.patch("dataworkspace.apps.applications.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_list_user_pagination(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
@@ -227,7 +227,7 @@ class TestSyncQuickSightPermissions:
 
     @pytest.mark.django_db
     @mock.patch("dataworkspace.apps.core.utils.new_private_database_credentials")
-    @mock.patch("dataworkspace.apps.applications.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_update_existing_data_source(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
@@ -341,7 +341,7 @@ class TestSyncQuickSightPermissions:
 
     @pytest.mark.django_db
     @mock.patch("dataworkspace.apps.core.utils.new_private_database_credentials")
-    @mock.patch("dataworkspace.apps.applications.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_missing_user_handled_gracefully(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
@@ -1013,7 +1013,7 @@ class TestSyncToolQueryLogs:
 
     @pytest.mark.django_db(transaction=True)
     @freeze_time("2020-12-08 18:04:00")
-    @mock.patch("dataworkspace.apps.applications.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @override_settings(
         PGAUDIT_LOG_TYPE="rds",
         CACHES={"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}},

--- a/dataworkspace/dataworkspace/tests/applications/test_views.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_views.py
@@ -271,7 +271,7 @@ class TestDataVisualisationUIApprovalPage:
 class TestQuickSightPollAndRedirect:
     @pytest.mark.django_db
     @override_settings(QUICKSIGHT_SSO_URL="https://sso.quicksight")
-    @mock.patch("dataworkspace.apps.applications.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_view_redirects_to_quicksight_sso_url(self, mock_boto_client):
         user = get_user_model().objects.create(is_staff=True, is_superuser=True)
 
@@ -285,7 +285,7 @@ class TestQuickSightPollAndRedirect:
         assert resp["Location"] == "https://sso.quicksight"
 
     @pytest.mark.django_db
-    @mock.patch("dataworkspace.apps.applications.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_view_starts_celery_polling_job(self, mock_boto_client):
         user = get_user_model().objects.create(is_staff=True, is_superuser=True)
 
@@ -507,7 +507,7 @@ class TestVisualisationLogs:
             "dataworkspace.apps.applications.views._application_template"
         )
         mock_get_application_template.return_value = application_template
-        mock_boto = mocker.patch("dataworkspace.apps.applications.utils.boto3.client")
+        mock_boto = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
         mock_boto.return_value.get_log_events.side_effect = botocore.exceptions.ClientError(
             error_response={"Error": {"Code": "ResourceNotFoundException"}},
             operation_name="get_log_events",
@@ -544,7 +544,7 @@ class TestVisualisationLogs:
             "dataworkspace.apps.applications.views._application_template"
         )
         mock_get_application_template.return_value = application_template
-        mock_boto = mocker.patch("dataworkspace.apps.applications.utils.boto3.client")
+        mock_boto = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
         mock_boto.return_value.get_log_events.side_effect = [
             {
                 "nextForwardToken": "12345",

--- a/dataworkspace/dataworkspace/tests/core/test_storage.py
+++ b/dataworkspace/dataworkspace/tests/core/test_storage.py
@@ -11,7 +11,7 @@ from dataworkspace.apps.core.storage import (
 
 
 @mock.patch("dataworkspace.apps.core.storage.uuid.uuid4")
-@mock.patch("dataworkspace.apps.core.storage.boto3.client")
+@mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
 @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
 def test_file_save(mock_upload_to_clamav, mock_client, mock_uuid):
     mock_upload_to_clamav.return_value = ClamAVResponse({"malware": False})
@@ -33,7 +33,7 @@ def test_file_save(mock_upload_to_clamav, mock_client, mock_uuid):
 
 @override_settings(LOCAL=False)
 @mock.patch("dataworkspace.apps.core.storage.uuid.uuid4")
-@mock.patch("dataworkspace.apps.core.storage.boto3.client")
+@mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
 @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
 def test_file_save_throws_exception_when_virus_found(
     mock_upload_to_clamav, mock_client, mock_uuid

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -361,7 +361,7 @@ def test_appstream_link_only_shown_to_user_with_permission(
 
 
 def test_media_serve_unauthenticated(mocker, unauthenticated_client):
-    mock_client = mocker.patch("dataworkspace.apps.core.storage.boto3.client")
+    mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     mock_client().head_object.side_effect = [
         botocore.exceptions.ClientError(
             error_response={"Error": {"Message": "it failed"}},
@@ -373,7 +373,7 @@ def test_media_serve_unauthenticated(mocker, unauthenticated_client):
 
 
 def test_media_serve_no_path(mocker, client):
-    mock_client = mocker.patch("dataworkspace.apps.core.storage.boto3.client")
+    mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     mock_client().head_object.side_effect = [
         botocore.exceptions.ClientError(
             error_response={"Error": {"Message": "it failed"}},
@@ -385,7 +385,7 @@ def test_media_serve_no_path(mocker, client):
 
 
 def test_media_serve_invalid_path(mocker, client):
-    mock_client = mocker.patch("dataworkspace.apps.core.storage.boto3.client")
+    mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     mock_client().head_object.side_effect = [
         botocore.exceptions.ClientError(
             error_response={"Error": {"Message": "it failed"}},
@@ -397,7 +397,7 @@ def test_media_serve_invalid_path(mocker, client):
 
 
 def test_media_s3_error(mocker, client):
-    mock_client = mocker.patch("dataworkspace.apps.core.storage.boto3.client")
+    mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     mock_client().get_object.side_effect = [
         botocore.exceptions.ClientError(
             error_response={
@@ -412,7 +412,7 @@ def test_media_s3_error(mocker, client):
 
 
 def test_media_s3_valid_file(mocker, client):
-    mock_client = mocker.patch("dataworkspace.apps.core.storage.boto3.client")
+    mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     file_content = b"some file content stored on s3"
     mock_client().get_object.return_value = {
         "ContentType": "text/plain",

--- a/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_download_views.py
@@ -503,7 +503,7 @@ class TestSourceLinkDownloadView:
         indirect=["request_client"],
     )
     @pytest.mark.django_db
-    @mock.patch("dataworkspace.apps.datasets.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_download_local_file(self, mock_client, request_client, published, access_type):
         dataset = factories.DataSetFactory.create(
             published=published, user_access_type=access_type

--- a/dataworkspace/dataworkspace/tests/datasets/test_models.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_models.py
@@ -201,7 +201,7 @@ def test_custom_query_data_last_updated(metadata_db):
 
 
 @pytest.mark.django_db
-@mock.patch("dataworkspace.apps.datasets.views.boto3.client")
+@mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
 def test_source_link_data_last_updated(mock_client):
     dataset = factories.DataSetFactory.create()
     local_link = factories.SourceLinkFactory(
@@ -239,7 +239,7 @@ def test_source_link_data_last_updated(mock_client):
 class TestSourceLinkPreview:
     @pytest.fixture
     def mock_client(self, mocker):
-        return mocker.patch("dataworkspace.apps.datasets.models.boto3.client")
+        return mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
 
     def test_not_s3_link(self):
         link = factories.SourceLinkFactory(url="http://example.com/a-file.csv")

--- a/dataworkspace/dataworkspace/tests/datasets/test_preview_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_preview_views.py
@@ -261,7 +261,7 @@ class TestDataCutPreviewDownloadView:
             dataset=dataset,
             url="s3://sourcelink/158776ec-5c40-4c58-ba7c-a3425905ec45/test.csv",
         )
-        mock_client = mocker.patch("dataworkspace.apps.datasets.models.boto3.client")
+        mock_client = mocker.patch("dataworkspace.apps.core.boto3_client.boto3.client")
         mock_client().head_object.return_value = {"ContentType": "text/csv"}
         csv_content = b"header1,header2\nrow1 col1, row1 col2\nrow2 col1, row2 col2\n"
         mock_client().get_object.return_value = {

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -195,7 +195,7 @@ class TestToolsAccessOnly:
         "access_type", (UserAccessType.REQUIRES_AUTHENTICATION, UserAccessType.OPEN)
     )
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
-    @mock.patch("dataworkspace.apps.request_access.views.models.storage.boto3")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_user_redirected_to_step_2_after_step_1_form_submission(
         self, mock_boto, _upload_to_clamav, access_type, client, metadata_db
     ):
@@ -287,7 +287,7 @@ class TestToolsAccessOnly:
     @pytest.mark.parametrize(
         "access_type", (UserAccessType.REQUIRES_AUTHENTICATION, UserAccessType.OPEN)
     )
-    @mock.patch("dataworkspace.apps.request_access.views.models.storage.boto3")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.request_access.views.zendesk.Zenpy")
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
     def test_zendesk_ticket_created_after_form_submission(
@@ -486,7 +486,7 @@ class TestEditAccessRequest:
         assert access_request.contact_email == "updated@example.com"
         assert access_request.reason_for_access == "I still need it"
 
-    @mock.patch("dataworkspace.apps.request_access.views.models.storage.boto3")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
     def test_edit_training_screenshot(self, mock_upload_to_clamav, mock_boto, client, user):
         mock_upload_to_clamav.return_value = ClamAVResponse({"malware": False})
@@ -512,7 +512,7 @@ class TestEditAccessRequest:
         access_request.refresh_from_db()
         assert access_request.training_screenshot.name.split("!")[0] == "new-file.txt"
 
-    @mock.patch("dataworkspace.apps.request_access.views.models.storage.boto3")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
     def test_cannot_access_other_users_access_request(
         self, mock_upload_to_clamav, mock_boto, client, user

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2390,7 +2390,7 @@ class TestSourceLinkAdmin(BaseAdminTestCase):
         )
         self.assertContains(response, "Upload source link")
 
-    @mock.patch("dataworkspace.apps.dw_admin.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_source_link_upload_failure(self, mock_client):
         mock_client().put_object.side_effect = ClientError(
             error_response={"Error": {"Message": "it failed"}},
@@ -2412,7 +2412,7 @@ class TestSourceLinkAdmin(BaseAdminTestCase):
         self.assertEqual(response.status_code, 500)
         self.assertEqual(link_count, dataset.sourcelink_set.count())
 
-    @mock.patch("dataworkspace.apps.dw_admin.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_source_link_upload(self, mock_client):
         dataset = factories.DataSetFactory.create()
         link_count = dataset.sourcelink_set.count()
@@ -2561,7 +2561,7 @@ class TestDatasetAdmin(BaseAdminTestCase):
         self.assertContains(response, "was changed successfully")
         self.assertEqual(dataset.sourcelink_set.count(), link_count - 1)
 
-    @mock.patch("dataworkspace.apps.datasets.models.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_delete_local_source_link_aws_failure(self, mock_client):
         dataset = factories.DataSetFactory.create()
         source_link = factories.SourceLinkFactory(link_type=SourceLink.TYPE_LOCAL, dataset=dataset)
@@ -2611,7 +2611,7 @@ class TestDatasetAdmin(BaseAdminTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(dataset.sourcelink_set.count(), link_count - 1)
 
-    @mock.patch("dataworkspace.apps.datasets.models.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_delete_local_source_link(self, mock_client):
         dataset = factories.DataSetFactory.create()
         source_link = factories.SourceLinkFactory(link_type=SourceLink.TYPE_LOCAL, dataset=dataset)

--- a/dataworkspace/dataworkspace/tests/test_models.py
+++ b/dataworkspace/dataworkspace/tests/test_models.py
@@ -811,7 +811,7 @@ class TestReferenceDatasets(ReferenceDatasetsMixin, BaseModelsTests):
 
 
 class TestSourceLinkModel(BaseTestCase):
-    @mock.patch("dataworkspace.apps.datasets.models.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_delete_local_source_link(self, mock_client):
         dataset = factories.DataSetFactory.create(
             published=True, user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
@@ -831,7 +831,7 @@ class TestSourceLinkModel(BaseTestCase):
             Bucket=settings.AWS_UPLOADS_BUCKET, Key=link.url
         )
 
-    @mock.patch("dataworkspace.apps.datasets.models.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     def test_delete_external_source_link(self, mock_client):
         dataset = factories.DataSetFactory.create(
             published=True, user_access_type=UserAccessType.REQUIRES_AUTHENTICATION

--- a/dataworkspace/dataworkspace/tests/your_files/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_utils.py
@@ -19,7 +19,7 @@ from dataworkspace.apps.your_files.utils import get_s3_csv_column_types
         b'col1,col2\n"row1-col1",1\n"row2\ncol1",2\n"row3\ncol\n1"',
     ],
 )
-@mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+@mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
 def test_s3_csv_column_types(mock_client, csv_content):
     mock_client().head_object.return_value = {"ContentType": "text/csv"}
     mock_client().get_object.return_value = {

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -45,7 +45,7 @@ class TestCreateTableViews:
         )
         assert "We can’t process your CSV file" in response.content.decode("utf-8")
 
-    @mock.patch("dataworkspace.apps.datasets.views.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_non_existent_file(self, mock_get_s3_prefix, mock_boto_client, client):
         mock_boto_client().head_object.side_effect = [
@@ -64,7 +64,7 @@ class TestCreateTableViews:
 
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
     def test_trigger_failed(
@@ -114,7 +114,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.views.trigger_dataflow_dag")
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
     def test_success(
@@ -180,7 +180,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_confirm_schema_with_teams(
         self,
@@ -224,7 +224,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_confirm_schema_without_teams(
         self,
@@ -264,7 +264,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_confirm_schema_staff_user(
         self,
@@ -306,7 +306,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_staff_user_create_new_schema(
         self,
@@ -342,7 +342,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_staff_user_create_new_schema_success(
         self,
@@ -384,7 +384,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.forms.get_schema_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_team_schemas_for_user")
     @mock.patch("dataworkspace.apps.your_files.forms.get_all_schemas")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_staff_user_create_new_schema_fail(
         self,
@@ -419,7 +419,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.views.trigger_dataflow_dag")
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_success_team_schema(
         self,
@@ -492,7 +492,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.views.trigger_dataflow_dag")
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_success_all_schemas(
         self,
@@ -585,7 +585,7 @@ class TestCreateTableViews:
 
     @freeze_time("2021-01-01 01:01:01")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_invalid_table_name(
         self, mock_get_s3_prefix, mock_boto_client, mock_get_column_types, client
@@ -605,7 +605,7 @@ class TestCreateTableViews:
 
     @freeze_time("2021-01-01 01:01:01")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     def test_table_name_too_long(
         self, mock_get_s3_prefix, mock_boto_client, mock_get_column_types, client
@@ -627,7 +627,7 @@ class TestCreateTableViews:
     @mock.patch("dataworkspace.apps.your_files.views.trigger_dataflow_dag")
     @mock.patch("dataworkspace.apps.your_files.views.copy_file_to_uploads_bucket")
     @mock.patch("dataworkspace.apps.your_files.views.get_s3_csv_column_types")
-    @mock.patch("dataworkspace.apps.your_files.utils.boto3.client")
+    @mock.patch("dataworkspace.apps.core.boto3_client.boto3.client")
     @mock.patch("dataworkspace.apps.your_files.forms.get_s3_prefix")
     @mock.patch("dataworkspace.apps.your_files.views.get_schema_for_user")
     def test_table_exists_override(


### PR DESCRIPTION
### Description of change
Move all calls to create S3 client to a helper function to allow easier proxying of AWS endpoints for local development.

### Checklist

* [x] Have tests been added to cover any changes?
