### PR TITLE
feat: don't explicitly set creds for Python snippets

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -122,13 +122,11 @@ def get_python_snippet(query):
     `backslash`, `"` and `'''` are also escaped
     """
     query = query.replace("\\", "\\\\").replace('"', '\\"')
-    return f"""import os
-import pandas
+    return f"""import pandas
 import psycopg2
 import sqlalchemy
 
-conn = psycopg2.connect(os.environ['DATABASE_DSN__datasets_1'])
-engine = sqlalchemy.create_engine('postgresql://', creator=lambda: conn, execution_options={{"stream_results": True}})
+engine = sqlalchemy.create_engine('postgresql://', execution_options={{"stream_results": True}})
 chunks = pandas.read_sql(sqlalchemy.text(\"""{query}\"""), engine, chunksize=10000)
 for chunk in chunks:
     display(chunk)"""


### PR DESCRIPTION
### Description of change

Now that credentials are populated using libpq-compatible environment variables, credentials don't need to be passed explicitly for code that uses libpq.

### Checklist

* [ ] Have tests been added to cover any changes?
