### PR TITLE
fix: data cut preview link and data type column width for data directionaries

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -48,12 +48,15 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-4">
         Data preview
       </h2>
+      {# We only support data dictionaries for master datasets currently #}
+      {% if object.type == 1 %}
       <p class="govuk-body govuk-body-m">
         <a href="{% url "datasets:data_dictionary" source_uuid=object.id %}?dataset_uuid={{object.dataset.id}}"
         class="govuk-link govuk-link--no-visited-state">
         Data dictionary
         </a>
       </p> 
+      {% endif %}
       <div id="data-grid" class="ag-theme-alpine"></div>
       <div class="govuk-!-margin-top-4">
         {% if object.data_grid_download_enabled %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_dictionary.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_dictionary.html
@@ -48,7 +48,7 @@
         <thead>
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header govuk-!-width-one-quarter" aria-sort="ascending">Name</th>
-          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter" aria-sort="none">Format</th>
+          <th scope="col" class="govuk-table__header" aria-sort="none">Format</th>
           <th scope="col" class="govuk-table__header" aria-sort="none">Definition</th>
         </tr>
         </thead>


### PR DESCRIPTION
### Description of change
- dictionary link in ```data_cut_source_detail``` only displayed for source datasets to fix error message on data cuts
- column width reduced for data type on dictionaries to allow more space for definitions when very long field names are present (e.g. Export Wins). 


### Checklist
~* [ ] Have tests been added to cover any changes?~
