### PR TITLE
Fix: Amend data type map dict to default choice

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/constants.py
+++ b/dataworkspace/dataworkspace/apps/core/constants.py
@@ -12,12 +12,12 @@ class PostgresDataTypes(models.TextChoices):
 
 
 SCHEMA_POSTGRES_DATA_TYPE_MAP = {
-    "Integer": PostgresDataTypes.BIGINT,
-    "Boolean": PostgresDataTypes.BOOLEAN,
-    "Date": PostgresDataTypes.DATE,
-    "Date time": PostgresDataTypes.TIMESTAMP,
-    "Numeric": PostgresDataTypes.NUMERIC,
-    "Text": PostgresDataTypes.TEXT,
+    "integer": PostgresDataTypes.BIGINT,
+    "boolean": PostgresDataTypes.BOOLEAN,
+    "date": PostgresDataTypes.DATE,
+    "datetime": PostgresDataTypes.TIMESTAMP,
+    "numeric": PostgresDataTypes.NUMERIC,
+    "text": PostgresDataTypes.TEXT,
     "UUID": PostgresDataTypes.UUID,
 }
 TABLESCHEMA_FIELD_TYPE_MAP = {

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -118,7 +118,9 @@ class CreateTableDataTypesForm(CreateTableForm):
             self.fields[col_def["column_name"]] = GOVUKDesignSystemChoiceField(
                 label=col_def["column_name"],
                 initial=col_def["data_type"],
-                choices=((name, name.capitalize()) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()),
+                choices=(
+                    (name, name.capitalize()) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()
+                ),
                 widget=GOVUKDesignSystemSelectWidget(
                     label_is_heading=False,
                     extra_label_classes="govuk-visually-hidden",

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -118,7 +118,7 @@ class CreateTableDataTypesForm(CreateTableForm):
             self.fields[col_def["column_name"]] = GOVUKDesignSystemChoiceField(
                 label=col_def["column_name"],
                 initial=col_def["data_type"],
-                choices=((name, name) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()),
+                choices=((name, name.capitalize()) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()),
                 widget=GOVUKDesignSystemSelectWidget(
                     label_is_heading=False,
                     extra_label_classes="govuk-visually-hidden",

--- a/dataworkspace/dataworkspace/tests/your_files/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_utils.py
@@ -41,7 +41,7 @@ def test_s3_csv_column_types(mock_client, csv_content):
         {
             "header_name": "col2",
             "column_name": "col2",
-            "data_type": PostgresDataTypes.TEXT,
+            "data_type": PostgresDataTypes.BIGINT,
             "sample_data": ["1", "2"],
         },
     ]

--- a/dataworkspace/dataworkspace/tests/your_files/test_views.py
+++ b/dataworkspace/dataworkspace/tests/your_files/test_views.py
@@ -106,7 +106,7 @@ class TestCreateTableViews:
                     "path": "user/federated/abc/a-csv.csv",
                     "table_name": "test_table",
                     "schema": "test_schema",
-                    "field1": "Integer",
+                    "field1": "integer",
                 },
                 follow=True,
             )
@@ -158,7 +158,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "test_schema",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )
@@ -214,7 +214,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "test_schema",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )
@@ -255,7 +255,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "test_schema",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )
@@ -295,7 +295,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "test_schema",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )
@@ -337,7 +337,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "new",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
         )
         assert response.status_code == 302
@@ -465,7 +465,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "test_team_schema",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )
@@ -539,7 +539,7 @@ class TestCreateTableViews:
                 "path": "user/federated/abc/a-csv.csv",
                 "schema": "public",
                 "table_name": "a_csv",
-                "field1": "Integer",
+                "field1": "integer",
             },
             follow=True,
         )


### PR DESCRIPTION
### Description of change
Amend data type map dict to be lower case as this broke the data types defaulting

### Checklist

* [ ] Have tests been added to cover any changes?
