### PR TITLE
perf: faster search - main query runs in around 1% of the time in some cases

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -124,8 +124,6 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
     )
 
     visualisations = visualisations.annotate(
-        # Define a `purpose` column denoting the dataset type
-        purpose=Value(DataSetType.VISUALISATION, IntegerField()),
         data_type=Value(DataSetType.VISUALISATION, IntegerField()),
         is_open_data=Case(
             When(user_access_type=UserAccessType.OPEN, then=True),
@@ -149,7 +147,6 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
             "source_tag_ids",
             "topic_tag_names",
             "topic_tag_ids",
-            "purpose",
             "data_type",
             "published",
             "published_at",
@@ -172,7 +169,6 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
         "source_tag_ids",
         "topic_tag_names",
         "topic_tag_ids",
-        "purpose",
         "data_type",
         "published",
         "published_at",
@@ -300,10 +296,8 @@ def _get_datasets_data_for_user_matching_query(
         topic_tag_names=ArrayAgg("tags__name", filter=Q(tags__type=TagType.TOPIC), distinct=True)
     )
 
-    # Define a `purpose` column denoting the dataset type.
     if is_reference_query:
         datasets = datasets.annotate(
-            purpose=Value(DataSetType.DATACUT, IntegerField()),
             data_type=Value(DataSetType.REFERENCE, IntegerField()),
             is_open_data=Value(False, BooleanField()),
             has_visuals=Value(False, BooleanField()),
@@ -311,7 +305,6 @@ def _get_datasets_data_for_user_matching_query(
     else:
         dataset_visual_filter = DataSetVisualisation.objects.filter(dataset_id=OuterRef("id"))
         datasets = datasets.annotate(
-            purpose=F("type"),
             data_type=F("type"),
             is_open_data=Case(
                 When(user_access_type=UserAccessType.OPEN, then=True),
@@ -339,7 +332,6 @@ def _get_datasets_data_for_user_matching_query(
             "source_tag_ids",
             "topic_tag_names",
             "topic_tag_ids",
-            "purpose",
             "data_type",
             "published",
             "published_at",
@@ -362,7 +354,6 @@ def _get_datasets_data_for_user_matching_query(
         "source_tag_ids",
         "topic_tag_names",
         "topic_tag_ids",
-        "purpose",
         "data_type",
         "published",
         "published_at",

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -1,5 +1,4 @@
 from django.contrib.postgres.aggregates.general import ArrayAgg, BoolOr
-from django.contrib.postgres.fields import ArrayField
 from django.contrib.postgres.search import SearchRank
 from django.db.models import (
     Exists,
@@ -11,7 +10,6 @@ from django.db.models import (
     When,
     BooleanField,
     OuterRef,
-    CharField,
 )
 from django.db.models import QuerySet
 
@@ -149,7 +147,6 @@ def _get_visualisations_data_for_user_matching_query(
             "published_at",
             "is_open_data",
             "has_visuals",
-            "eligibility_criteria",
         )
         .annotate(has_access=BoolOr("_has_access"))
         .annotate(is_bookmarked=BoolOr("_is_bookmarked"))
@@ -171,7 +168,6 @@ def _get_visualisations_data_for_user_matching_query(
         "published_at",
         "is_open_data",
         "has_visuals",
-        "eligibility_criteria",
         "has_access",
         "is_bookmarked",
         "is_subscribed",
@@ -197,10 +193,6 @@ def _get_datasets_data_for_user_matching_query(
 
         if user.has_perm(reference_perm):
             visibility_filter |= Q(published=False)
-
-        datasets = datasets.annotate(
-            eligibility_criteria=Value(None, ArrayField(CharField(max_length=20)))
-        )
 
     if datasets.model is DataSet:
         master_type, datacut_type = (
@@ -336,7 +328,6 @@ def _get_datasets_data_for_user_matching_query(
             "published_at",
             "is_open_data",
             "has_visuals",
-            "eligibility_criteria",
         )
         .annotate(has_access=BoolOr("_has_access"))
         .annotate(is_bookmarked=BoolOr("_is_bookmarked"))
@@ -358,7 +349,6 @@ def _get_datasets_data_for_user_matching_query(
         "published_at",
         "is_open_data",
         "has_visuals",
-        "eligibility_criteria",
         "has_access",
         "is_bookmarked",
         "is_subscribed",

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -185,6 +185,9 @@ def _get_datasets_data_for_user_matching_query(
             datasets, query, id_field, user=user
         )
 
+    #####################################################################
+    # Filter out datasets that the user is not allowed to even know about
+
     visibility_filter = Q(published=True)
 
     if datasets.model is ReferenceDataset:
@@ -206,7 +209,9 @@ def _get_datasets_data_for_user_matching_query(
 
     datasets = datasets.filter(visibility_filter)
 
+    #######################################################
     # Filter out datasets that don't match the search terms
+
     datasets = datasets.annotate(search_rank=SearchRank(F("search_vector"), query))
 
     if query:
@@ -215,7 +220,9 @@ def _get_datasets_data_for_user_matching_query(
             source_table_match = Q(sourcetable__table=query)
         datasets = datasets.filter(source_table_match | Q(search_vector=query))
 
-    # Mark up whether the user can access the data in the dataset.
+    #########################################################################
+    # Annotate datasets for filtering in Python and showing totals in filters
+
     access_filter = Q()
     bookmark_filter = Q(referencedatasetbookmark__user=user)
 

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -188,25 +188,21 @@ def _get_datasets_data_for_user_matching_query(
     visibility_filter = Q(published=True)
 
     if datasets.model is ReferenceDataset:
-        reference_type = DataSetType.REFERENCE
-        reference_perm = dataset_type_to_manage_unpublished_permission_codename(reference_type)
-
-        if user.has_perm(reference_perm):
+        if user.has_perm(
+            dataset_type_to_manage_unpublished_permission_codename(DataSetType.REFERENCE)
+        ):
             visibility_filter |= Q(published=False)
 
     if datasets.model is DataSet:
-        master_type, datacut_type = (
-            DataSetType.MASTER,
-            DataSetType.DATACUT,
-        )
-        master_perm = dataset_type_to_manage_unpublished_permission_codename(master_type)
-        datacut_perm = dataset_type_to_manage_unpublished_permission_codename(datacut_type)
+        if user.has_perm(
+            dataset_type_to_manage_unpublished_permission_codename(DataSetType.MASTER)
+        ):
+            visibility_filter |= Q(published=False, type=DataSetType.MASTER)
 
-        if user.has_perm(master_perm):
-            visibility_filter |= Q(published=False, type=master_type)
-
-        if user.has_perm(datacut_perm):
-            visibility_filter |= Q(published=False, type=datacut_type)
+        if user.has_perm(
+            dataset_type_to_manage_unpublished_permission_codename(DataSetType.DATACUT)
+        ):
+            visibility_filter |= Q(published=False, type=DataSetType.DATACUT)
 
     datasets = datasets.filter(visibility_filter)
 

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -189,11 +189,9 @@ def _get_datasets_data_for_user_matching_query(
             datasets, query, id_field, user=user
         )
 
-    is_reference_query = datasets.model is ReferenceDataset
-
     visibility_filter = Q(published=True)
 
-    if is_reference_query:
+    if datasets.model is ReferenceDataset:
         reference_type = DataSetType.REFERENCE
         reference_perm = dataset_type_to_manage_unpublished_permission_codename(reference_type)
 
@@ -297,7 +295,7 @@ def _get_datasets_data_for_user_matching_query(
         topic_tag_names=ArrayAgg("tags__name", filter=Q(tags__type=TagType.TOPIC), distinct=True)
     )
 
-    if is_reference_query:
+    if datasets.model is ReferenceDataset:
         datasets = datasets.annotate(
             data_type=Value(DataSetType.REFERENCE, IntegerField()),
             is_open_data=Value(False, BooleanField()),

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -188,7 +188,6 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
 def _get_datasets_data_for_user_matching_query(
     datasets: QuerySet,
     query,
-    use=None,
     data_type=None,
     user=None,
     id_field="id",
@@ -377,15 +376,13 @@ def _get_datasets_data_for_user_matching_query(
     )
 
 
-def _sorted_datasets_and_visualisations_matching_query_for_user(
-    query, use, data_type, user, sort_by
-):
+def _sorted_datasets_and_visualisations_matching_query_for_user(query, data_type, user, sort_by):
     """
     Retrieves all master datasets, datacuts, reference datasets and visualisations (i.e. searchable items)
     and returns them, sorted by incoming sort field, default is desc(search_rank).
     """
     master_and_datacut_datasets = _get_datasets_data_for_user_matching_query(
-        DataSet.objects.live(), query, use, data_type, user=user, id_field="id"
+        DataSet.objects.live(), query, data_type, user=user, id_field="id"
     )
 
     reference_datasets = _get_datasets_data_for_user_matching_query(
@@ -416,7 +413,6 @@ def search_for_datasets(user, filters: SearchDatasetsFilters, matcher) -> tuple:
     all_datasets_visible_to_user_matching_query = (
         _sorted_datasets_and_visualisations_matching_query_for_user(
             query=filters.query,
-            use=filters.use,
             data_type=filters.data_type,
             user=user,
             sort_by=filters.sort_type,

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -28,7 +28,9 @@ from dataworkspace.apps.datasets.utils import (
 )
 
 
-def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, query, user):
+def _get_visualisations_data_for_user_matching_query(
+    visualisations: QuerySet, query, id_field, user
+):
     """
     Filters the visualisation queryset for:
         1) visibility (whether the user can know if the visualisation exists)
@@ -133,7 +135,7 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
     # of the records say that access is available.
     visualisations = (
         visualisations.values(
-            "id",
+            id_field,
             "name",
             "slug",
             "short_description",
@@ -155,7 +157,7 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
     )
 
     return visualisations.values(
-        "id",
+        id_field,
         "name",
         "slug",
         "short_description",
@@ -380,7 +382,7 @@ def _sorted_datasets_and_visualisations_matching_query_for_user(query, user, sor
     )
 
     visualisations = _get_visualisations_data_for_user_matching_query(
-        VisualisationCatalogueItem.objects.live(), query, user=user
+        VisualisationCatalogueItem.objects.live(), query, id_field="id", user=user
     )
 
     # Combine all datasets and visualisations and order them.

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -188,7 +188,6 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
 def _get_datasets_data_for_user_matching_query(
     datasets: QuerySet,
     query,
-    data_type=None,
     user=None,
     id_field="id",
 ):
@@ -376,13 +375,13 @@ def _get_datasets_data_for_user_matching_query(
     )
 
 
-def _sorted_datasets_and_visualisations_matching_query_for_user(query, data_type, user, sort_by):
+def _sorted_datasets_and_visualisations_matching_query_for_user(query, user, sort_by):
     """
     Retrieves all master datasets, datacuts, reference datasets and visualisations (i.e. searchable items)
     and returns them, sorted by incoming sort field, default is desc(search_rank).
     """
     master_and_datacut_datasets = _get_datasets_data_for_user_matching_query(
-        DataSet.objects.live(), query, data_type, user=user, id_field="id"
+        DataSet.objects.live(), query, user=user, id_field="id"
     )
 
     reference_datasets = _get_datasets_data_for_user_matching_query(
@@ -413,7 +412,6 @@ def search_for_datasets(user, filters: SearchDatasetsFilters, matcher) -> tuple:
     all_datasets_visible_to_user_matching_query = (
         _sorted_datasets_and_visualisations_matching_query_for_user(
             query=filters.query,
-            data_type=filters.data_type,
             user=user,
             sort_by=filters.sort_type,
         )

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -219,7 +219,7 @@ def _get_datasets_data_for_user_matching_query(
     access_filter = Q()
     bookmark_filter = Q(referencedatasetbookmark__user=user)
 
-    if datasets.model is not ReferenceDataset:
+    if datasets.model is DataSet:
         user_email_domain = user.email.split("@")[1]
         access_filter &= (
             Q(
@@ -263,7 +263,7 @@ def _get_datasets_data_for_user_matching_query(
         _is_subscribed=Case(
             When(subscription_filter, then=True), default=False, output_field=BooleanField()
         )
-        if subscription_filter and datasets.model is not ReferenceDataset
+        if subscription_filter and datasets.model is DataSet
         else Value(False, BooleanField())
     )
 
@@ -289,7 +289,8 @@ def _get_datasets_data_for_user_matching_query(
             is_open_data=Value(False, BooleanField()),
             has_visuals=Value(False, BooleanField()),
         )
-    else:
+
+    if datasets.model is DataSet:
         dataset_visual_filter = DataSetVisualisation.objects.filter(dataset_id=OuterRef("id"))
         datasets = datasets.annotate(
             data_type=F("type"),

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -188,8 +188,8 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
 def _get_datasets_data_for_user_matching_query(
     datasets: QuerySet,
     query,
+    id_field,
     user=None,
-    id_field="id",
 ):
     is_reference_query = datasets.model is ReferenceDataset
 
@@ -381,14 +381,17 @@ def _sorted_datasets_and_visualisations_matching_query_for_user(query, user, sor
     and returns them, sorted by incoming sort field, default is desc(search_rank).
     """
     master_and_datacut_datasets = _get_datasets_data_for_user_matching_query(
-        DataSet.objects.live(), query, user=user, id_field="id"
+        DataSet.objects.live(),
+        query,
+        id_field="id",
+        user=user,
     )
 
     reference_datasets = _get_datasets_data_for_user_matching_query(
         ReferenceDataset.objects.live(),
         query,
-        user=user,
         id_field="uuid",
+        user=user,
     )
 
     visualisations = _get_visualisations_data_for_user_matching_query(

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -28,7 +28,7 @@ from dataworkspace.apps.datasets.utils import (
 )
 
 
-def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, query, user=None):
+def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, query, user):
     """
     Filters the visualisation queryset for:
         1) visibility (whether the user can know if the visualisation exists)
@@ -39,8 +39,7 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
     """
     # Filter out visualisations that the user is not allowed to even know about.
     if not (
-        user
-        and user.has_perm(
+        user.has_perm(
             dataset_type_to_manage_unpublished_permission_codename(DataSetType.VISUALISATION)
         )
     ):
@@ -54,32 +53,28 @@ def _get_visualisations_data_for_user_matching_query(visualisations: QuerySet, q
         visualisations = visualisations.filter(search_vector=query)
 
     # Mark up whether the user can access the visualisation.
-    if user:
-        user_email_domain = user.email.split("@")[1]
-        access_filter = (
+    user_email_domain = user.email.split("@")[1]
+    access_filter = (
+        (
             (
-                (
-                    Q(
-                        user_access_type__in=[
-                            UserAccessType.REQUIRES_AUTHENTICATION,
-                            UserAccessType.OPEN,
-                        ]
-                    )
-                )
-                & (
-                    Q(visualisationuserpermission__user=user)
-                    | Q(visualisationuserpermission__isnull=True)
+                Q(
+                    user_access_type__in=[
+                        UserAccessType.REQUIRES_AUTHENTICATION,
+                        UserAccessType.OPEN,
+                    ]
                 )
             )
-            | Q(
-                user_access_type=UserAccessType.REQUIRES_AUTHORIZATION,
-                visualisationuserpermission__user=user,
+            & (
+                Q(visualisationuserpermission__user=user)
+                | Q(visualisationuserpermission__isnull=True)
             )
-            | Q(authorized_email_domains__contains=[user_email_domain])
         )
-
-    else:
-        access_filter = Q()
+        | Q(
+            user_access_type=UserAccessType.REQUIRES_AUTHORIZATION,
+            visualisationuserpermission__user=user,
+        )
+        | Q(authorized_email_domains__contains=[user_email_domain])
+    )
 
     visualisations = visualisations.annotate(
         _has_access=Case(
@@ -185,37 +180,36 @@ def _get_datasets_data_for_user_matching_query(
     datasets: QuerySet,
     query,
     id_field,
-    user=None,
+    user,
 ):
     is_reference_query = datasets.model is ReferenceDataset
 
     visibility_filter = Q(published=True)
 
-    if user:
-        if is_reference_query:
-            reference_type = DataSetType.REFERENCE
-            reference_perm = dataset_type_to_manage_unpublished_permission_codename(reference_type)
+    if is_reference_query:
+        reference_type = DataSetType.REFERENCE
+        reference_perm = dataset_type_to_manage_unpublished_permission_codename(reference_type)
 
-            if user.has_perm(reference_perm):
-                visibility_filter |= Q(published=False)
+        if user.has_perm(reference_perm):
+            visibility_filter |= Q(published=False)
 
-            datasets = datasets.annotate(
-                eligibility_criteria=Value(None, ArrayField(CharField(max_length=20)))
-            )
+        datasets = datasets.annotate(
+            eligibility_criteria=Value(None, ArrayField(CharField(max_length=20)))
+        )
 
-        if datasets.model is DataSet:
-            master_type, datacut_type = (
-                DataSetType.MASTER,
-                DataSetType.DATACUT,
-            )
-            master_perm = dataset_type_to_manage_unpublished_permission_codename(master_type)
-            datacut_perm = dataset_type_to_manage_unpublished_permission_codename(datacut_type)
+    if datasets.model is DataSet:
+        master_type, datacut_type = (
+            DataSetType.MASTER,
+            DataSetType.DATACUT,
+        )
+        master_perm = dataset_type_to_manage_unpublished_permission_codename(master_type)
+        datacut_perm = dataset_type_to_manage_unpublished_permission_codename(datacut_type)
 
-            if user.has_perm(master_perm):
-                visibility_filter |= Q(published=False, type=master_type)
+        if user.has_perm(master_perm):
+            visibility_filter |= Q(published=False, type=master_type)
 
-            if user.has_perm(datacut_perm):
-                visibility_filter |= Q(published=False, type=datacut_type)
+        if user.has_perm(datacut_perm):
+            visibility_filter |= Q(published=False, type=datacut_type)
 
     datasets = datasets.filter(visibility_filter)
 
@@ -232,7 +226,7 @@ def _get_datasets_data_for_user_matching_query(
     access_filter = Q()
     bookmark_filter = Q(referencedatasetbookmark__user=user)
 
-    if user and datasets.model is not ReferenceDataset:
+    if datasets.model is not ReferenceDataset:
         user_email_domain = user.email.split("@")[1]
         access_filter &= (
             Q(

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -184,6 +184,11 @@ def _get_datasets_data_for_user_matching_query(
     id_field,
     user,
 ):
+    if datasets.model is VisualisationCatalogueItem:
+        return _get_visualisations_data_for_user_matching_query(
+            datasets, query, id_field, user=user
+        )
+
     is_reference_query = datasets.model is ReferenceDataset
 
     visibility_filter = Q(published=True)
@@ -381,7 +386,7 @@ def _sorted_datasets_and_visualisations_matching_query_for_user(query, user, sor
         user=user,
     )
 
-    visualisations = _get_visualisations_data_for_user_matching_query(
+    visualisations = _get_datasets_data_for_user_matching_query(
         VisualisationCatalogueItem.objects.live(), query, id_field="id", user=user
     )
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -153,7 +153,6 @@ def _matches_filters(
         and (unpublished or data["published"])
         and (not opendata or data["is_open_data"])
         and (not withvisuals or data["has_visuals"])
-        and (not use or use == [None] or data["purpose"] in use)
         and (not data_type or data_type == [None] or data["data_type"] in data_type)
         and (not source_ids or source_ids.intersection(set(data["source_tag_ids"])))
         and (not topic_ids or topic_ids.intersection(set(data["topic_tag_ids"])))

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -670,7 +670,7 @@ def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type
         assert len(references) == len(set(reference["uuid"] for reference in references))
 
         visualisations = _get_visualisations_data_for_user_matching_query(
-            VisualisationCatalogueItem.objects, query="", user=u
+            VisualisationCatalogueItem.objects, query="", id_field="id", user=u
         )
         assert len(visualisations) == len(
             set(visualisation["id"] for visualisation in visualisations)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -674,7 +674,7 @@ def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type
         assert len(datasets) == len(set(dataset["id"] for dataset in datasets))
 
         references = _get_datasets_data_for_user_matching_query(
-            ReferenceDataset.objects.live(), "", {}, user=u
+            ReferenceDataset.objects.live(), "", user=u
         )
         assert len(references) == len(set(reference["id"] for reference in references))
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -669,14 +669,14 @@ def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type
 
     for u in [normal_user, staff_user]:
         datasets = _get_datasets_data_for_user_matching_query(
-            DataSet.objects.live(), query="", user=u
+            DataSet.objects.live(), query="", id_field="id", user=u
         )
         assert len(datasets) == len(set(dataset["id"] for dataset in datasets))
 
         references = _get_datasets_data_for_user_matching_query(
-            ReferenceDataset.objects.live(), "", user=u
+            ReferenceDataset.objects.live(), "", id_field="uuid", user=u
         )
-        assert len(references) == len(set(reference["id"] for reference in references))
+        assert len(references) == len(set(reference["uuid"] for reference in references))
 
         visualisations = _get_visualisations_data_for_user_matching_query(
             VisualisationCatalogueItem.objects, query="", user=u

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -247,7 +247,6 @@ def expected_search_result(catalogue_item, **kwargs):
         "is_subscribed": False,
         "has_visuals": mock.ANY,
         "is_open_data": getattr(catalogue_item, "user_access_type", None) == UserAccessType.OPEN,
-        "eligibility_criteria": mock.ANY,
         "sources": mock.ANY,
         "topics": mock.ANY,
         "last_updated": mock.ANY,

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -36,7 +36,6 @@ from dataworkspace.apps.datasets.models import (
 )
 from dataworkspace.apps.datasets.search import (
     _get_datasets_data_for_user_matching_query,
-    _get_visualisations_data_for_user_matching_query,
 )
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.your_files.models import UploadedTable
@@ -669,7 +668,7 @@ def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type
         )
         assert len(references) == len(set(reference["uuid"] for reference in references))
 
-        visualisations = _get_visualisations_data_for_user_matching_query(
+        visualisations = _get_datasets_data_for_user_matching_query(
             VisualisationCatalogueItem.objects, query="", id_field="id", user=u
         )
         assert len(visualisations) == len(

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -241,7 +241,6 @@ def expected_search_result(catalogue_item, **kwargs):
         "source_tag_ids": mock.ANY,
         "topic_tag_names": mock.ANY,
         "topic_tag_ids": mock.ANY,
-        "purpose": mock.ANY,
         "data_type": mock.ANY,
         "published": catalogue_item.published,
         "has_access": True,
@@ -275,9 +274,9 @@ def test_find_datasets_combines_results(client):
     datasets = list(response.context["datasets"])
 
     expected_results = [
-        expected_search_result(ds, has_access=False, purpose=DataSetType.DATACUT),
-        expected_search_result(rds, purpose=DataSetType.DATACUT),
-        expected_search_result(vis, purpose=DataSetType.VISUALISATION),
+        expected_search_result(ds, has_access=False, data_type=DataSetType.DATACUT),
+        expected_search_result(rds, data_type=DataSetType.REFERENCE),
+        expected_search_result(vis, data_type=DataSetType.VISUALISATION),
     ]
 
     for i, ds in enumerate(datasets):
@@ -303,7 +302,7 @@ def test_find_datasets_by_source_table_name(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ds, has_access=False, purpose=DataSetType.MASTER),
+        expected_search_result(ds, has_access=False, data_type=DataSetType.MASTER),
     ]
 
 
@@ -337,7 +336,7 @@ def test_find_datasets_by_source_table_falls_back_to_normal_search(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ds, has_access=False, purpose=DataSetType.MASTER),
+        expected_search_result(ds, has_access=False, data_type=DataSetType.MASTER),
     ]
 
 
@@ -378,13 +377,12 @@ def test_find_datasets_filters_by_query(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ds, purpose=ds.type, has_access=False),
+        expected_search_result(ds, data_type=ds.type, has_access=False),
         expected_search_result(
             rds,
-            purpose=DataSetType.DATACUT,
             data_type=DataSetType.REFERENCE,
         ),
-        expected_search_result(vis, purpose=DataSetType.VISUALISATION),
+        expected_search_result(vis, data_type=DataSetType.VISUALISATION),
     ]
 
 
@@ -401,52 +399,46 @@ def test_find_datasets_filters_by_query_acronym(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ds, purpose=ds.type, has_access=False),
+        expected_search_result(ds, data_type=ds.type, has_access=False),
     ]
 
 
-def test_find_datasets_filters_by_use(client):
+def test_find_datasets_filters_by_data_type(client):
     factories.DataSetFactory.create(published=True, type=1, name="A dataset")
     ds = factories.DataSetFactory.create(published=True, type=2, name="A new dataset")
-    rds = factories.ReferenceDatasetFactory.create(published=True, name="A new reference dataset")
+    factories.ReferenceDatasetFactory.create(published=True, name="A new reference dataset")
 
-    response = client.get(reverse("datasets:find_datasets"), {"use": [DataSetType.DATACUT]})
+    response = client.get(reverse("datasets:find_datasets"), {"data_type": [DataSetType.DATACUT]})
 
     assert response.status_code == 200
 
     expected_results = [
         expected_search_result(ds, has_access=False),
-        expected_search_result(rds),
     ]
 
     datasets = list(response.context["datasets"])
 
-    assert len(datasets) == 2
+    assert len(datasets) == 1
 
     for i, ds in enumerate(datasets):
         expected = expected_results[i]
         assert ds == expected
 
 
-def test_find_datasets_filters_visualisations_by_use(client):
+def test_find_datasets_filters_visualisations_by_data_type(client):
     factories.DataSetFactory.create(published=True, type=1, name="A dataset")
     ds = factories.DataSetFactory.create(published=True, type=2, name="A new dataset")
-    rds = factories.ReferenceDatasetFactory.create(published=True, name="A new reference dataset")
+    factories.ReferenceDatasetFactory.create(published=True, name="A new reference dataset")
     vis = factories.VisualisationCatalogueItemFactory.create(
         published=True, name="A new visualisation"
     )
 
-    response = client.get(reverse("datasets:find_datasets"), {"use": [2, 3]})
+    response = client.get(reverse("datasets:find_datasets"), {"data_type": [2, 3]})
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
         expected_search_result(ds, has_access=False),
-        expected_search_result(
-            rds,
-            purpose=DataSetType.DATACUT,
-            data_type=DataSetType.REFERENCE,
-        ),
-        expected_search_result(vis, purpose=DataSetType.VISUALISATION),
+        expected_search_result(vis, data_type=DataSetType.VISUALISATION),
     ]
 
 
@@ -497,7 +489,7 @@ def test_find_datasets_filters_by_source(client):
             vis,
             source_tag_names=[source.name],
             source_tag_ids=[source.id],
-            purpose=DataSetType.VISUALISATION,
+            data_type=DataSetType.VISUALISATION,
         ),
     ]
 
@@ -551,14 +543,13 @@ def test_find_datasets_filters_by_topic(client):
             rds,
             topic_tag_names=[topic.name],
             topic_tag_ids=[topic.id],
-            purpose=DataSetType.DATACUT,
             data_type=DataSetType.REFERENCE,
         ),
         expected_search_result(
             vis,
             topic_tag_names=[topic.name],
             topic_tag_ids=[topic.id],
-            purpose=DataSetType.VISUALISATION,
+            data_type=DataSetType.VISUALISATION,
         ),
     ]
 
@@ -575,8 +566,8 @@ def test_find_datasets_order_by_name_asc(client):
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
         expected_search_result(ds1, has_access=False),
-        expected_search_result(rds, purpose=DataSetType.DATACUT, data_type=DataSetType.REFERENCE),
-        expected_search_result(vis, purpose=DataSetType.VISUALISATION),
+        expected_search_result(rds, data_type=DataSetType.REFERENCE),
+        expected_search_result(vis, data_type=DataSetType.VISUALISATION),
     ]
 
 
@@ -589,7 +580,7 @@ def test_find_datasets_order_by_newest_first(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ads1, purpose=ads1.type, has_access=False),
+        expected_search_result(ads1, data_type=ads1.type, has_access=False),
         expected_search_result(ads2, has_access=False),
         expected_search_result(ads3, has_access=False),
     ]
@@ -604,9 +595,9 @@ def test_find_datasets_order_by_oldest_first(client):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(ads3, has_access=False, purpose=ads3.type),
-        expected_search_result(ads2, has_access=False, purpose=ads2.type),
-        expected_search_result(ads1, has_access=False, purpose=ads1.type),
+        expected_search_result(ads3, has_access=False, data_type=ads3.type),
+        expected_search_result(ads2, has_access=False, data_type=ads2.type),
+        expected_search_result(ads1, has_access=False, data_type=ads1.type),
     ]
 
 
@@ -773,7 +764,7 @@ def test_finding_datasets_doesnt_query_database_excessively(
     with django_assert_num_queries(expected_num_queries, exact=False):
         response = client.get(
             reverse("datasets:find_datasets"),
-            {"purpose": str(DataSetType.MASTER)},
+            {"data_type": str(DataSetType.MASTER)},
         )
         assert response.status_code == 200
 
@@ -954,7 +945,6 @@ def test_find_datasets_filters_by_bookmark_reference(access_type):
         expected_search_result(
             public_reference,
             is_bookmarked=True,
-            purpose=DataSetType.DATACUT,
             data_type=DataSetType.REFERENCE,
         )
     ]
@@ -1008,7 +998,7 @@ def test_find_datasets_filters_by_bookmark_visualisation(access_type):
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
-        expected_search_result(public_vis, is_bookmarked=True, purpose=DataSetType.VISUALISATION)
+        expected_search_result(public_vis, is_bookmarked=True, data_type=DataSetType.VISUALISATION)
     ]
 
 
@@ -1062,7 +1052,7 @@ def test_find_datasets_filters_by_bookmark_datacut(access_type):
     assert list(response.context["datasets"]) == [
         expected_search_result(
             public_datacut,
-            purpose=DataSetType.DATACUT,
+            data_type=DataSetType.DATACUT,
             is_bookmarked=True,
             has_access=False,
         )
@@ -2050,7 +2040,6 @@ def test_find_datasets_search_by_source_name(client):
         expected_search_result(
             rds,
             search_rank=0.12158542,
-            purpose=DataSetType.DATACUT,
             data_type=DataSetType.REFERENCE,
         ),
     ]
@@ -3774,9 +3763,11 @@ def test_filter_reference_datasets_search_v2(access_type):
         user_access_type=access_type,
     )
     factories.ReferenceDatasetFactory.create(published=True, name="Reference")
-    response = client.get(reverse("datasets:find_datasets"), {"use": [DataSetType.DATACUT]})
+    response = client.get(
+        reverse("datasets:find_datasets"), {"data_type": [DataSetType.REFERENCE]}
+    )
     assert response.status_code == 200
-    assert len(response.context["datasets"]) == 2
+    assert len(response.context["datasets"]) == 1
 
 
 @pytest.mark.parametrize(

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -669,7 +669,7 @@ def test_datasets_and_visualisations_doesnt_return_duplicate_results(access_type
 
     for u in [normal_user, staff_user]:
         datasets = _get_datasets_data_for_user_matching_query(
-            DataSet.objects.live(), query="", use={}, user=u
+            DataSet.objects.live(), query="", user=u
         )
         assert len(datasets) == len(set(dataset["id"] for dataset in datasets))
 


### PR DESCRIPTION
### Description of change

A good amount of the performance issues came from joining datasets with _all_ user permissions, subscriptions, and bookmarks - essentially a "combinatorial explosion". These are then collapsed down to one row per dataset by a GROUP BY (annotation).

However, most of these rows do not contribute to the results - they are rows for users other than the current. So this PR uses FilteredRelation to filter out the these rows in the JOIN itself, to hopefully greatly reduce the combinatorial explosion.

Quite a lot of refactoring is done in order to support this. Specifically to a) reduce duplicated code, and b) be able to have the related code for each annotation together for the different dataset types. Hopefully this supports the upcoming work to improve search results ordering as well.

From a brief test of the main query on production, this has reduced the main search query from ~10 seconds to ~100ms. It's not a perfect test - I'm taking the query on master from my system locally and running it on prod, and ditto for the code from this branch. But hopefully it's representative enough, and I think very unlikely to make search worse on prod.


### Checklist

* [x] Have tests been added to cover any changes?
