### PR TITLE
fix: grid row values can be null or undefined

### DIFF
--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -203,8 +203,8 @@ function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, expo
     columnDefs: columnConfig,
     components: {
       loadingRenderer: function (params) {
-        if (params.value !== undefined) {
-          return params.valueFormatted !== undefined ? params.valueFormatted : params.value;
+        if (params.value != null) {
+          return params.valueFormatted != null ? params.valueFormatted : params.value;
         }
         return '<img src="/__django_static/assets/images/loading.gif">';
       },


### PR DESCRIPTION
### Description of change

check if a value is null OR undefined when displaying cells in the grid

### Checklist

* [ ] Have tests been added to cover any changes?
