### PR TITLE
fix: make use of pglast for extracting tables from queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -580,9 +580,7 @@ class CustomDatasetQueryInlineForm(forms.ModelForm):
 
         instance = super().save(commit)
 
-        tables = extract_queried_tables_from_sql_query(
-            instance.database.memorable_name, instance.query
-        )
+        tables = extract_queried_tables_from_sql_query(instance.query)
 
         # Save the extracted tables in a seperate model for later user
         instance.tables.all().delete()

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -113,10 +113,12 @@ class CustomRelationNames(Visitor):
     for a query
     """
 
-    cte_names = set()
-    relation_names = set()
+    cte_names: set
+    relation_names: set
 
     def __call__(self, node):
+        self.cte_names = set()
+        self.relation_names = set()
         super().__call__(node)
         relations = self.relation_names - self.cte_names
         return sorted(

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2746,7 +2746,7 @@ class TestDatasetAdminPytest:
                 ["public.auth_user"],
             ),
             ("SELECT 1", []),
-            ("SELECT * FROM test", []),
+            ("SELECT * FROM test", ["public.test"]),
             ("SELECT * FROM", []),
         ),
     )

--- a/dataworkspace/dataworkspace/tests/test_datasets_db.py
+++ b/dataworkspace/dataworkspace/tests/test_datasets_db.py
@@ -23,13 +23,17 @@ from dataworkspace.datasets_db import (
             [("public", "auth_user")],
         ),
         ("SELECT 1", []),
-        ("SELECT * FROM test", []),
+        ("SELECT * FROM test", [("public", "test")]),
         ("SELECT * FROM", []),
+        (
+            'SELECT * FROM "schema.with.dots"."table.with.dots"',
+            [("schema.with.dots", "table.with.dots")],
+        ),
     ),
 )
 @pytest.mark.django_db
 def test_sql_query_tables_extracted_correctly(query, expected_tables):
-    tables = extract_queried_tables_from_sql_query("test_external_db", query)
+    tables = extract_queried_tables_from_sql_query(query)
     assert tables == expected_tables
 
 


### PR DESCRIPTION
### Description of change

Use `pglast` to extract schema/table information from queries. This removes the need for creating views to get the same information which has a knock on effect on data flow.

### Checklist

* [x] Have tests been added to cover any changes?
