### PR TITLE
feat: search by popularity as flag rather than switch

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -196,7 +196,7 @@ def find_datasets(request):
     ###############
     # Validate form
 
-    form = DatasetSearchForm(request.GET)
+    form = DatasetSearchForm(request, request.GET)
 
     if not form.is_valid():
         logger.warning(form.errors)


### PR DESCRIPTION
### Description of change

Converting the search by popularity to a flag to allow specific users (such as member of the Data Infrastructure team) to test it in production before we roll it out to all users.

Also, putting it at the bottom of the list, so default behaviour is as it is for all users.

### Checklist

* [ ] Have tests been added to cover any changes?
