### PR TITLE
perf: reduce N+1 queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -69,7 +69,7 @@ from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.core.charts.models import ChartBuilderChart
 from dataworkspace.apps.your_files.models import UploadedTable
 from dataworkspace.datasets_db import (
-    get_tables_last_updated_date,
+    get_earliest_tables_last_updated_date,
 )
 
 
@@ -707,7 +707,7 @@ class SourceTable(BaseSource):
         return DataLinkType.SOURCE_TABLE
 
     def get_data_last_updated_date(self):
-        return get_tables_last_updated_date(
+        return get_earliest_tables_last_updated_date(
             self.database.memorable_name, ((self.schema, self.table),)
         )
 
@@ -986,7 +986,7 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
     def get_data_last_updated_date(self):
         tables = CustomDatasetQueryTable.objects.filter(query=self)
         if tables:
-            return get_tables_last_updated_date(
+            return get_earliest_tables_last_updated_date(
                 self.database.memorable_name,
                 tuple((table.schema, table.table) for table in tables),
             )

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -178,22 +178,13 @@ def _get_datasets_data_for_user_matching_query(
             )
         )
 
-    # source_tag_ids and source_tag_names
+    # tags
 
     datasets = datasets.annotate(
         source_tag_ids=ArrayAgg("tags", filter=Q(tags__type=TagType.SOURCE), distinct=True)
     )
     datasets = datasets.annotate(
-        source_tag_names=ArrayAgg("tags__name", filter=Q(tags__type=TagType.SOURCE), distinct=True)
-    )
-
-    # topic_tag_ids and topic_tag_names
-
-    datasets = datasets.annotate(
         topic_tag_ids=ArrayAgg("tags", filter=Q(tags__type=TagType.TOPIC), distinct=True)
-    )
-    datasets = datasets.annotate(
-        topic_tag_names=ArrayAgg("tags__name", filter=Q(tags__type=TagType.TOPIC), distinct=True)
     )
 
     # data_type
@@ -244,9 +235,7 @@ def _get_datasets_data_for_user_matching_query(
         "slug",
         "short_description",
         "search_rank",
-        "source_tag_names",
         "source_tag_ids",
-        "topic_tag_names",
         "topic_tag_ids",
         "data_type",
         "published",

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -39,7 +39,7 @@ from dataworkspace.datasets_db import (
     get_data_hash,
     get_reference_dataset_changelog,
     get_source_table_changelog,
-    get_tables_last_updated_date,
+    get_earliest_tables_last_updated_date,
 )
 from dataworkspace.notify import EmailSendFailureException, send_email
 from dataworkspace.utils import TYPE_CODES_REVERSED
@@ -182,7 +182,7 @@ def process_quicksight_dashboard_visualisations():
 
     def get_last_updated_date_by_table_name(schema, table):
         for connection_alias, _ in settings.DATABASES_DATA.items():
-            date = get_tables_last_updated_date(connection_alias, ((schema, table),))
+            date = get_earliest_tables_last_updated_date(connection_alias, ((schema, table),))
             if date:
                 return date
         return None
@@ -667,7 +667,7 @@ def store_custom_dataset_query_metadata():
             )
             continue
 
-        tables_last_updated_date = get_tables_last_updated_date(
+        tables_last_updated_date = get_earliest_tables_last_updated_date(
             query.database.memorable_name, tuple(tables)
         )
         query_last_updated_date = query.modified_date

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -188,11 +188,6 @@ def _get_tags_as_dict():
 
 @require_GET
 def find_datasets(request):
-    def _enrich_tags(dataset, tags_dict):
-        dataset["sources"] = [
-            tags_dict.get(str(source_id)) for source_id in dataset["source_tag_ids"]
-        ]
-        dataset["topics"] = [tags_dict.get(str(topic_id)) for topic_id in dataset["topic_tag_ids"]]
 
     form = DatasetSearchForm(request.GET)
 
@@ -225,7 +220,10 @@ def find_datasets(request):
     datasets = paginator.get_page(request.GET.get("page"))
 
     for dataset in datasets:
-        _enrich_tags(dataset, tags_dict)
+        dataset["sources"] = [
+            tags_dict.get(str(source_id)) for source_id in dataset["source_tag_ids"]
+        ]
+        dataset["topics"] = [tags_dict.get(str(topic_id)) for topic_id in dataset["topic_tag_ids"]]
 
     # Data structures so can easily loop over datasets dicts for a type, and
     # find a dataset dict by type and ID

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -273,15 +273,17 @@ def find_datasets(request):
             default=None,
         )
 
-    for dataset in datasets_by_type[DataSetType.DATACUT.value]:
+    datacut_datasets = DataCutDataset.objects.filter(
+        id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.DATACUT.value])
+    )
+    for datacut_dataset in datacut_datasets:
+        dataset = datasets_by_type_id[(DataSetType.DATACUT.value, datacut_dataset.id)]
         dataset["last_updated"] = max(
             (
                 d
                 for d in (
                     query.get_data_last_updated_date()
-                    for query in DataCutDataset.objects.get(
-                        id=dataset["id"]
-                    ).customdatasetquery_set.all()
+                    for query in datacut_dataset.customdatasetquery_set.all()
                 )
                 if d is not None
             ),

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -294,7 +294,7 @@ def find_datasets(request):
         id__in=tuple(
             dataset["id"] for dataset in datasets_by_type[DataSetType.VISUALISATION.value]
         )
-    )
+    ).prefetch_related("visualisationlink_set")
     for visualisation_dataset in visualisation_datasets:
         dataset = datasets_by_type_id[(DataSetType.VISUALISATION.value, visualisation_dataset.id)]
         dataset["last_updated"] = max(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -4,7 +4,7 @@ import json
 import logging
 import uuid
 from abc import ABCMeta, abstractmethod
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from contextlib import closing
 from itertools import chain
 from typing import Set
@@ -281,6 +281,21 @@ def find_datasets(request):
 
     for dataset in datasets:
         _enrich_tags(dataset, tags_dict)
+
+    datasets_by_type = defaultdict(list)
+    for dataset in datasets:
+        datasets_by_type[dataset["data_type"]].append(dataset)
+
+    for dataset in datasets_by_type[DataSetType.REFERENCE.value]:
+        dataset["last_updated"] = _get_last_updated_date(dataset)
+
+    for dataset in datasets_by_type[DataSetType.MASTER.value]:
+        dataset["last_updated"] = _get_last_updated_date(dataset)
+
+    for dataset in datasets_by_type[DataSetType.DATACUT.value]:
+        dataset["last_updated"] = _get_last_updated_date(dataset)
+
+    for dataset in datasets_by_type[DataSetType.VISUALISATION.value]:
         dataset["last_updated"] = _get_last_updated_date(dataset)
 
     return render(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -175,7 +175,6 @@ def has_unpublished_dataset_access(user):
 def _get_tags_as_dict():
     """
     Gets all tags and returns them as a dictionary keyed by the tag.id as a string
-    This is a workaround until we refactor dataset search
     @return:
     """
     tags = Tag.objects.all()
@@ -280,7 +279,6 @@ def find_datasets(request):
 
     datasets = paginator.get_page(request.GET.get("page"))
 
-    # This is a workaround until we refactor search
     for dataset in datasets:
         _enrich_tags(dataset, tags_dict)
         dataset["last_updated"] = _get_last_updated_date(dataset)

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -228,25 +228,6 @@ def find_datasets(request):
 
         return [link.data_source_last_updated for link in dataset.visualisationlink_set.all()]
 
-    def _get_last_updated_date(dataset):
-        last_updated_dates = []
-
-        if dataset["data_type"] == DataSetType.REFERENCE:
-            last_updated_dates = _get_reference_dataset_last_updated(dataset["id"])
-
-        elif dataset["data_type"] == DataSetType.MASTER:
-            last_updated_dates = _get_master_dataset_last_updated(dataset["id"])
-
-        elif dataset["data_type"] == DataSetType.DATACUT:
-            last_updated_dates = _get_datacut_query_last_updated(dataset["id"])
-
-        elif dataset["data_type"] == DataSetType.VISUALISATION:
-            last_updated_dates = _get_visualisationcatalogue_link_last_updated(dataset["id"])
-
-        last_update_dates_no_null = [d for d in last_updated_dates if d is not None]
-
-        return max(last_update_dates_no_null, default=None)
-
     form = DatasetSearchForm(request.GET)
 
     if not form.is_valid():
@@ -287,16 +268,32 @@ def find_datasets(request):
         datasets_by_type[dataset["data_type"]].append(dataset)
 
     for dataset in datasets_by_type[DataSetType.REFERENCE.value]:
-        dataset["last_updated"] = _get_last_updated_date(dataset)
+        dataset["last_updated"] = max(
+            (d for d in _get_reference_dataset_last_updated(dataset["id"]) if d is not None),
+            default=None,
+        )
 
     for dataset in datasets_by_type[DataSetType.MASTER.value]:
-        dataset["last_updated"] = _get_last_updated_date(dataset)
+        dataset["last_updated"] = max(
+            (d for d in _get_master_dataset_last_updated(dataset["id"]) if d is not None),
+            default=None,
+        )
 
     for dataset in datasets_by_type[DataSetType.DATACUT.value]:
-        dataset["last_updated"] = _get_last_updated_date(dataset)
+        dataset["last_updated"] = max(
+            (d for d in _get_datacut_query_last_updated(dataset["id"]) if d is not None),
+            default=None,
+        )
 
     for dataset in datasets_by_type[DataSetType.VISUALISATION.value]:
-        dataset["last_updated"] = _get_last_updated_date(dataset)
+        dataset["last_updated"] = max(
+            (
+                d
+                for d in _get_visualisationcatalogue_link_last_updated(dataset["id"])
+                if d is not None
+            ),
+            default=None,
+        )
 
     return render(
         request,

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -258,10 +258,10 @@ def find_datasets(request):
 
     master_datasets = MasterDataset.objects.filter(
         id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.MASTER.value])
-    )
+    ).prefetch_related("sourcetable_set")
     datacut_datasets = DataCutDataset.objects.filter(
         id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.DATACUT.value])
