### PR TITLE
fix: make search results order by relevance again

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -26,13 +26,13 @@ from dataworkspace.apps.datasets.utils import (
 )
 
 SORT_CHOICES = [
-    ("-published_date,name", "Date published: newest"),
-    ("published_date,name", "Date published: oldest"),
-    ("-search_rank,name", "Relevance"),
+    ("-search_rank,-published_date,name", "Relevance"),
+    ("-published_date,-search_rank,name", "Date published: newest"),
+    ("published_date,-search_rank,name", "Date published: oldest"),
     ("name", "Alphabetical (A-Z)"),
 ]
 
-DEFAULT_SORT, _ = SORT_CHOICES[0]
+DEFAULT_SORT = SORT_CHOICES[0][0]
 
 
 class SearchDatasetsFilters:

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -587,7 +587,9 @@ def test_find_datasets_order_by_newest_first(client):
     ads2 = factories.DataSetFactory.create(published_at=date.today() - timedelta(days=3))
     ads3 = factories.DataSetFactory.create(published_at=date.today() - timedelta(days=4))
 
-    response = client.get(reverse("datasets:find_datasets"), {"sort": "-published_date,name"})
+    response = client.get(
+        reverse("datasets:find_datasets"), {"sort": "-published_date,-search_rank,name"}
+    )
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [
@@ -602,7 +604,9 @@ def test_find_datasets_order_by_oldest_first(client):
     ads2 = factories.DataSetFactory.create(published_at=date.today() - timedelta(days=2))
     ads3 = factories.DataSetFactory.create(published_at=date.today() - timedelta(days=3))
 
-    response = client.get(reverse("datasets:find_datasets"), {"sort": "published_date,name"})
+    response = client.get(
+        reverse("datasets:find_datasets"), {"sort": "published_date,-search_rank,name"}
+    )
 
     assert response.status_code == 200
     assert list(response.context["datasets"]) == [


### PR DESCRIPTION
### Description of change
Adjust sort orders available from the dropdown on catalogue index page so that Search relevance is first priority regardless of whether a search term has been provided

### Checklist

~* [ ] Have tests been added to cover any changes?~
