### PR TITLE
fix: add govuk-link class to links on about.html

### DIFF
--- a/dataworkspace/dataworkspace/templates/about.html
+++ b/dataworkspace/dataworkspace/templates/about.html
@@ -22,7 +22,7 @@
       <li>up to date data through a single searchable catalogue of datasets</li>
       <li>powerful and accessible tools to analyse and visualise data</li>
       <li>dashboards to visualise data</li>
-      <li>a <a href="https://data.trade.gov.uk/support-and-feedback/">support team</a> that can help you in setting up you and your team's data requirements.</li>
+      <li>a <a class="govuk-link" href="https://data.trade.gov.uk/support-and-feedback/">support team</a> that can help you in setting up you and your team's data requirements.</li>
     </ul>
   </div>
 </div>
@@ -40,8 +40,8 @@
       Where datasets contain personal data or other sensitive information, you will need to ask for access because of DIT’s legal obligation to data protection. You’ll need to request access on the individual dataset pages. We aim to provide access within 5 working days.
     </p>
     <p class='govuk-body'>
-      Data Workspace offers a growing <a href="https://data.trade.gov.uk/">catalogue</a> of data from across DIT. </p>
-    <p class = "govuk-body"><a href="https://data.trade.gov.uk/support-and-feedback/">Let our support team know</a> if you want a dataset to be added.</p>
+      Data Workspace offers a growing <a class="govuk-link" href="https://data.trade.gov.uk/">catalogue</a> of data from across DIT. </p>
+    <p class = "govuk-body"><a class="govuk-link" href="https://data.trade.gov.uk/support-and-feedback/">Let our support team know</a> if you want a dataset to be added.</p>
   </div>
 </div>
 
@@ -49,13 +49,13 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Data tools</h2>
     <p class='govuk-body'>
-      Users that prefer to gain insight themselves into their data can do so directly on Data Workspace. It offers a range of <a href="{% url 'applications:tools'%}">powerful analysis and data visualisation tools</a>. You will be able to use SQL, R or Python coding languages or be willing to learn them.
+      Users that prefer to gain insight themselves into their data can do so directly on Data Workspace. It offers a range of <a class="govuk-link" href="{% url 'applications:tools'%}">powerful analysis and data visualisation tools</a>. You will be able to use SQL, R or Python coding languages or be willing to learn them.
     </p>
     <p class="govuk-body">
       We also offer an accessible dashboarding tool, for those without coding skills.
     </p>
     <p class="govuk-body">
-      See the <a href="{% url 'applications:tools'%}">tools we offer and request access to them</a>.
+      See the <a class="govuk-link" href="{% url 'applications:tools'%}">tools we offer and request access to them</a>.
     </p>
   </div>
 </div>
@@ -63,7 +63,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Using and improving Data Workspace</h2>
-    <p class='govuk-body'>Read our easily accessible <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/">user guides</a> on getting started on the Data Workspace and using the tools.</p>
+    <p class='govuk-body'>Read our easily accessible <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-to/">user guides</a> on getting started on the Data Workspace and using the tools.</p>
     <p class='govuk-body'>You can also stay up to date with the latest features and updates on Data Workspace by:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>joining the Data show and tell sessions every second Wednesday</li>


### PR DESCRIPTION
### Description of change
Add missing `govuk-link` css class for links on about page

### Checklist

~* [ ] Have tests been added to cover any changes?~
