### PR TITLE
feat: update CSP for GA4

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -245,6 +245,9 @@ CSP_FRAME_ANCESTORS = [APPLICATION_ROOT_DOMAIN]
 CSP_CONNECT_SRC = [
     APPLICATION_ROOT_DOMAIN,
     "https://www.google-analytics.com",
+    "*.google-analytics.com",
+    "*.analytics.google.com",
+    "*.googletagmanager.com",
 ]
 CSP_IMG_SRC = [
     APPLICATION_ROOT_DOMAIN,
@@ -254,12 +257,15 @@ CSP_IMG_SRC = [
     "https://www.google-analytics.com",
     "https://ssl.gstatic.com",
     "https://www.gstatic.com",
+    "*.google-analytics.com",
+    "*.googletagmanager.com",
 ]
 CSP_SCRIPT_SRC = [
     APPLICATION_ROOT_DOMAIN,
     "https://www.googletagmanager.com",
     "https://www.google-analytics.com",
     "https://tagmanager.google.com",
+    "*.googletagmanager.com",
 ]
 CSP_STYLE_SRC = [
     APPLICATION_ROOT_DOMAIN,

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -180,6 +180,9 @@ def test_csp_on_files_endpoint_includes_s3(client):
         "dataworkspace.test:3000",
         "ws://dataworkspace.test:3000",
         "https://s3.eu-west-2.amazonaws.com",
+        "*.google-analytics.com",
+        "*.analytics.google.com",
+        "*.googletagmanager.com",
     ]
 
     for element in expected_elements:

--- a/dataworkspace/dataworkspace/tests/test_security.py
+++ b/dataworkspace/dataworkspace/tests/test_security.py
@@ -19,14 +19,14 @@ def test_baseline_content_security_policy(client):
         "object-src 'none'",
         "form-action dataworkspace.test:8000 *.dataworkspace.test:8000",
         "base-uri dataworkspace.test:8000",
-        "img-src dataworkspace.test:8000 data: https://www.googletagmanager.com https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com",  # pylint: disable=line-too-long
-        f"script-src dataworkspace.test:8000 https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com 'nonce-{response.wsgi_request.csp_nonce}'",  # pylint: disable=line-too-long
+        "img-src dataworkspace.test:8000 data: https://www.googletagmanager.com https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com *.google-analytics.com *.googletagmanager.com",  # pylint: disable=line-too-long
+        f"script-src dataworkspace.test:8000 https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com *.googletagmanager.com 'nonce-{response.wsgi_request.csp_nonce}'",  # pylint: disable=line-too-long
         "frame-ancestors dataworkspace.test:8000",
         "font-src dataworkspace.test:8000 data: https://fonts.gstatic.com",
         "style-src dataworkspace.test:8000 'unsafe-inline' https://tagmanager.google.com https://fonts.googleapis.com",
         "default-src dataworkspace.test:8000",
-        "connect-src dataworkspace.test:8000 https://www.google-analytics.com "
-        "dataworkspace.test:3000 ws://dataworkspace.test:3000",
+        "connect-src dataworkspace.test:8000 https://www.google-analytics.com *.google-analytics.com *.analytics.google.com "
+        "*.googletagmanager.com dataworkspace.test:3000 ws://dataworkspace.test:3000",
     }
 
     assert policies == expected_policies

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -112,10 +112,10 @@ async def async_main():
         f"font-src {root_domain} data:  https://fonts.gstatic.com;"
         f"form-action {root_domain} *.{root_domain};"
         f"frame-ancestors {root_domain};"
-        f"img-src {root_domain} data: https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com;"  # pylint: disable=line-too-long
-        f"script-src 'unsafe-inline' {root_domain} https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com;"  # pylint: disable=line-too-long
+        f"img-src {root_domain} data: https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com *.google-analytics.com *.googletagmanager.com;"  # pylint: disable=line-too-long
+        f"script-src 'unsafe-inline' {root_domain} https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com *.googletagmanager.com;"  # pylint: disable=line-too-long
         f"style-src 'unsafe-inline' {root_domain} https://tagmanager.google.com https://fonts.googleapis.com;"
-        f"connect-src {root_domain} 'self';"
+        f"connect-src {root_domain} 'self' *.google-analytics.com *.analytics.google.com *.googletagmanager.com;"
     )
 
     # A running wrapped application on <my-application>.<root_domain>  has an
@@ -127,10 +127,11 @@ async def async_main():
             f"form-action 'none';"
             f"frame-ancestors 'none';"
             f"frame-src {direct_host} {sso_host} https://www.googletagmanager.com;"
-            f"img-src {root_domain} https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com;"  # pylint: disable=line-too-long
+            f"img-src {root_domain} https://www.googletagmanager.com https://www.google-analytics.com https://ssl.gstatic.com https://www.gstatic.com *.google-analytics.com *.googletagmanager.com;"  # pylint: disable=line-too-long
             f"font-src {root_domain} data: https://fonts.gstatic.com;"
-            f"script-src 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com;"  # pylint: disable=line-too-long
+            f"script-src 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://tagmanager.google.com *.googletagmanager.com;"  # pylint: disable=line-too-long
             f"style-src 'unsafe-inline' {root_domain} https://tagmanager.google.com https://fonts.googleapis.com;"
+            f"connect-src *.google-analytics.com *.analytics.google.com *.googletagmanager.com;"
         )
 
     # A running application should only connect to self: this is where we have the most


### PR DESCRIPTION
### Description of change

This is so we now have a CSP for both GA4 and Universal Analytics. Should be able to remove the ones for Universal Analytics when the migration to GA4 is complete, hopefully not too far in the future..

The directives are from https://developers.google.com/tag-platform/tag-manager/web/csp#google_analytics_4_google_analytics

### Checklist

* [ ] Have tests been added to cover any changes?
