### PR TITLE
feat: avoid touching the database when extracting database tables

### DIFF
--- a/dataworkspace/dataworkspace/apps/dw_admin/forms.py
+++ b/dataworkspace/dataworkspace/apps/dw_admin/forms.py
@@ -580,9 +580,7 @@ class CustomDatasetQueryInlineForm(forms.ModelForm):
 
         instance = super().save(commit)
 
-        tables = extract_queried_tables_from_sql_query(
-            instance.database.memorable_name, instance.query
-        )
+        tables = extract_queried_tables_from_sql_query(instance.query)
 
         # Save the extracted tables in a seperate model for later user
         instance.tables.all().delete()

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -2746,7 +2746,7 @@ class TestDatasetAdminPytest:
                 ["public.auth_user"],
             ),
             ("SELECT 1", []),
-            ("SELECT * FROM test", []),
+            ("SELECT * FROM test", ["public.test"]),
             ("SELECT * FROM", []),
         ),
     )


### PR DESCRIPTION
### Description of change

The previous version caused issues with dataflow in terms of not having permission to drop the temporary views, as well as some cases of the views hanging around even though they are temporary

### Checklist

* [ ] Have tests been added to cover any changes?
