### PR TITLE
feat: calculate visualisation popularity via the event log

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -460,10 +460,10 @@ def _get_popularity_calculation_period(dataset):
     Returns the start and end datetimes for a valid period to calculate dataset usage on.
     The calculation period is:
 
-    From: Midnight 28 days should before the calculation is done
+    From: Midnight 28 days before the calculation is done
     To: Midnight of the day the calculation is done
 
-    If the dataset was published less than 28 days ago start the period at midnight the day
+    If the dataset was published less than 28 days ago, start the period at midnight the day
     after it was published.
     """
     # The farthest we go back is 00:00 28 days ago

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -473,7 +473,7 @@ def _get_popularity_calculation_period(dataset):
     # If the vis was published < 28 days ago, start the count
     # from the end of the day it was first published
     published_date = datetime.combine(dataset.published_at, time.max)
-    period_start = published_date if published_date > min_start_date else min_start_date
+    period_start = max(min_start_date, published_date)
 
     return period_start, period_end
 

--- a/dataworkspace/dataworkspace/tests/datasets/test_search.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_search.py
@@ -1,0 +1,104 @@
+from datetime import datetime, timedelta
+
+import pytest
+from freezegun import freeze_time
+
+from dataworkspace.apps.datasets.search import calculate_visualisation_average
+from dataworkspace.apps.eventlog.models import EventLog
+from dataworkspace.tests import factories
+
+
+@pytest.mark.django_db
+def test_update_visualisation_averages(user):
+    # Events over 28 days old should be ignored
+    vis = factories.VisualisationCatalogueItemFactory.create(
+        published_at=datetime.now() - timedelta(days=30)
+    )
+    with freeze_time(datetime.now() - timedelta(days=29)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
+            related_object=vis,
+        )
+    assert calculate_visualisation_average(vis) == 0
+
+    # Events that happened today should be ignored
+    vis = factories.VisualisationCatalogueItemFactory.create(
+        published_at=datetime.now() - timedelta(days=30)
+    )
+    factories.EventLogFactory(
+        event_type=EventLog.TYPE_VIEW_QUICKSIGHT_VISUALISATION,
+        timestamp=datetime.now(),
+        related_object=vis,
+    )
+    assert calculate_visualisation_average(vis) == 0
+
+    # Events published within the last 28 days should be included
+    # in the calculation
+    vis = factories.VisualisationCatalogueItemFactory.create(
+        published_at=datetime.now() - timedelta(days=30)
+    )
+    with freeze_time(datetime.now() - timedelta(days=28)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    with freeze_time(datetime.now() - timedelta(days=1)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    assert calculate_visualisation_average(vis) == 0.07142857142857142
+
+    # A "view" event should only count once per user per day
+    vis = factories.VisualisationCatalogueItemFactory.create(
+        published_at=datetime.now() - timedelta(days=30)
+    )
+    with freeze_time(datetime.now() - timedelta(days=10)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+            user=user,
+        )
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+            user=user,
+        )
+    with freeze_time(datetime.now() - timedelta(days=9)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+            user=user,
+        )
+    with freeze_time(datetime.now() - timedelta(days=8)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    assert calculate_visualisation_average(vis) == 0.10714285714285714
+
+    # If vis is published less than 28 days ago calculations should start
+    # from midnight the day after the day it was published
+    vis = factories.VisualisationCatalogueItemFactory.create(
+        published_at=datetime.now() - timedelta(days=10)
+    )
+    with freeze_time(datetime.now() - timedelta(days=11)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    with freeze_time(datetime.now() - timedelta(days=10)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    with freeze_time(datetime.now() - timedelta(days=9)):
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+        factories.EventLogFactory(
+            event_type=EventLog.TYPE_VIEW_SUPERSET_VISUALISATION,
+            related_object=vis,
+        )
+    assert calculate_visualisation_average(vis) == 0.2222222222222222


### PR DESCRIPTION
### Description of change

Calculate visualisation catalogue item popularity...

- Popularity is average number of unique users per day in the past 28 days
- The past 28 days should be the midnight before the calculation is done, to the midnight 28 days before that
- For newly published datasets include only whole days they have been published in the calculation.
- Each user can be counted as a "viewer" of a given dataset at most once per day


### Checklist

* [x] Have tests been added to cover any changes?
