### PR TITLE
feat: add api endpoints for dictionary_published field reporting

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -47,6 +47,7 @@ class CatalogueItemSerializer(serializers.Serializer):
     source_tables = serializers.SerializerMethodField()
     slug = serializers.CharField()
     is_draft = serializers.BooleanField(source="draft")
+    dictionary_published = serializers.BooleanField(source="dictionary")
 
     def to_representation(self, instance):
         instance = super().to_representation(instance)

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -324,6 +324,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "purpose",
         "source_tags",
         "draft",
+        "dictionary",
         "personal_data",
         "retention_policy",
         "eligibility_criteria",
@@ -339,6 +340,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             )
         )
         .annotate(draft=_static_bool(None))
+        .annotate(dictionary=F("dictionary_published"))
         .values(*fields)
         .union(
             ReferenceDataset.objects.live()
@@ -354,6 +356,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                 )
             )
             .annotate(draft=F("is_draft"))
+            .annotate(dictionary=_static_bool(None))
             .values(*_replace(fields, "id", "uuid"))
         )
         .union(
@@ -367,6 +370,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                 )
             )
             .annotate(draft=_static_bool(None))
+            .annotate(dictionary=_static_bool(None))
             .values(*fields)
         )
     ).order_by("created_date")

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -451,6 +451,9 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             if dataset.enquiries_contact
             else None,
             "is_draft": dataset.is_draft if dataset.type == DataSetType.REFERENCE else None,
+            "dictionary_published": dataset.dictionary_published
+            if dataset.type == DataSetType.MASTER
+            else None,
             "licence": dataset.licence or None,
             "purpose": purpose,
             "source_tags": [t.name for t in dataset.tags.all()] if dataset.tags.all() else None,

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -485,7 +485,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             information_asset_manager=factories.UserFactory(),
             personal_data="personal",
             retention_policy="retention",
-            dictionary_publihsed="dictionary",
+            dictionary_published="dictionary",
         )
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -485,7 +485,6 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             information_asset_manager=factories.UserFactory(),
             personal_data="personal",
             retention_policy="retention",
-            dictionary_published=True
         )
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
@@ -514,7 +513,6 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
                 "Master dataset",
                 master_dataset.personal_data,
                 master_dataset.retention_policy,
-                master_dataset.dictionary_published,
             ),
             self.expected_response(
                 reference_dataset,

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -451,9 +451,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             if dataset.enquiries_contact
             else None,
             "is_draft": dataset.is_draft if dataset.type == DataSetType.REFERENCE else None,
-            "dictionary_published": dataset.dictionary_published
-            if dataset.type == DataSetType.MASTER
-            else None,
+            "dictionary_published": getattr(dataset, "dictionary_published", None),
             "licence": dataset.licence or None,
             "purpose": purpose,
             "source_tags": [t.name for t in dataset.tags.all()] if dataset.tags.all() else None,
@@ -485,6 +483,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             information_asset_manager=factories.UserFactory(),
             personal_data="personal",
             retention_policy="retention",
+            dictionary_published=True,
         )
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -485,7 +485,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             information_asset_manager=factories.UserFactory(),
             personal_data="personal",
             retention_policy="retention",
-            dictionary_published="dictionary",
+            dictionary_published=True
         )
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -485,6 +485,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             information_asset_manager=factories.UserFactory(),
             personal_data="personal",
             retention_policy="retention",
+            dictionary_publihsed="dictionary",
         )
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
         factories.SourceTableFactory(dataset=master_dataset, schema="public", table="test_table1")
@@ -513,6 +514,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
                 "Master dataset",
                 master_dataset.personal_data,
                 master_dataset.retention_policy,
+                master_dataset.dictionary_published,
             ),
             self.expected_response(
                 reference_dataset,


### PR DESCRIPTION
### Description of change

- Edit API endpoint that lists catalogue items for consumption by data flow to include ```dictionary_published```

### Checklist

* [X] Have tests been added to cover any changes?
