### PR TITLE
fix: correct article links following Help Centre restructure

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils_tools.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils_tools.py
@@ -74,7 +74,7 @@ def get_groups(request):
                 ),
             ],
             "group_description": "create dashboards",
-            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/create-a-dashboard/",
+            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/",
         },
         "Data Analysis Tools": {
             "group_name": "Data Analysis Tools",
@@ -96,12 +96,12 @@ def get_groups(request):
                     "outputs.",
                     link=settings.APPSTREAM_URL,
                     has_access=request.user.has_perm("applications.access_appstream"),
-                    help_link="https://data-services-help.trade.gov.uk/data-workspace/how-articles/"
-                    "tools-and-how-access-them/start-using-spss/",
+                    help_link="https://data-services-help.trade.gov.uk/data-workspace/how-to/"
+                    "see-tools-specific-guidance/spss-and-stata/",
                 ),
             ],
             "group_description": "analyse data",
-            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/",
+            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/",
         },
         "Data Managament Tools": {
             "group_name": "Data Management Tools",
@@ -127,7 +127,7 @@ def get_groups(request):
             ],
             "group_description": "upload data and share data",
             "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/"
-            "2-analyse-data/upload-your-own-data/",
+            "see-tools-specific-guidance/your-files/start-using-your-files/",
         },
         "Integrated Development Environments": {
             "group_name": "Integrated Development Environments",

--- a/dataworkspace/dataworkspace/apps/applications/utils_tools.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils_tools.py
@@ -74,7 +74,8 @@ def get_groups(request):
                 ),
             ],
             "group_description": "create dashboards",
-            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/",
+            "group_link": "https://data-services-help.trade.gov.uk/data-workspace/how-to/"
+            "see-tools-specific-guidance/quicksight/create-a-dashboard/",
         },
         "Data Analysis Tools": {
             "group_name": "Data Analysis Tools",

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -46,8 +46,8 @@
             <p class="govuk-body govuk-!-margin-top-6 govuk-!-margin-bottom-6">You can:</p>
             <ul class="govuk-list govuk-list--bullet">
               <li>filter, combine or search datasets using an SQL query</li>
-              <li><a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/3-share-analysis/share-a-subset-of-a-dataset/" class="govuk-link">share an SQL query</a> with your colleagues</li>
-              <li>learn <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/data-explorer/start-data-explorer/" class="govuk-link">how to use Data Explorer</a></li>
+              <li><a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/share-and-collaborate/share-a-subset-of-a-dataset/" class="govuk-link">share an SQL query</a> with your colleagues</li>
+              <li>learn <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/data-explorer/start-data-explorer/" class="govuk-link">how to use Data Explorer</a></li>
           </ul>
           </div>
         </div>

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/share_email.txt
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/share_email.txt
@@ -5,7 +5,7 @@ I thought you might find this SQL query useful.
 
 If you already have access to the data, you can access the query in Data Explorer here https://{{ request.get_host }}{% open_query_in_explorer_link query %}.
 
-You may need to request access to Data Explorer before you can use it: https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-workspace-basics/how-do-i-request-access-tool/.
+You may need to request access to Data Explorer before you can use it: https://data-services-help.trade.gov.uk/data-workspace/how-to/use-tools/access-tools/.
 
 {{ query }}
 

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -36,7 +36,7 @@
         {{ object.name }}
       </h1>
       <p class="govuk-body">Use this data grid to <a class="govuk-link"
-                                                     href="https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/filter-and-sort-data/">
+                                                     href="https://data-services-help.trade.gov.uk/data-workspace/how-to/start-using-data-workspace/filter-and-sort-data/">
         filter, sort and download data
       </a>. You can:
       </p>

--- a/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
+++ b/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
@@ -29,7 +29,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ model.name }}</h1>
       <p class="govuk-body">
-        Use this data grid to <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/filter-and-sort-data/">filter, sort and download data</a>. You can:
+        Use this data grid to <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-to/start-using-data-workspace/filter-and-sort-data/">filter, sort and download data</a>. You can:
 
         <ul class="govuk-list govuk-list--bullet">
           <li>reorder columns by dragging and dropping them</li>

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -5,7 +5,7 @@
   {% if code_snippets %}
   <link rel="stylesheet" href="{% static 'assets/vendor/highlight/styles/a11y-light.css' %}">
 
-  <p><a class="govuk-link--no-visited-state" href="https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/use-tools/">Use code snippets in our tools</a> to analyse this data.</p>
+  <p><a class="govuk-link--no-visited-state" href="https://data-services-help.trade.gov.uk/data-workspace/how-to/use-tools/use-tools/">Use code snippets in our tools</a> to analyse this data.</p>
 
   <div class="govuk-tabs" data-module="govuk-tabs">
     <h2 class="govuk-tabs__title">Contents</h2>

--- a/dataworkspace/dataworkspace/templates/request_access/you_have_access.html
+++ b/dataworkspace/dataworkspace/templates/request_access/you_have_access.html
@@ -19,7 +19,7 @@
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">You have access to our tools</h1>
             <p class="govuk-body">
-                You can use our <a href="{% url 'applications:tools' %}">tools</a> to <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/2-analyse-data/">analyse data</a> 
+                You can use our <a href="{% url 'applications:tools' %}">tools</a> to <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/">analyse data</a> 
             </p>
         </div>
     </div>

--- a/dataworkspace/dataworkspace/templates/request_data/index.html
+++ b/dataworkspace/dataworkspace/templates/request_data/index.html
@@ -39,8 +39,8 @@
         <li>what the data will be used for</li>
         <li>the security classification of the data</li>
         <li>where it is currently held</li>
-        <li>the <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-standards/what-information-asset-owner/">information asset owner</a>
-          or <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/how-articles/data-standards/what-information-asset-manager/">information asset manager</a>.
+        <li>the <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/policies-and-standards/policies/information-asset-owner/">information asset owner</a>
+          or <a class="govuk-link" href="https://data-services-help.trade.gov.uk/data-workspace/policies-and-standards/policies/information-asset-manager/">information asset manager</a>.
         </li>
         <li>licensing details</li>
       </ul>


### PR DESCRIPTION
### Description of change
_The Data Workspace article Help Centre has been restructured, and so some hard-coded links are showing error messages and do not work anymore_ 

- Links updated for relevant pages where links are broken

### Checklist

~* [ ] Have tests been added to cover any changes?~
