### PR TITLE
Feat/uploader enhanced error messages

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/constants.py
+++ b/dataworkspace/dataworkspace/apps/core/constants.py
@@ -23,3 +23,10 @@ SCHEMA_POSTGRES_DATA_TYPE_MAP = {
 TABLESCHEMA_FIELD_TYPE_MAP = {
     "number": "numeric",
 }
+
+DATA_FLOW_TASK_ERROR_MAP = {
+    r".*Unable to decode CSV as.*|.*UnicodeDecodeError.*": "core/partial/errors/decode.html",
+    r".*invalid input syntax for (type )?(numeric|integer).*": "core/partial/errors/input-syntax.html",
+    r".*NumericValueOutOfRange.*": "core/partial/errors/out-of-range.html",
+    r".*DatetimeFieldOverflow.*|.*InvalidDatetimeFormat*": "core/partial/errors/invalid-date.html",
+}

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -14,6 +14,7 @@ from io import StringIO
 from typing import Tuple
 
 from timeit import default_timer as timer
+from urllib.parse import unquote
 
 import gevent
 import gevent.queue
@@ -35,6 +36,7 @@ from tableschema import Schema
 
 from dataworkspace.apps.core.boto3_client import get_s3_client, get_iam_client
 from dataworkspace.apps.core.constants import (
+    DATA_FLOW_TASK_ERROR_MAP,
     PostgresDataTypes,
     SCHEMA_POSTGRES_DATA_TYPE_MAP,
     TABLESCHEMA_FIELD_TYPE_MAP,
@@ -1374,3 +1376,37 @@ def get_dataflow_task_status(dag, execution_date, task_id):
     response = requests.get(url, headers={"Authorization": header, "Content-Type": ""})
     response.raise_for_status()
     return response.json().get("state")
+
+
+def get_dataflow_task_log(dag, execution_date, task_id):
+    config = settings.DATAFLOW_API_CONFIG
+    url = (
+        f'{config["DATAFLOW_BASE_URL"]}/api/experimental/derived-dags/'
+        f"dag/{dag}/{execution_date.split('+')[0]}/{task_id}/log"
+    )
+    header = Sender(
+        {
+            "id": config["DATAFLOW_HAWK_ID"],
+            "key": config["DATAFLOW_HAWK_KEY"],
+            "algorithm": "sha256",
+        },
+        url,
+        "get",
+        content="",
+        content_type="",
+    ).request_header
+    response = requests.get(url, headers={"Authorization": header, "Content-Type": ""})
+    response.raise_for_status()
+    return response.json().get("log")
+
+
+def get_task_error_message_template(execution_date, task_name):
+    logs = get_dataflow_task_log(
+        settings.DATAFLOW_API_CONFIG["DATAFLOW_S3_IMPORT_DAG"],
+        unquote(execution_date).replace(" ", "+"),
+        task_name,
+    )
+    for error_re, template_name in DATA_FLOW_TASK_ERROR_MAP.items():
+        if re.match(error_re, logs, re.DOTALL | re.IGNORECASE):
+            return template_name
+    return None

--- a/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
@@ -23,6 +23,7 @@ class SourceTableUploadForm(GOVUKDesignSystemForm):
             heading_class="govuk-heading-s",
             extra_label_classes="govuk-!-font-weight-bold",
             show_selected_file=True,
+            attrs={"accept": "text/csv"},
         ),
         validators=[
             FileExtensionValidator(allowed_extensions=["csv"]),

--- a/dataworkspace/dataworkspace/apps/your_files/views.py
+++ b/dataworkspace/dataworkspace/apps/your_files/views.py
@@ -29,6 +29,7 @@ from dataworkspace.apps.core.utils import (
     get_all_schemas,
     get_random_data_sample,
     get_s3_prefix,
+    get_task_error_message_template,
     get_team_schemas_for_user,
     new_private_database_credentials,
     postgres_user,
@@ -382,10 +383,12 @@ class BaseCreateTableStepView(BaseCreateTableTemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data()
+        query_params = self._get_query_parameters()
+        query_params["task_name"] = self.task_name
         context.update(
             {
                 "task_name": self.task_name,
-                "next_step": f"{reverse(self.next_step_url_name)}?{urlencode(self._get_query_parameters())}",
+                "next_step": f"{reverse(self.next_step_url_name)}?{urlencode(query_params)}",
             }
         )
         return context
@@ -485,6 +488,10 @@ class CreateTableFailedView(RequiredParameterGetRequestMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["filename"] = self.request.GET["filename"]
+        if "execution_date" in self.request.GET and "task_name" in self.request.GET:
+            context["error_message_template"] = get_task_error_message_template(
+                self.request.GET["execution_date"], self.request.GET["task_name"]
+            )
         return context
 
 

--- a/dataworkspace/dataworkspace/static/your-files-create-table.js
+++ b/dataworkspace/dataworkspace/static/your-files-create-table.js
@@ -1,10 +1,19 @@
 var POLL_DELAY = 1000;
 var FAILURE_STATES = ['failed', 'upstream_failed'];
 
-function pollForDagStateChange(taskStatusUrl, successRedirectUrl, failureRedirectUrl) {
+function buildFailureUrl(failureRedirectUrl, taskName) {
+  var queryParams = Object.fromEntries(new URLSearchParams(location.search))
+  queryParams.task_name = taskName;
+  return failureRedirectUrl + '?' + Object.keys(queryParams).map(function(key) {
+      return key + '=' + queryParams[key]
+  }).join('&');
+}
+
+function pollForDagStateChange(taskStatusUrl, successRedirectUrl, failureRedirectUrl, taskName) {
   var xhr = new XMLHttpRequest();
   xhr.open('GET', taskStatusUrl);
   xhr.onreadystatechange = function() {
+
     if (this.readyState === XMLHttpRequest.DONE) {
       if (this.status === 200) {
         var resp = JSON.parse(xhr.responseText);
@@ -12,18 +21,19 @@ function pollForDagStateChange(taskStatusUrl, successRedirectUrl, failureRedirec
           window.location.href = successRedirectUrl;
         }
         if (FAILURE_STATES.includes(resp.state)) {
-          window.location.href = failureRedirectUrl;
+          window.location.href = buildFailureUrl(failureRedirectUrl, taskName);
         }
         setTimeout(function () {
           pollForDagStateChange(
               taskStatusUrl,
               successRedirectUrl,
-              failureRedirectUrl
+              failureRedirectUrl,
+              taskName
           )
         }, POLL_DELAY);
       }
       else {
-        window.location.href = failureRedirectUrl;
+        window.location.href = buildFailureUrl(failureRedirectUrl, taskName);
       }
     }
   }

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/decode.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/decode.html
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  Your file, {{ filename }}, cannot be processed due to a character encoding error.
+</p>
+<p class="govuk-body">
+ If this problem persists, <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Team</a> for help.
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/input-syntax.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/input-syntax.html
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  Your file, {{ filename }}, cannot be processed due to an error parsing a numeric field.
+</p>
+<p class="govuk-body">
+ This can occur when a column's data type is set as numeric or integer and the column in the csv contains characters.
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/invalid-date.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/invalid-date.html
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  Your file, {{ filename }}, cannot be processed due to an error parsing a date field. This can occur when a date column is in US format.
+</p>
+<p class="govuk-body">
+ The recommended date format for data workspace uploads is <nobr>YYYY-MM-DD</nobr>.
+</p>

--- a/dataworkspace/dataworkspace/templates/core/partial/errors/out-of-range.html
+++ b/dataworkspace/dataworkspace/templates/core/partial/errors/out-of-range.html
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  Your file, {{ filename }}, cannot be processed due to an out of range error.
+</p>
+<p class="govuk-body">
+ This can occur when a column with a data type set to integer contains numbers with more than 12 digits.
+</p>

--- a/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table_column_config.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table_column_config.html
@@ -26,7 +26,30 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Choose data types for {{ form.table_name.value }}</h1>
+      <h1 class="govuk-heading-xl">Choose data types for {{ source.name }}</h1>
+
+      {% if form.column_definitions|length != source.get_column_config|length %}
+        <div class="govuk-grid-column-full">
+          <div class="govuk-error-summary">
+            <div class="govuk-warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                Column number mismatch
+              </strong>
+            </div>
+            <p class="govuk-body">
+              The number of columns in the uploaded file ({{ form.column_definitions|length }}) does not match the number
+              of columns in the table "{{ source.schema }}"."{{ source.table }}" ({{ source.get_column_config|length }}).
+            </p>
+            <div class="button-wrap">
+              <a class="govuk-button govuk-button--secondary" href="{% url 'datasets:manager:manage-source-table' source.dataset_id source.id %}">
+              Back
+            </a>
+            </div>
+          </div>
+        </div>
+      {% endif %}
       {% include 'design_system/error_summary.html' with form=form %}
       <form method="POST" novalidate>
         {% csrf_token %}

--- a/dataworkspace/dataworkspace/templates/datasets/manager/restoring.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/restoring.html
@@ -24,7 +24,7 @@
         '{% url "restore-table-task-status" request.GET.execution_date request.GET.task_name as status_url %}{{ status_url|escapejs }}',
         '{% url "datasets:manager:restore-success" source.dataset_id source.id version.id as success_url %}{{ success_url|escapejs }}',
         '{% url "datasets:manager:restore-failed" source.dataset_id source.id version.id as failure_url %}{{ failure_url|escapejs }}',
-        500
+        '{{ request.GET.task_name }}',
     );
   </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/upload_failed.html
@@ -7,16 +7,20 @@
       <h1 class="govuk-heading-l">
         We can’t process your CSV file
       </h1>
-      <p class="govuk-body">
-        Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
-      </p>
-      <div class="govuk-inset-text">
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Make sure the file uploaded is a CSV file</li>
-          <li>All rows in your file must have the same number of columns</li>
-          <li>Column names must be unique</li>
-        </ul>
-      </div>
+      {% if error_message_template %}
+        {% include error_message_template %}
+      {% else %}
+        <p class="govuk-body">
+          Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
+        </p>
+        <div class="govuk-inset-text">
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Make sure the file uploaded is a CSV file</li>
+            <li>All rows in your file must have the same number of columns</li>
+            <li>Column names must be unique</li>
+          </ul>
+        </div>
+      {% endif %}
       <p class="govuk-body">
         <a href="{{ next_step }}" class="govuk-link">Return to dataset upload page</a>
       </p>

--- a/dataworkspace/dataworkspace/templates/datasets/manager/uploading.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/uploading.html
@@ -26,8 +26,8 @@
     window.pollForDagStateChange(
         '{% url "create-table-task-status" execution_date task_name as status_url %}{{ status_url|escapejs }}',
         '{{ next_step|escapejs }}',
-        '{% url "datasets:manager:upload-failed" pk=source.dataset_id source_uuid=source.id as failure_url %}{{ failure_url|escapejs }}?{{ request.GET.urlencode|escapejs }}',
-        500
+        '{% url "datasets:manager:upload-failed" pk=source.dataset_id source_uuid=source.id as failure_url %}{{ failure_url|escapejs }}',
+        '{{ task_name }}'
     );
   </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-failed.html
@@ -6,16 +6,20 @@
       <h1 class="govuk-heading-l">
         We can’t process your CSV file
       </h1>
-      <p class="govuk-body">
-        Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
-      </p>
-      <div class="govuk-inset-text">
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Make sure the file uploaded is a CSV file</li>
-          <li>All rows in your file must have the same number of columns</li>
-          <li>Column names must be unique</li>
-        </ul>
-      </div>
+      {% if error_message_template %}
+        {% include error_message_template %}
+      {% else %}
+        <p class="govuk-body">
+          Your file, {{ filename }}, cannot be processed. Please check the following before you try again.
+        </p>
+        <div class="govuk-inset-text">
+          <ul class="govuk-list govuk-list--bullet">
+            <li>Make sure the file uploaded is a CSV file</li>
+            <li>All rows in your file must have the same number of columns</li>
+            <li>Column names must be unique</li>
+          </ul>
+        </div>
+      {% endif %}
       <p class="govuk-body">
         <a href="{% url 'your_files:files' %}" class="govuk-link">Return to your files</a>
       </p>

--- a/dataworkspace/dataworkspace/templates/your_files/create-table-processing.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-processing.html
@@ -24,8 +24,8 @@
     window.pollForDagStateChange(
         '{% url "create-table-task-status" execution_date task_name as status_url %}{{ status_url|escapejs }}',
         '{{ next_step|escapejs }}',
-        '{% url "your-files:create-table-failed" as failure_url %}{{ failure_url|escapejs }}?{{ request.GET.urlencode|escapejs }}',
-        500
+        '{% url "your-files:create-table-failed" as failure_url %}{{ failure_url|escapejs }}',
+        '{{ task_name }}'
     );
   </script>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/your_files/restore-table-in-progress.html
+++ b/dataworkspace/dataworkspace/templates/your_files/restore-table-in-progress.html
@@ -23,7 +23,7 @@
         '{% url "restore-table-task-status" request.GET.execution_date request.GET.task_name as status_url %}{{ status_url|escapejs }}',
         '{% url "your-files:restore-table-success" object.id as success_url %}{{ success_url|escapejs }}',
         '{% url "your-files:restore-table-failed" object.id as failure_url %}{{ failure_url|escapejs }}',
-        500
+        '{{ task_name }}'
     );
   </script>  
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4557,3 +4557,51 @@ class TestDatasetManagerViews:
             "DataWorkspaceRestoreTablePipeline",
             "restore-public-dataset_test-2021-01-01T01:01:01",
         )
+
+    @override_flag(settings.DATA_UPLOADER_UI_FLAG, active=True)
+    @pytest.mark.django_db
+    @freeze_time("2021-01-01 01:01:01")
+    @pytest.mark.parametrize(
+        "log_message,expected_text",
+        [
+            ("Generic Error", b"Please check the following before you try again"),
+            ("UnicodeDecodeError", b"character encoding error"),
+            ("Invalid input syntax for type Numeric", b"error parsing a numeric field"),
+            ("NumericValueOutOfRange", b"out of range error"),
+            ("DatetimeFieldOverflow", b"error parsing a date field"),
+        ],
+    )
+    @mock.patch("dataworkspace.apps.core.utils.get_dataflow_task_log")
+    def test_upload_failed_view(
+        self,
+        mock_get_task_log,
+        log_message,
+        expected_text,
+        dataset_db_with_swap_table,
+        user,
+        client,
+    ):
+        mock_get_task_log.return_value = (
+            f"Dummy logging output...\n{log_message}\nmore log output\nEND"
+        )
+        source = factories.SourceTableFactory.create(
+            dataset=factories.MasterDataSetFactory.create(
+                published=True,
+                user_access_type=UserAccessType.REQUIRES_AUTHENTICATION,
+                information_asset_manager=user,
+            ),
+            schema="public",
+            table="dataset_test",
+        )
+        response = client.get(
+            reverse(
+                "datasets:manager:upload-failed",
+                args=(
+                    source.dataset.id,
+                    source.id,
+                ),
+            )
+            + "?filename=test.csv&execution_date=2022-01-01&task_name=dummy"
+        )
+        assert response.status_code == 200
+        assert expected_text in response.content


### PR DESCRIPTION
### Description of change

If an upload (your files or dataset uploader) fails, scan the logs for the failed task and try to match with a known error. If a match is found, include the associated error message in the template, otherwise fall back to the generic message.

Generic
![generic](https://user-images.githubusercontent.com/594496/171164790-883a6793-1640-453d-be20-b4ea5954ba15.png)

Invalid numeric field
![invalid-numeric](https://user-images.githubusercontent.com/594496/171164810-527d805c-7f6d-46e9-a530-65762f6316ba.png)

Number out of range
![numeric-out-of-range](https://user-images.githubusercontent.com/594496/171164854-5ef92a7e-ed41-4987-895c-14fd870dc2c7.png)

Invalid date
![invalid-date](https://user-images.githubusercontent.com/594496/171164870-57b1c482-6a0b-4c09-bcfa-17518cf10fe1.png)

Unicode decode error
![unicode](https://user-images.githubusercontent.com/594496/171164889-ca385557-7377-427a-a7e1-3f699ec66f2b.png)


### Checklist

* [x] Have tests been added to cover any changes?
