### PR TITLE
fix: add 2 closing div tags to draft reference dataset message

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -76,6 +76,8 @@
         <p class="govuk-body govuk-!-margin-top-4">
           This reference dataset has not been approved for use by the DIT Reference Data Board.
         </p>
+      </div>
+    </div>
   {% endif %}
   {% if not model.published %}
     {% include 'partials/unpublished_banner.html' with type='dataset' %}


### PR DESCRIPTION
### Description of change
Added back two missing closing `div` tags from the `govuk-warning-text` container. This was causing the entire page to be indented.

### Checklist

~* [ ] Have tests been added to cover any changes?~
