### PR TITLE
tests: more robust tests by cleaning up temporary tables

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/management/commands/delete_temporary_tables.py
+++ b/dataworkspace/dataworkspace/apps/datasets/management/commands/delete_temporary_tables.py
@@ -1,0 +1,41 @@
+from psycopg2 import connect
+import psycopg2.sql
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from dataworkspace.apps.core.utils import database_dsn
+
+
+class Command(BaseCommand):
+    """Deletes temporary Data Explorer results
+
+    To be used from tests to cleanup between them
+    """
+
+    help = "Delete temporary Data Explorer result tables"
+
+    def handle(self, *args, **options):
+        self.stdout.write("deleting temporary Data Explorer result tables...")
+
+        for _database_name, database_data in settings.DATABASES_DATA.items():
+            with connect(database_dsn(database_data)) as conn, conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT table_schema, table_name
+                    FROM information_schema.tables
+                    WHERE table_name
+                    LIKE '%_tmp_query_%'
+                """
+                )
+                for table_schema, table_name in cur.fetchall():
+                    cur.execute(
+                        psycopg2.sql.SQL("DROP TABLE {}.{}").format(
+                            psycopg2.sql.Identifier(table_schema),
+                            psycopg2.sql.Identifier(table_name),
+                        )
+                    )
+
+        self.stdout.write(
+            self.style.SUCCESS("deleting temporary Data Explorer result tables (done)")
+        )

--- a/dataworkspace/start-test.sh
+++ b/dataworkspace/start-test.sh
@@ -13,6 +13,7 @@ set -e
 
     django-admin ensure_databases_configured
     django-admin ensure_application_template_models
+    django-admin delete_temporary_tables
 
     # nginx is configured to log to stdout/stderr, _except_ before
     # it manages to read its config file. To avoid errors on startup,


### PR DESCRIPTION
### Description of change

Especially locally when running multiple tests, the tables wouldn't get cleaned up and would result in errors like `relation "_data_explorer_tmp_query_6" already exists` when trying to run a query in Data Explorer

### Checklist

* [ ] Have tests been added to cover any changes?
