### PR TITLE
fix: statment timeout is too small by a factor of 1000

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -660,7 +660,7 @@ def store_custom_dataset_query_metadata():
 
 
 def do_store_custom_dataset_query_metadata():
-    statement_timeout = 60
+    statement_timeout = 60 * 1000
     for query in CustomDatasetQuery.objects.filter(dataset__published=True):
         sql = query.query.rstrip().rstrip(";")
 


### PR DESCRIPTION
### Description of change

We wanted it as 60 seconds, not 60 milliseconds - many datacut metadata queries are failing.

### Checklist

* [ ] Have tests been added to cover any changes?
