### PR TITLE
fix: workaround ref datasets missing publish date

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -589,7 +589,11 @@ def _get_popularity_calculation_period(dataset):
 
     # If the vis was published < 28 days ago, start the count
     # from the end of the day it was first published
-    published_date = datetime.combine(dataset.published_at, time.max)
+    published_date = (
+        datetime.combine(dataset.published_at, time.max)
+        if dataset.published_at is not None
+        else min_start_date
+    )
     period_start = max(min_start_date, published_date)
 
     return period_start, period_end


### PR DESCRIPTION
### Description of change

We have some reference datasets that are published but don't have `published_at` set. If this is the case set the lookback to 28 days when calculating averages

### Checklist

* [ ] Have tests been added to cover any changes?