-    )
+    ).prefetch_related("customdatasetquery_set")
     for master_dataset in master_datasets:
         dataset = datasets_by_type_id[(DataSetType.MASTER.value, master_dataset.id)]
         dataset["last_updated"] = max(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -201,38 +201,33 @@ def find_datasets(request):
             dataset["topics"].append(tag)
 
     def _get_reference_dataset_last_updated(dataset_id):
-        datasets = ReferenceDataset.objects.filter(uuid=dataset_id)
+        dataset = ReferenceDataset.objects.get(uuid=dataset_id)
 
         try:
             # If the reference dataset csv table doesn't exist we
             # get an unhandled relation does not exist error
             # this is currently only a problem with integration tests
-            return [datasets.first().data_last_updated]
+            return [dataset.data_last_updated]
         except ProgrammingError as e:
             logger.error(e)
             return []
 
     def _get_master_dataset_last_updated(dataset_id):
-        datasets = MasterDataset.objects.filter(id=dataset_id)
+        dataset = MasterDataset.objects.get(id=dataset_id)
 
-        return [
-            table.get_data_last_updated_date() for table in datasets.first().sourcetable_set.all()
-        ]
+        return [table.get_data_last_updated_date() for table in dataset.sourcetable_set.all()]
 
     def _get_datacut_query_last_updated(dataset_id):
-        datasets = DataCutDataset.objects.filter(id=dataset_id)
+        dataset = DataCutDataset.objects.get(id=dataset_id)
 
         return [
-            query.get_data_last_updated_date()
-            for query in datasets.first().customdatasetquery_set.all()
+            query.get_data_last_updated_date() for query in dataset.customdatasetquery_set.all()
         ]
 
     def _get_visualisationcatalogue_link_last_updated(dataset_id):
-        datasets = VisualisationCatalogueItem.objects.filter(id=dataset_id)
+        dataset = VisualisationCatalogueItem.objects.get(id=dataset_id)
 
-        return [
-            link.data_source_last_updated for link in datasets.first().visualisationlink_set.all()
-        ]
+        return [link.data_source_last_updated for link in dataset.visualisationlink_set.all()]
 
     def _get_last_updated_date(dataset):
         last_updated_dates = []

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -256,13 +256,17 @@ def find_datasets(request):
             logger.error(e)
             dataset["last_updated"] = None
 
-    for dataset in datasets_by_type[DataSetType.MASTER.value]:
+    master_datasets = MasterDataset.objects.filter(
+        id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.MASTER.value])
+    )
+    for master_dataset in master_datasets:
+        dataset = datasets_by_type_id[(DataSetType.MASTER.value, master_dataset.id)]
         dataset["last_updated"] = max(
             (
                 d
                 for d in (
                     table.get_data_last_updated_date()
-                    for table in MasterDataset.objects.get(id=dataset["id"]).sourcetable_set.all()
+                    for table in master_dataset.sourcetable_set.all()
                 )
                 if d is not None
             ),

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -227,8 +227,6 @@ def find_datasets(request):
         settings.SEARCH_RESULTS_DATASETS_PER_PAGE,
     )
 
