### PR TITLE
fix: ensure boolean values are actually filtered

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -449,7 +449,7 @@ def build_filtered_dataset_query(inner_query, column_config, params):
                 terms[0] = bool(int(terms[0]))
 
             # Arrays are a special case
-            elif data_type == "array":
+            if data_type == "array":
                 if filter_data["type"] == "contains":
                     query_params[field] = terms[0]
                     where_clause.append(


### PR DESCRIPTION
### Description of change

Ensure bool searches are actually filtered by the "equals" operator

### Checklist

* [ ] Have tests been added to cover any changes?
