### PR TITLE
fix: ensure related visualisations are in eventlog api response

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/eventlog/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/eventlog/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from dataworkspace.apps.datasets.models import (
     DataSet,
     ReferenceDataset,
+    VisualisationCatalogueItem,
     VisualisationLink,
 )
 from dataworkspace.apps.eventlog.models import EventLog
@@ -91,7 +92,7 @@ class EventLogDataUserSerializer(serializers.ModelSerializer):
 
 class EventLogRelatedObjectField(serializers.RelatedField):
     def to_representation(self, value):  # pylint: disable=inconsistent-return-statements
-        if isinstance(value, DataSet):
+        if isinstance(value, (DataSet, VisualisationCatalogueItem)):
             return EventLogDatasetSerializer(value).data
         if isinstance(value, ReferenceDataset):
             return EventLogReferenceDatasetSerializer(value).data


### PR DESCRIPTION
### Description of change

"Viewed visualisation" events were not included in the related object serialiser and hence not visible in the datasets db. This PR ensures VisualisationCatalogueItems are serialised in the same way other datasets are.

### Checklist

* [ ] Have tests been added to cover any changes?
