### PR TITLE
fix: attempt to do gevent monkey patching in Celery worker that doesn't run start.py

### DIFF
--- a/dataworkspace/dataworkspace/cel.py
+++ b/dataworkspace/dataworkspace/cel.py
@@ -1,3 +1,10 @@
+# Monkey-patching should happen as early as possible ...
+# pylint: disable=multiple-statements,wrong-import-position,wrong-import-order
+
+# fmt: off
+from psycogreen.gevent import patch_psycopg; patch_psycopg()  # noqa: E402,E702
+# fmt: on
+
 import logging
 
 from celery import Celery


### PR DESCRIPTION
### Description of change

This is a slightly speculative change since something is causing things to stop in the Celery workers. The change to the download view may just be due to the test environment - it was causing errors in tests:

> execute cannot be used while an asynchronous query is underway

At most as I can tell, it was something to do with the fact that there was a connection to the admin db from inside the manually spawned greenlet that also queries the datsets db. This felt slightly messy anyway, so I think it's a step forward to only query the datasets db from the greenlet, and only query the admin db from inside the request directly.

### Checklist

* [ ] Have tests been added to cover any changes?
