### PR TITLE
feat: remove tools access requirement for gitlab and your files

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils_tools.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils_tools.py
@@ -114,7 +114,7 @@ def get_groups(request):
                     "JupyterLab, RStudio, and Theia. You can use 'Your files' to upload files "
                     "to this folder, and download files from this folder.",
                     link=reverse("your-files:files"),
-                    has_access=request.user.has_perm("applications.start_all_applications"),
+                    has_access=True,
                     help_link=None,
                 ),
                 ToolsViewModel(
@@ -123,7 +123,7 @@ def get_groups(request):
                     summary="Collaborate on and store analysis, projects and "
                     "code with your colleagues",
                     link=settings.GITLAB_URL_FOR_TOOLS,
-                    has_access=request.user.has_perm("applications.start_all_applications"),
+                    has_access=True,
                 ),
             ],
             "group_description": "upload data and share data",

--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -24,7 +24,8 @@
       <h1 class="govuk-heading-xl">Tools</h1>
     </div>
   </div>
-  {% if not perms.applications.start_all_applications %}
+  {# removed until new designs are ready for tools access warning message  #}
+  <!-- {% if not perms.applications.start_all_applications %}
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
       <div class="govuk-grid-column-two-thirds">
         <div class="govuk-warning-text">
@@ -39,7 +40,7 @@
         <a class="govuk-button govuk-button--primary" href="{% url 'request_access:index' %}">Request access</a>
       </div>
     </div>
-  {% endif %}
+  {% endif %} -->
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <p class="govuk-body govuk-!-margin-bottom-8">

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -289,17 +289,6 @@ def test_footer_links(request_client):
 
 
 @pytest.mark.parametrize(
-    "has_tools_access, expected_href, expected_text",
-    (
-        (False, "/request-access/", "Request access to GitLab"),
-        (
-            True,
-            "https://gitlab",
-            "Open GitLab",
-        ),
-    ),
-)
-@pytest.mark.parametrize(
     "has_quicksight_access, expected_href, expected_text",
     (
         (True, "/tools/quicksight/redirect", "Open QuickSight"),

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -299,23 +299,6 @@ def test_footer_links(request_client):
         ),
     ),
 )
-# @override_settings(GITLAB_URL_FOR_TOOLS="https://gitlab")
-# @pytest.mark.django_db
-# def test_gitlab_access(has_tools_access, expected_href, expected_text):
-#     user = UserFactory.create(is_staff=False, is_superuser=False)
-#     if has_tools_access:
-#         perm = Permission.objects.get(codename="start_all_applications")
-#         user.user_permissions.add(perm)
-#         user.save()
-
-#     client = Client(**get_http_sso_data(user))
-#     response = client.get(reverse("applications:tools"))
-
-#     soup = BeautifulSoup(response.content.decode(response.charset))
-#     gitlab_link = soup.find("a", href=True, text=expected_text)
-#     assert gitlab_link.get("href") == expected_href
-
-
 @pytest.mark.parametrize(
     "has_quicksight_access, expected_href, expected_text",
     (

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -299,21 +299,21 @@ def test_footer_links(request_client):
         ),
     ),
 )
-@override_settings(GITLAB_URL_FOR_TOOLS="https://gitlab")
-@pytest.mark.django_db
-def test_gitlab_access(has_tools_access, expected_href, expected_text):
-    user = UserFactory.create(is_staff=False, is_superuser=False)
-    if has_tools_access:
-        perm = Permission.objects.get(codename="start_all_applications")
-        user.user_permissions.add(perm)
-        user.save()
+# @override_settings(GITLAB_URL_FOR_TOOLS="https://gitlab")
+# @pytest.mark.django_db
+# def test_gitlab_access(has_tools_access, expected_href, expected_text):
+#     user = UserFactory.create(is_staff=False, is_superuser=False)
+#     if has_tools_access:
+#         perm = Permission.objects.get(codename="start_all_applications")
+#         user.user_permissions.add(perm)
+#         user.save()
 
-    client = Client(**get_http_sso_data(user))
-    response = client.get(reverse("applications:tools"))
+#     client = Client(**get_http_sso_data(user))
+#     response = client.get(reverse("applications:tools"))
 
-    soup = BeautifulSoup(response.content.decode(response.charset))
-    gitlab_link = soup.find("a", href=True, text=expected_text)
-    assert gitlab_link.get("href") == expected_href
+#     soup = BeautifulSoup(response.content.decode(response.charset))
+#     gitlab_link = soup.find("a", href=True, text=expected_text)
+#     assert gitlab_link.get("href") == expected_href
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of change

- With the new tools access policy, users no longer need to complete any mandatory training in order to access Gitlab and Your Files on Data Workspace
- Update to ```utils_tools.py``` to enable this change
- Temporary removal of tools access warning sign on the tools page in ```tools.html```. This will be reinstated and updated once the appropriate designs are available.


### Checklist

* [X] Have tests been added to cover any changes?
