### PR TITLE
feature: add lock to store_custom_dataset_query_metadata celery task

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -9,6 +9,7 @@ import boto3
 import botocore
 import requests
 from django.conf import settings
+from django.core.cache import cache
 from django.db import connections, IntegrityError, transaction
 from django.db.models import Q
 from django.http import Http404
@@ -656,11 +657,20 @@ def update_metadata_with_source_table_id():
 
 
 @celery_app.task()
+@close_all_connections_if_not_in_atomic_block
 def store_custom_dataset_query_metadata():
+    with cache.lock("store_custom_dataset_query_metadata_lock", blocking_timeout=0, timeout=86400):
+        do_store_custom_dataset_query_metadata()
+
+
+def do_store_custom_dataset_query_metadata():
+    statement_timeout = 60
     for query in CustomDatasetQuery.objects.filter(dataset__published=True):
         sql = query.query.rstrip().rstrip(";")
 
-        tables = extract_queried_tables_from_sql_query(query.database.memorable_name, sql)
+        tables = extract_queried_tables_from_sql_query(
+            query.database.memorable_name, sql, statement_timeout=statement_timeout
+        )
         if not tables:
             logger.info(
                 "Not adding metadata for query %s as no tables could be extracted", query.name
@@ -678,6 +688,7 @@ def store_custom_dataset_query_metadata():
             else query_last_updated_date
         )
         with connections[query.database.memorable_name].cursor() as cursor:
+            cursor.execute(f"SET statement_timeout = {statement_timeout}")
             cursor.execute(
                 SQL(
                     "SELECT DISTINCT ON(source_data_modified_utc) "

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -107,9 +107,11 @@ def get_all_tables_last_updated_date(tables: Tuple[Tuple[str, str, str]]):
     }
 
 
-def extract_queried_tables_from_sql_query(database_name, query):
+def extract_queried_tables_from_sql_query(database_name, query, statement_timeout=None):
     # Extract the queried tables from the FROM clause using temporary views
     with connections[database_name].cursor() as cursor:
+        if statement_timeout:
+            cursor.execute(f"SET statement_timeout = {statement_timeout}")
         try:
             with transaction.atomic():
                 cursor.execute(


### PR DESCRIPTION
### Description of change
This is to prevent slow datacut queries causing a backlog of tasks


### Checklist

* [ ] Have tests been added to cover any changes?