-    data_types.append((DataSetType.VISUALISATION, "Visualisation"))
-
     datasets = paginator.get_page(request.GET.get("page"))
 
     for dataset in datasets:

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -66,6 +66,9 @@ from dataworkspace.apps.core.utils import (
     view_exists,
     get_random_data_sample,
 )
+from dataworkspace.apps.core.models import (
+    Database,
+)
 from dataworkspace.apps.datasets.constants import (
     DataSetType,
     DataLinkType,
@@ -252,9 +255,11 @@ def find_datasets(request):
     datacut_datasets = DataCutDataset.objects.filter(
         id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.DATACUT.value])
     ).prefetch_related("customdatasetquery_set")
+    databases = {database.id: database for database in Database.objects.all()}
+
     tables_and_last_updated_dates = datasets_db.get_all_tables_last_updated_date(
         [
-            (table.database.memorable_name, table.schema, table.table)
+            (databases[table.database_id].memorable_name, table.schema, table.table)
             for master_dataset in master_datasets
             for table in master_dataset.sourcetable_set.all()
         ]
@@ -266,7 +271,7 @@ def find_datasets(request):
             (
                 d
                 for d in (
-                    tables_and_last_updated_dates[table.database.memorable_name].get(
+                    tables_and_last_updated_dates[databases[table.database_id].memorable_name].get(
                         (table.schema, table.table)
                     )
                     for table in master_dataset.sourcetable_set.all()

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -259,6 +259,9 @@ def find_datasets(request):
     master_datasets = MasterDataset.objects.filter(
         id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.MASTER.value])
     )
+    datacut_datasets = DataCutDataset.objects.filter(
+        id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.DATACUT.value])
+    )
     for master_dataset in master_datasets:
         dataset = datasets_by_type_id[(DataSetType.MASTER.value, master_dataset.id)]
         dataset["last_updated"] = max(
@@ -273,9 +276,6 @@ def find_datasets(request):
             default=None,
         )
 
