### PR TITLE
fix: correct selector for filters and try catch if gtm fails

### DIFF
--- a/dataworkspace/dataworkspace/static/gtm-support.js
+++ b/dataworkspace/dataworkspace/static/gtm-support.js
@@ -32,7 +32,7 @@ GTMDatasetSearchSupport.prototype.pushSearchEvent = function pushSearchEvent() {
       ),
     };
 
-    $("#live-search-form .accordion-filter").map(function () {
+    $("#live-search-form .accordion-filter .govuk-accordion__section").map(function () {
       var labels = [];
       var filterId = $(this).attr("id").replace(/^id_/, "");
       $(this)

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -111,7 +111,11 @@ LiveSearch.prototype.formChange = function formChange(e) {
     pageUpdated.done(
       function () {
         if (typeof this.GTM !== "undefined") {
-          this.GTM.pushSearchEvent();
+          try {
+            this.GTM.pushSearchEvent();
+          } catch(e){
+            console.error(e);
+          }
         }
 
         var newPath =


### PR DESCRIPTION
### Description of change
Fix selector for filters and GTM datalayer.
Add try/catch to GTM datapush so it doesn't block updating of history

### Checklist

~* [ ] Have tests been added to cover any changes?~
