### PR TITLE
fix: recursive CTEs were being mis-identified as in the public schema

### DIFF
--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -113,7 +113,13 @@ def extract_queried_tables_from_sql_query(query):
     This does not communicate with a database, and instead uses pglast to parse the
     query. However, it does not use pglast's built-in functions to extract tables -
     they're buggy in the cases where CTEs have the same names as tables in the
-    default/public schema.
+    search path.
+
+    This isn't perfect though - it assumes tables without a schema are in the "public"
+    schema, but "public" might not be in the search path, or it might not be the only
+    schema in the search path. However, it's probably fine for our usage where "public"
+    _is_ in the search path, and the only tables without a schema that we care about in
+    our queries are indeed in the public schema - typically only reference dataset tables.
     """
 
     def _get_tables(node, ctenames=()):

--- a/dataworkspace/dataworkspace/datasets_db.py
+++ b/dataworkspace/dataworkspace/datasets_db.py
@@ -126,9 +126,14 @@ def extract_queried_tables_from_sql_query(query):
         tables = set()
 
         if node.get("withClause", None) is not None:
-            for cte in node["withClause"]["ctes"]:
-                tables = tables.union(_get_tables(cte, ctenames))
-                ctenames += (cte["ctename"],)
+            if node["withClause"]["recursive"]:
+                for cte in node["withClause"]["ctes"]:
+                    ctenames += (cte["ctename"],)
+                    tables = tables.union(_get_tables(cte, ctenames))
+            else:
+                for cte in node["withClause"]["ctes"]:
+                    tables = tables.union(_get_tables(cte, ctenames))
+                    ctenames += (cte["ctename"],)
 
         if node.get("@", None) == "RangeVar" and (
             node["schemaname"] is not None or node["relname"] not in ctenames

--- a/dataworkspace/dataworkspace/tests/test_datasets_db.py
+++ b/dataworkspace/dataworkspace/tests/test_datasets_db.py
@@ -86,6 +86,17 @@ from dataworkspace.datasets_db import (
             """,
             [("public", "my_inner_1"), ("public", "my_inner_2")],
         ),
+        (
+            """
+                WITH RECURSIVE t(n) AS (
+                    VALUES (1)
+                  UNION ALL
+                    SELECT n+1 FROM t INNER JOIN a ON 1=1 WHERE n < 100
+                )
+                SELECT sum(n) FROM t;
+            """,
+            [("public", "a")],
+        ),
     ),
 )
 def test_sql_query_tables_extracted_correctly(query, expected_tables):


### PR DESCRIPTION
### Description of change

It's rare for us to use recursive CTEs, but they can be used in Tariff data, which is complicated enough, so avoiding that bug before it hits.

### Checklist

* [ ] Have tests been added to cover any changes?
