### PR TITLE
fix: flakey Data Explorer tests

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/home.html
@@ -153,7 +153,7 @@
                     <input aria-label="Title" type="govuk-visually-hidden" value="{{ form.title.value|default_if_none:"Playground Query" }}" name="title" hidden/>
                   </div>
                 </fieldset>
-                <div id="query-results">
+                <div id="query-results-wrapper">
                   {% if query_log.state == 0 %}
                     {% include 'explorer/partials/query_executing.html' %}
                   {% endif %}

--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/partials/query_results.html
@@ -1,5 +1,5 @@
 {% load explorer_tags waffle_tags %}
-<div class="govuk-grid-row" id="query-results">
+<div class="govuk-grid-row">
   {% if headers %}
     <div class="govuk-grid-column-full">
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
@@ -11,7 +11,7 @@
       <p class="govuk-body">
         Execution time: {{ duration|format_duration }}
       </p>
-      <div class="scrollable-table" tabindex="0">
+      <div class="scrollable-table" tabindex="0" id="query-results">
         <table class="govuk-table">
           <thead class="govuk-table">
           <tr class="govuk-table__row">

--- a/dataworkspace/dataworkspace/static/explorer_async.js
+++ b/dataworkspace/dataworkspace/static/explorer_async.js
@@ -22,7 +22,7 @@ function pollForQueryResults(queryLogId, delay, delayStep, maxDelay) {
         document.getElementById('async-query-submitting').classList.add('govuk-!-display-none');
       }
       else {
-        document.getElementById('query-results').innerHTML = resp.html;
+        document.getElementById('query-results-wrapper').innerHTML = resp.html;
       }
     }
   }


### PR DESCRIPTION
### Description of change

There were 2 issues:

- Duplicate `id="query-results"` in the page
- The tests were waiting for an element with `id="query-results"`, but that element was in the page from the get-go, and so the waiting didn't wait long enough.



### Checklist

* [ ] Have tests been added to cover any changes?