-    datacut_datasets = DataCutDataset.objects.filter(
-        id__in=tuple(dataset["id"] for dataset in datasets_by_type[DataSetType.DATACUT.value])
-    )
     for datacut_dataset in datacut_datasets:
         dataset = datasets_by_type_id[(DataSetType.DATACUT.value, datacut_dataset.id)]
         dataset["last_updated"] = max(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -189,15 +189,10 @@ def _get_tags_as_dict():
 @require_GET
 def find_datasets(request):
     def _enrich_tags(dataset, tags_dict):
-        dataset["sources"] = []
-        for source_id in dataset["source_tag_ids"]:
-            tag = tags_dict.get(str(source_id))
-            dataset["sources"].append(tag)
-
-        dataset["topics"] = []
-        for topic_id in dataset["topic_tag_ids"]:
-            tag = tags_dict.get(str(topic_id))
-            dataset["topics"].append(tag)
+        dataset["sources"] = [
+            tags_dict.get(str(source_id)) for source_id in dataset["source_tag_ids"]
+        ]
+        dataset["topics"] = [tags_dict.get(str(topic_id)) for topic_id in dataset["topic_tag_ids"]]
 
     form = DatasetSearchForm(request.GET)
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -202,8 +202,6 @@ def find_datasets(request):
 
     def _get_reference_dataset_last_updated(dataset_id):
         datasets = ReferenceDataset.objects.filter(uuid=dataset_id)
-        if not datasets.exists():
-            return []
 
         try:
             # If the reference dataset csv table doesn't exist we
@@ -216,8 +214,6 @@ def find_datasets(request):
 
     def _get_master_dataset_last_updated(dataset_id):
         datasets = MasterDataset.objects.filter(id=dataset_id)
-        if not datasets.exists():
-            return []
 
         return [
             table.get_data_last_updated_date() for table in datasets.first().sourcetable_set.all()
@@ -225,8 +221,6 @@ def find_datasets(request):
 
     def _get_datacut_query_last_updated(dataset_id):
         datasets = DataCutDataset.objects.filter(id=dataset_id)
-        if not datasets.exists():
-            return []
 
         return [
             query.get_data_last_updated_date()
@@ -235,8 +229,6 @@ def find_datasets(request):
 
     def _get_visualisationcatalogue_link_last_updated(dataset_id):
         datasets = VisualisationCatalogueItem.objects.filter(id=dataset_id)
-        if not datasets.exists():
-            return []
 
         return [
             link.data_source_last_updated for link in datasets.first().visualisationlink_set.all()

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -199,8 +199,6 @@ def find_datasets(request):
         "data_type"
     ].choices  # Cache these now, as we annotate them with result numbers later which we don't want here.
 
-    tags_dict = _get_tags_as_dict()
-
     filters = form.get_filters()
 
     all_visible_datasets, matched_datasets = search_for_datasets(
@@ -219,6 +217,7 @@ def find_datasets(request):
 
     datasets = paginator.get_page(request.GET.get("page"))
 
+    tags_dict = _get_tags_as_dict()
     for dataset in datasets:
         dataset["sources"] = [
             tags_dict.get(str(source_id)) for source_id in dataset["source_tag_ids"]

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -290,13 +290,17 @@ def find_datasets(request):
             default=None,
         )
 
-    for dataset in datasets_by_type[DataSetType.VISUALISATION.value]:
+    visualisation_datasets = VisualisationCatalogueItem.objects.filter(
+        id__in=tuple(
+            dataset["id"] for dataset in datasets_by_type[DataSetType.VISUALISATION.value]
+        )
+    )
+    for visualisation_dataset in visualisation_datasets:
+        dataset = datasets_by_type_id[(DataSetType.VISUALISATION.value, visualisation_dataset.id)]
         dataset["last_updated"] = max(
             (
                 link.data_source_last_updated
-                for link in VisualisationCatalogueItem.objects.get(
-                    id=dataset["id"]
-                ).visualisationlink_set.all()
+                for link in visualisation_dataset.visualisationlink_set.all()
                 if link.data_source_last_updated is not None
             ),
             default=None,

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -42,7 +42,7 @@ def get_columns(database_name, schema=None, table=None, query=None, include_type
             return []
 
 
-def get_tables_last_updated_date(database_name: str, tables: Tuple[Tuple[str, str]]):
+def get_earliest_tables_last_updated_date(database_name: str, tables: Tuple[Tuple[str, str]]):
     """
     Return the earliest of the last updated dates for a list of tables in UTC.
     """

--- a/dataworkspace/dataworkspace/templates/datasets/index.html
+++ b/dataworkspace/dataworkspace/templates/datasets/index.html
@@ -210,7 +210,7 @@
                       N/A
                     {% endfor %}
                   </dd>
-                  {% if dataset.topic_tag_names %}
+                  {% if dataset.topics %}
                     <dt>Topics:</dt>
                     <dd>
                       {% for topic in dataset.topics %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_utils.py
@@ -122,9 +122,9 @@ class TestUpdateQuickSightVisualisationsLastUpdatedDate:
         ).replace(tzinfo=pytz.UTC)
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     def test_direct_query_visualisation_with_relational_table(
-        self, mock_get_tables_last_updated_date
+        self, mock_get_earliest_tables_last_updated_date
     ):
         self.mock_quicksight_client.describe_data_set.return_value = {
             "DataSet": {
@@ -138,12 +138,12 @@ class TestUpdateQuickSightVisualisationsLastUpdatedDate:
                 },
             }
         }
-        mock_get_tables_last_updated_date.return_value = datetime.date(2021, 1, 2)
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.date(2021, 1, 2)
 
         visualisation_link = VisualisationLinkFactory(visualisation_type="QUICKSIGHT")
         process_quicksight_dashboard_visualisations()
 
-        assert mock_get_tables_last_updated_date.call_args_list == [
+        assert mock_get_earliest_tables_last_updated_date.call_args_list == [
             call("my_database", (("public", "bar"),))
         ]
 
@@ -247,9 +247,9 @@ class TestUpdateQuickSightVisualisationsLastUpdatedDate:
         ).replace(tzinfo=pytz.UTC)
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     def test_visualisation_data_set_with_multiple_mappings(
-        self, mock_get_tables_last_updated_date
+        self, mock_get_earliest_tables_last_updated_date
     ):
         self.mock_quicksight_client.describe_data_set.return_value = {
             "DataSet": {
@@ -266,14 +266,14 @@ class TestUpdateQuickSightVisualisationsLastUpdatedDate:
                 },
             }
         }
-        mock_get_tables_last_updated_date.side_effect = [
+        mock_get_earliest_tables_last_updated_date.side_effect = [
             datetime.date(2021, 1, 2),
             datetime.date(2021, 1, 3),
         ]
 
         visualisation_link = VisualisationLinkFactory(visualisation_type="QUICKSIGHT")
         process_quicksight_dashboard_visualisations()
-        assert mock_get_tables_last_updated_date.call_args_list == [
+        assert mock_get_earliest_tables_last_updated_date.call_args_list == [
             call("my_database", (("public", "bar"),)),
             call("my_database", (("public", "baz"),)),
         ]
@@ -304,9 +304,9 @@ class TestUpdateQuickSightVisualisationsRelatedDatasets:
         boto3_patcher.stop()
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     def test_direct_query_visualisation_with_relational_table(
-        self, mock_get_tables_last_updated_date
+        self, mock_get_earliest_tables_last_updated_date
     ):
         self.mock_quicksight_client.describe_data_set.return_value = {
             "DataSet": {
@@ -320,7 +320,7 @@ class TestUpdateQuickSightVisualisationsRelatedDatasets:
                 },
             }
         }
-        mock_get_tables_last_updated_date.return_value = datetime.date(2021, 1, 2)
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.date(2021, 1, 2)
         ds = DataSetFactory.create(type=DataSetType.MASTER)
         SourceTableFactory.create(dataset=ds, schema="public", table="bar")
 
@@ -660,12 +660,12 @@ def get_dsn():
 
 class TestStoreCustomDatasetQueryMetadata:
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_stores_table_structure_first_run_query_updated_after_table(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 14:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.return_value = "abcdefghijklmnopqrstuvwxyz"
@@ -697,12 +697,12 @@ class TestStoreCustomDatasetQueryMetadata:
         )
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_stores_table_structure_first_run_table_updated_after_query(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 16:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.return_value = "abcdefghijklmnopqrstuvwxyz"
@@ -734,12 +734,12 @@ class TestStoreCustomDatasetQueryMetadata:
         )
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_multiple_runs_without_change_doesnt_result_in_new_changelog_records(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 14:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.return_value = "abcdefghijklmnopqrstuvwxyz"
@@ -772,12 +772,12 @@ class TestStoreCustomDatasetQueryMetadata:
         )
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_update_query_where_clause_results_in_data_change_not_structure_change(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 14:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.side_effect = [
@@ -834,12 +834,12 @@ class TestStoreCustomDatasetQueryMetadata:
         )
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_update_query_select_clause_results_in_data_change_and_structure_change(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 14:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.side_effect = [
@@ -896,12 +896,12 @@ class TestStoreCustomDatasetQueryMetadata:
         )
 
     @pytest.mark.django_db
-    @patch("dataworkspace.apps.datasets.utils.get_tables_last_updated_date")
+    @patch("dataworkspace.apps.datasets.utils.get_earliest_tables_last_updated_date")
     @patch("dataworkspace.apps.datasets.utils.get_data_hash")
     def test_update_query_select_clause_and_change_back_results_in_new_changelog_records(
-        self, mock_get_data_hash, mock_get_tables_last_updated_date, test_dataset
+        self, mock_get_data_hash, mock_get_earliest_tables_last_updated_date, test_dataset
     ):
-        mock_get_tables_last_updated_date.return_value = datetime.datetime.strptime(
+        mock_get_earliest_tables_last_updated_date.return_value = datetime.datetime.strptime(
             "2021-01-01 14:00", "%Y-%m-%d %H:%M"
         ).replace(tzinfo=pytz.UTC)
         mock_get_data_hash.side_effect = [

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -236,9 +236,7 @@ def expected_search_result(catalogue_item, **kwargs):
         "search_rank": mock.ANY,
         "short_description": catalogue_item.short_description,
         "published_at": mock.ANY,
-        "source_tag_names": mock.ANY,
         "source_tag_ids": mock.ANY,
-        "topic_tag_names": mock.ANY,
         "topic_tag_ids": mock.ANY,
         "data_type": mock.ANY,
         "published": catalogue_item.published,
@@ -479,13 +477,11 @@ def test_find_datasets_filters_by_source(client):
         expected_search_result(
             ds,
             has_access=False,
-            source_tag_names=MatchUnorderedMembers([source.name, source_2.name]),
             source_tag_ids=MatchUnorderedMembers([source.id, source_2.id]),
         ),
-        expected_search_result(rds, source_tag_names=[source.name], source_tag_ids=[source.id]),
+        expected_search_result(rds, source_tag_ids=[source.id]),
         expected_search_result(
             vis,
-            source_tag_names=[source.name],
             source_tag_ids=[source.id],
             data_type=DataSetType.VISUALISATION,
         ),
@@ -533,19 +529,16 @@ def test_find_datasets_filters_by_topic(client):
         expected_search_result(
             ds,
             has_access=False,
-            topic_tag_names=MatchUnorderedMembers([topic.name, topic_2.name]),
             topic_tag_ids=MatchUnorderedMembers([topic.id, topic_2.id]),
             search_rank=0.0,
         ),
         expected_search_result(
             rds,
-            topic_tag_names=[topic.name],
             topic_tag_ids=[topic.id],
             data_type=DataSetType.REFERENCE,
         ),
         expected_search_result(
             vis,
-            topic_tag_names=[topic.name],
             topic_tag_ids=[topic.id],
             data_type=DataSetType.VISUALISATION,
         ),
@@ -2031,7 +2024,6 @@ def test_find_datasets_search_by_source_name(client):
         expected_search_result(
             ds1,
             search_rank=0.12158542,
-            source_tag_names=[source.name, source_2.name],
             source_tag_ids=MatchUnorderedMembers([source.id, source_2.id]),
             has_access=False,
         ),
@@ -2065,14 +2057,12 @@ def test_find_datasets_search_by_topic_name(client):
         expected_search_result(
             ds1,
             search_rank=0.12158542,
-            topic_tag_names=MatchUnorderedMembers([topic.name, topic_2.name]),
             topic_tag_ids=MatchUnorderedMembers([topic.id, topic_2.id]),
             has_access=False,
         ),
         expected_search_result(
             rds,
             search_rank=0.12158542,
-            topic_tag_names=[topic.name],
             topic_tag_ids=[topic.id],
         ),
     ]
@@ -2121,7 +2111,6 @@ def test_find_datasets_matches_both_source_and_name(client):
     assert list(response.context["datasets"]) == [
         expected_search_result(
             ds1,
-            source_tag_names=MatchUnorderedMembers([source_1.name, source_2.name]),
             source_tag_ids=MatchUnorderedMembers([source_1.id, source_2.id]),
             has_access=False,
         )

--- a/dataworkspace/dataworkspace/tests/test_datasets_db.py
+++ b/dataworkspace/dataworkspace/tests/test_datasets_db.py
@@ -5,7 +5,7 @@ import pytz
 
 from dataworkspace.datasets_db import (
     extract_queried_tables_from_sql_query,
-    get_tables_last_updated_date,
+    get_earliest_tables_last_updated_date,
 )
 
 
@@ -35,13 +35,13 @@ def test_sql_query_tables_extracted_correctly(query, expected_tables):
 
 @pytest.mark.django_db
 def test_get_table_last_updated_date_with_source_data_modified_metadata(metadata_db):
-    assert get_tables_last_updated_date(
+    assert get_earliest_tables_last_updated_date(
         "my_database", (("public", "table2"),)
     ) == datetime.datetime(2020, 9, 1, 0, 1).replace(tzinfo=pytz.UTC)
 
 
 @pytest.mark.django_db
 def test_get_table_last_updated_date_with_dataflow_swapped_table_metadata(metadata_db):
-    assert get_tables_last_updated_date(
+    assert get_earliest_tables_last_updated_date(
         "my_database", (("public", "table4"),)
     ) == datetime.datetime(2021, 12, 1, 0, 0).replace(tzinfo=pytz.UTC)


### PR DESCRIPTION
### Description of change

Most of the request time on the front page appears to be due from having a high number of queries per search result. This PR merges the queries, using prefetch_related, as well as some more "manual" prefetch related techniques. Specifically the number of queries for finding model instances and for finding the last update date should be reduced.

However, for Reference datasets, suspect it might be too tricky to group the queries for last update date, so leaving this for now. Also I've not actually seen the queries for finding the last updated dates for reference datasets in APM for prod, so it might not actually be much of a problem to solve.

### Checklist

* [ ] Have tests been added to cover any changes?
