### PR TITLE
vulnerability: bump eventsource to 2.0.2

### DIFF
--- a/dataworkspace/dataworkspace/static/js/chart-builder/package-lock.json
+++ b/dataworkspace/dataworkspace/static/js/chart-builder/package-lock.json
@@ -5053,7 +5053,7 @@
     },
     "node_modules/eventsource": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "dev": true,
       "dependencies": {
@@ -11705,7 +11705,7 @@
       "dev": true,
       "dependencies": {
         "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
+        "eventsource": "^2.0.2",
         "faye-websocket": "^0.11.3",
         "inherits": "^2.0.4",
         "json3": "^3.3.3",
@@ -17656,7 +17656,7 @@
     },
     "eventsource": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "dev": true,
       "requires": {
@@ -23094,7 +23094,7 @@
       "dev": true,
       "requires": {
         "debug": "^3.2.6",
-        "eventsource": "^1.0.7",
+        "eventsource": "^2.0.2",
         "faye-websocket": "^0.11.3",
         "inherits": "^2.0.4",
         "json3": "^3.3.3",


### PR DESCRIPTION
### Description of change

- Fix [1 Dependabot alert](https://github.com/uktrade/data-workspace/security/dependabot?q=is%3Aopen+package%3Aeventsource+manifest%3Adataworkspace%2Fdataworkspace%2Fstatic%2Fjs%2Fchart-builder%2Fpackage-lock.json+has%3Apatch) on eventsource in [dataworkspace/dataworkspace/static/js/chart-builder/package-lock.json](https://github.com/uktrade/data-workspace/blob/-/dataworkspace/dataworkspace/static/js/chart-builder/package-lock.json) by manually upgrading eventsource to version 2.0.2.

### Checklist

~* [ ] Have tests been added to cover any changes?~
