### PR TITLE
feat: stronger normalisation and no cover density in dataset title search rank

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -88,8 +88,7 @@ def _get_datasets_data_for_user_matching_query(
         search_rank_name=SearchRank(
             F("search_vector_english_name"),
             SearchQuery(query, config="english"),
-            cover_density=True,
-            normalization=Value(1),
+            normalization=Value(2),
         ),
         search_rank_short_description=SearchRank(
             F("search_vector_english_short_description"),


### PR DESCRIPTION
### Description of change

When searching for "companies in the uk", the dataset "Companies in the UK" was ar below other result. Specifically, below those of the form "UK Companies xxx xxxx xxxx". Suspect this is due to

- The fact that cover density strongly prioritises results with the words "UK" and "Companies" close together.

- The fact that normalization=1, dividing the search rank by log of the document length, doesn't penalise longer titles enough.

So trying out turning off cover density matching for the name, and setting normalization=2, dividing the search rank by the document length.

Can't be completely sure how much this helps before it hits production data, but it's behind a feature flag.

### Checklist

* [ ] Have tests been added to cover any changes?
