### PR TITLE
fix: relevance should be default search

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -42,18 +42,6 @@ logger = logging.getLogger("app")
 
 
 SORT_FIELD_MAP = {
-    "-published": {
-        "display_name": "Date published: newest",
-        "fields": ("-published_date", "-search_rank", "name"),
-    },
-    "published": {
-        "display_name": "Date published: oldest",
-        "fields": ("published_date", "-search_rank", "name"),
-    },
-    "alphabetical": {
-        "display_name": "Alphabetical (A-Z)",
-        "fields": ("name",),
-    },
     "relevance": {
         "display_name": "Relevance",
         "fields": (
@@ -68,11 +56,25 @@ SORT_FIELD_MAP = {
             "name",
         ),
     },
+    "-published": {
+        "display_name": "Date published: newest",
+        "fields": ("-published_date", "-search_rank", "name"),
+    },
+    "published": {
+        "display_name": "Date published: oldest",
+        "fields": ("published_date", "-search_rank", "name"),
+    },
+    "alphabetical": {
+        "display_name": "Alphabetical (A-Z)",
+        "fields": ("name",),
+    },
     "popularity": {
         "display_name": "Popularity",
         "fields": ("-average_unique_users_daily", "-published_date", "name"),
     },
 }
+DEFAULT_SORT = "relevance"
+
 # Legacy fields to be deleted
 LEGACY_SORT_FIELD_MAP = {",".join(v["fields"]): k for k, v in SORT_FIELD_MAP.items()}
 

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -73,7 +73,6 @@ SORT_FIELD_MAP = {
         "fields": ("-average_unique_users_daily", "-published_date", "name"),
     },
 }
-DEFAULT_SORT = "relevance"
 
 # Legacy fields to be deleted
 LEGACY_SORT_FIELD_MAP = {",".join(v["fields"]): k for k, v in SORT_FIELD_MAP.items()}


### PR DESCRIPTION
### Description of change

Reorder sort mapping to make relevance first. This is the only way to select a default choice in a django sort field.  

### Checklist

* [ ] Have tests been added to cover any changes?
