### PR TITLE
feat: limit prefetching and close admin db connection where possible in celery

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -28,6 +28,7 @@ from dataworkspace.apps.applications.gitlab import (
     gitlab_api_v4_ecr_pipeline_trigger,
 )
 from dataworkspace.apps.core.utils import (
+    close_admin_db_connection_if_not_in_atomic_block,
     close_all_connections_if_not_in_atomic_block,
     create_tools_access_iam_role,
     stable_identification_suffix,
@@ -132,6 +133,7 @@ class ProcessSpawner:
                     db_persistent_role=creds["db_persistent_role"],
                 )
 
+            close_admin_db_connection_if_not_in_atomic_block()
             gevent.sleep(1)
             cmd = json.loads(spawner_options)["CMD"]
 
@@ -145,10 +147,12 @@ class ProcessSpawner:
                 {"process_id": proc.pid}
             )
             application_instance.save(update_fields=["spawner_application_instance_id"])
+            close_admin_db_connection_if_not_in_atomic_block()
 
             gevent.sleep(1)
             application_instance.proxy_url = "http://localhost:8888/"
             application_instance.save(update_fields=["proxy_url"])
+            close_admin_db_connection_if_not_in_atomic_block()
         except Exception:  # pylint: disable=broad-except
             logger.exception("PROCESS %s %s", application_instance.id, spawner_options)
             if proc:
@@ -265,8 +269,12 @@ class FargateSpawner:
 
             logger.info("Starting %s", cmd)
 
+            user_email = user.email
+            user_profile_sso_id = user.profile.sso_id
+            close_admin_db_connection_if_not_in_atomic_block()
+
             role_arn, s3_prefix = create_tools_access_iam_role(
-                user.email, str(user.profile.sso_id), user_efs_access_point_id
+                user_email, str(user_profile_sso_id), user_efs_access_point_id
             )
 
             s3_env = {
@@ -284,10 +292,14 @@ class FargateSpawner:
                 and application_instance.application_template.gitlab_project_id
                 and not _ecr_tag_exists(ecr_repository_name, tag)
             ):
+                gitlab_project_id = application_instance.application_template.gitlab_project_id
+                commit_id = application_instance.commit_id
+                close_admin_db_connection_if_not_in_atomic_block()
+
                 pipeline = gitlab_api_v4_ecr_pipeline_trigger(
                     ECR_PROJECT_ID,
-                    application_instance.application_template.gitlab_project_id,
-                    application_instance.commit_id,
+                    gitlab_project_id,
+                    commit_id,
                     ecr_repository_name,
                     tag,
                 )
@@ -298,6 +310,7 @@ class FargateSpawner:
                     {"pipeline_id": pipeline_id, "task_arn": None}
                 )
                 application_instance.save(update_fields=["spawner_application_instance_id"])
+                close_admin_db_connection_if_not_in_atomic_block()
 
                 for _ in range(0, 900):
                     gevent.sleep(3)
@@ -328,6 +341,10 @@ class FargateSpawner:
                 user_efs_access_point_id,
             )
 
+            cpu = application_instance.cpu
+            memory = application_instance.memory
+            close_admin_db_connection_if_not_in_atomic_block()
+
             for i in range(0, 10):
                 # Sometimes there is an error assuming the new role: both IAM  and ECS are
                 # eventually consistent
@@ -339,8 +356,8 @@ class FargateSpawner:
                         definition_arn_with_image,
                         security_groups,
                         subnets,
-                        application_instance.cpu,
-                        application_instance.memory,
+                        cpu,
+                        memory,
                         cmd,
                         {**s3_env, **database_env, **schema_env, **env},
                         s3_sync,
@@ -377,6 +394,8 @@ class FargateSpawner:
             application_instance.refresh_from_db()
             if application_instance.state == "STOPPED":
                 raise Exception("Application set to stopped before spawning complete")
+
+            close_admin_db_connection_if_not_in_atomic_block()
 
             for _ in range(0, 60):
                 ip_address = _fargate_task_ip(options["CLUSTER_NAME"], task_arn)

--- a/dataworkspace/dataworkspace/apps/explorer/tasks.py
+++ b/dataworkspace/dataworkspace/apps/explorer/tasks.py
@@ -12,6 +12,7 @@ from pytz import utc
 
 from dataworkspace.apps.core.utils import (
     USER_SCHEMA_STEM,
+    close_admin_db_connection_if_not_in_atomic_block,
     close_all_connections_if_not_in_atomic_block,
     database_dsn,
     db_role_schema_suffix_for_user,
@@ -99,6 +100,7 @@ def _run_querylog_query(query_log_id, page, limit, timeout):
     user_connection_settings = get_user_explorer_connection_settings(
         query_log.run_by_user, query_log.connection
     )
+    close_admin_db_connection_if_not_in_atomic_block()
     with user_explorer_connection(user_connection_settings) as conn:
         _run_query(
             conn,

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -17,6 +17,7 @@ from django.shortcuts import get_object_or_404
 
 from dataworkspace.apps.core.models import Database
 from dataworkspace.apps.core.utils import (
+    close_admin_db_connection_if_not_in_atomic_block,
     new_private_database_credentials,
     source_tables_for_user,
     db_role_schema_suffix_for_user,
@@ -151,8 +152,10 @@ def get_user_explorer_connection_settings(user, alias):
     def get_available_user_connections(_user_credentials):
         return {data["memorable_name"]: data for data in _user_credentials}
 
+    user_profile_sso_id = user.profile.sso_id
+    close_admin_db_connection_if_not_in_atomic_block()
     with cache.lock(
-        f"get-explorer-connection-{user.profile.sso_id}",
+        f"get-explorer-connection-{user_profile_sso_id}",
         blocking_timeout=30,
         timeout=180,
     ):

--- a/dataworkspace/start-celery.sh
+++ b/dataworkspace/start-celery.sh
@@ -6,5 +6,5 @@ set -e
     cd "$(dirname "$0")"
 
     echo "starting celery..."
-    celery --app dataworkspace.cel.celery_app worker --pool gevent --concurrency 150
+    celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150
 )


### PR DESCRIPTION
### Description of change

Slightly speculative changes to try to address problems that seem to stem from Celery tasks not running/getting blocked when starting tools and running Data Explorer queries.

Might need to go through things a bit more thoroughly later / enforce things in code to not hold multiple db connections open at the same time.

### Checklist

* [ ] Have tests been added to cover any changes?
