### PR TITLE
fix: remove leading slash to prevent django warnings

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/manager/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/urls.py
@@ -19,62 +19,62 @@ from dataworkspace.apps.datasets.manager.views import (
 
 urlpatterns = [
     path(
-        "/<uuid:source_uuid>",
+        "<uuid:source_uuid>",
         login_required(DatasetManageSourceTableView.as_view()),
         name="manage-source-table",
     ),
     path(
-        "/<uuid:source_uuid>/columns",
+        "<uuid:source_uuid>/columns",
         login_required(DatasetManageSourceTableColumnConfigView.as_view()),
         name="manage-source-table-column-config",
     ),
     path(
-        "/<uuid:source_uuid>/upload/validating",
+        "<uuid:source_uuid>/upload/validating",
         login_required(SourceTableUploadValidatingView.as_view()),
         name="upload-validating",
     ),
     path(
-        "/<uuid:source_uuid>/upload/creating-table",
+        "<uuid:source_uuid>/upload/creating-table",
         login_required(SourceTableUploadCreatingTableView.as_view()),
         name="upload-creating-table",
     ),
     path(
-        "/<uuid:source_uuid>/upload/ingesting",
+        "<uuid:source_uuid>/upload/ingesting",
         login_required(SourceTableUploadIngestingView.as_view()),
         name="upload-ingesting",
     ),
     path(
-        "/<uuid:source_uuid>/upload/renaming-table",
+        "<uuid:source_uuid>/upload/renaming-table",
         login_required(SourceTableUploadRenamingTableView.as_view()),
         name="upload-renaming-table",
     ),
     path(
-        "/<uuid:source_uuid>/upload/success",
+        "<uuid:source_uuid>/upload/success",
         login_required(SourceTableUploadSuccessView.as_view()),
         name="upload-success",
     ),
     path(
-        "/<uuid:source_uuid>/upload/failed",
+        "<uuid:source_uuid>/upload/failed",
         login_required(SourceTableUploadFailedView.as_view()),
         name="upload-failed",
     ),
     path(
-        "/<uuid:source_uuid>/restore/<int:version_id>",
+        "<uuid:source_uuid>/restore/<int:version_id>",
         login_required(SourceTableRestoreView.as_view()),
         name="restore-table",
     ),
     path(
-        "/<uuid:source_uuid>/restore-table/<int:version_id>/restoring",
+        "<uuid:source_uuid>/restore-table/<int:version_id>/restoring",
         login_required(SourceTableRestoringView.as_view()),
         name="restoring-table",
     ),
     path(
-        "/<uuid:source_uuid>/restore-table/<int:version_id>/failed",
+        "<uuid:source_uuid>/restore-table/<int:version_id>/failed",
         login_required(SourceTableRestoreFailedView.as_view()),
         name="restore-failed",
     ),
     path(
-        "/<uuid:source_uuid>/restore-table/<int:version_id>/success",
+        "<uuid:source_uuid>/restore-table/<int:version_id>/success",
         login_required(SourceTableRestoreSuccessView.as_view()),
         name="restore-success",
     ),

--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -273,7 +273,7 @@ urlpatterns = [
         name="dataset_charts",
     ),
     path(
-        "<uuid:pk>/manage",
+        "<uuid:pk>/manage/",
         include(
             ("dataworkspace.apps.datasets.manager.urls", "dataset_manager"),
             namespace="manager",


### PR DESCRIPTION
### Description of change
Remove a load of django warnings about urls
```
data-workspace-data-workspace-1  | ?: (urls.W002) Your URL pattern '/<uuid:source_uuid>' [name='manage-source-table'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), e
data-workspace-data-workspace-1  | ?: (urls.W002) Your URL pattern '/<uuid:source_uuid>/columns' [name='manage-source-table-column-config'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targe
data-workspace-data-workspace-1  | ?: (urls.W002) Your URL pattern '/<uuid:source_uuid>/restore-table/<int:version_id>/failed' [name='restore-failed'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this patte
data-workspace-data-workspace-1  | ?: (urls.W002) Your URL pattern '/<uuid:source_uuid>/restore-table/<int:version_id>/restoring' [name='restoring-table'] has a route beginning with a '/'. Remove this slash as it is unnecessary. If this p
```

### Checklist

~* [ ] Have tests been added to cover any changes?~
