### PR TITLE
fix: add authorized domains to has_access logic in search results

### DIFF
--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -612,10 +612,10 @@ def test_find_datasets_order_by_oldest_first(client):
 )
 def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type, staff_client):
     normal_user = get_user_model().objects.create(
-        username="bob.user@test.com", is_staff=False, is_superuser=False
+        username="bob.user@test.com", is_staff=False, is_superuser=False, email="bob.user@test.com"
     )
     staff_user = get_user_model().objects.create(
-        username="bob.staff@test.com", is_staff=True, is_superuser=True
+        username="bob.staff@test.com", is_staff=True, is_superuser=True, email="bob.staff@test.com"
     )
 
     users = [factories.UserFactory.create() for _ in range(3)]
@@ -1178,7 +1178,8 @@ def test_find_datasets_filters_by_access_and_use_only_returns_the_dataset_once(
 def test_find_datasets_includes_unpublished_results_based_on_permissions(
     permissions, result_dataset_names
 ):
-    user = get_user_model().objects.create(is_staff=True)
+    email = "test.user@example.com"
+    user = get_user_model().objects.create(is_staff=True, email=email, username=email)
     perms = Permission.objects.filter(codename__in=permissions).all()
     user.user_permissions.add(*perms)
     user.save()


### PR DESCRIPTION
### Description of change
Added Authorized email domains to the `has_access` field in search results for MasterDataset, DataCutDataset and VisualisationDataset. 
N/A for ReferenceDatasets

### Checklist

~* [ ] Have tests been added to cover any changes?~
