### PR TITLE
fix: handle error in store_custom_dataset_query_metadata task 

### DIFF
--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -77,7 +77,8 @@ def extract_queried_tables_from_sql_query(database_name, query):
                 cursor.execute(
                     f"create temporary view get_tables as (select 1 from ({query.strip().rstrip(';')}) sq)"
                 )
-        except DatabaseError:
+        except DatabaseError as e:
+            logger.error(e)
             tables = []
         else:
             cursor.execute(


### PR DESCRIPTION
### Description of change
The `store_custom_dataset_query_metadata` celery task is failing multiple times in live. 
This change should help diagnose why

### Checklist

* [ ] Have tests been added to cover any changes?
