### PR TITLE
feat: design changes to the data catalogue

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import operator
-import hashlib
 import os
 from functools import reduce
 from uuid import UUID
@@ -18,7 +17,10 @@ from django.http import Http404
 from django.urls import reverse
 from psycopg2.sql import Identifier, Literal, SQL
 
-from dataworkspace.apps.core.utils import close_all_connections_if_not_in_atomic_block
+from dataworkspace.apps.core.utils import (
+    close_all_connections_if_not_in_atomic_block,
+    stable_identification_suffix,
+)
 from dataworkspace.apps.core.errors import DatasetUnpublishedError
 from dataworkspace.apps.datasets.models import (
     CustomDatasetQuery,
@@ -87,25 +89,22 @@ def dataset_type_to_manage_unpublished_permission_codename(dataset_type: int):
     }[dataset_type]
 
 
-# Todo: use the version of this function in core.utils.py and fix circular reference issues.
-def _stable_identification_suffix(identifier, short):
-    digest = hashlib.sha256(identifier.encode("utf-8")).hexdigest()
-    if short:
-        return digest[:8]
-    return digest
+def get_tools_links_for_user(user, scheme="https"):
+    sso_id_hex_short = stable_identification_suffix(str(user.profile.sso_id), short=True)
+    return {
+        "jupyterlab_link": f"{scheme}://jupyterlab-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
+        "rstudio_link": f"{scheme}://rstudio-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
+    }
 
 
-def get_code_snippets_for_table(request, source_table):
+def get_code_snippets_for_table(source_table):
     if not hasattr(source_table, "schema") or not hasattr(source_table, "table"):
         return {"python": "", "r": "", "sql": ""}
     query = get_sql_snippet(source_table.schema, source_table.table, 50)
-    sso_id_hex_short = _stable_identification_suffix(str(request.user.profile.sso_id), short=True)
     return {
         "python": get_python_snippet(query),
         "r": get_r_snippet(query),
         "sql": query,
-        "jupyterlab_link": f"{request.scheme}://jupyterlabpython-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
-        "rstudio_link": f"{request.scheme}://rstudio-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
     }
 
 
@@ -119,13 +118,10 @@ def get_code_snippets_for_reference_table(table):
 
 
 def get_code_snippets_for_query(request, query):
-    sso_id_hex_short = _stable_identification_suffix(str(request.user.profile.sso_id), short=True)
     return {
         "python": get_python_snippet(query),
         "r": get_r_snippet(query),
         "sql": query,
-        "jupyterlab_link": f"{request.scheme}://jupyterlab-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
-        "rstudio_link": f"{request.scheme}://rstudio-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
     }
 
 

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -86,12 +86,14 @@ def dataset_type_to_manage_unpublished_permission_codename(dataset_type: int):
         DataSetType.VISUALISATION: "datasets.manage_unpublished_visualisations",
     }[dataset_type]
 
-#Todo: use the version of this function in core.utils.py and fix circular reference issues.
+
+# Todo: use the version of this function in core.utils.py and fix circular reference issues.
 def _stable_identification_suffix(identifier, short):
     digest = hashlib.sha256(identifier.encode("utf-8")).hexdigest()
     if short:
         return digest[:8]
     return digest
+
 
 def get_code_snippets_for_table(request, source_table):
     if not hasattr(source_table, "schema") or not hasattr(source_table, "table"):
@@ -102,7 +104,7 @@ def get_code_snippets_for_table(request, source_table):
         "python": get_python_snippet(query),
         "r": get_r_snippet(query),
         "sql": query,
-        "jupyterlab_link": f"{request.scheme}://jupyterlabpython-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/", 
+        "jupyterlab_link": f"{request.scheme}://jupyterlabpython-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
         "rstudio_link": f"{request.scheme}://rstudio-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
     }
 
@@ -122,7 +124,7 @@ def get_code_snippets_for_query(request, query):
         "python": get_python_snippet(query),
         "r": get_r_snippet(query),
         "sql": query,
-        "jupyterlab_link": f"{request.scheme}://jupyterlab-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/", 
+        "jupyterlab_link": f"{request.scheme}://jupyterlab-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
         "rstudio_link": f"{request.scheme}://rstudio-{sso_id_hex_short}.{settings.APPLICATION_ROOT_DOMAIN}/",
     }
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -409,7 +409,7 @@ class DatasetDetailView(DetailView):
         master_datasets_info = [
             MasterDatasetInfo(
                 source_table=source_table,
-                code_snippets=get_code_snippets_for_table(source_table),
+                code_snippets=get_code_snippets_for_table(self.request, source_table),
                 columns=datasets_db.get_columns(
                     source_table.database.memorable_name,
                     schema=source_table.schema,
@@ -472,7 +472,7 @@ class DatasetDetailView(DetailView):
                 datacut_link=datacut_link,
                 can_show_link=datacut_link.can_show_link_for_user(self.request.user),
                 code_snippets=(
-                    get_code_snippets_for_query(datacut_link.query)
+                    get_code_snippets_for_query(self.request, datacut_link.query)
                     if hasattr(datacut_link, "query")
                     else None
                 ),

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -180,7 +180,7 @@
         </thead>
         <tbody>
 
-        {% for datacut_link, can_show_link, code_snippets, columns in datacut_links_info %}
+        {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
               {{ datacut_link.name }}
@@ -242,7 +242,7 @@
                                   </span>
                       </summary>
                       <div class="govuk-details__text">
-                        {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=datacut_link %}
+                        {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=datacut_link tools_links=tools_links %}
 
                       </div>
                     </details>

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -134,8 +134,8 @@
           {% endif %}
           <p class="govuk-body">
             <small>If you'd like to create a dashboard using this data then you can see                   
-            <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
-            class="govuk-link govuk-link--no-visited-state">
+            <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/" 
+            class="govuk-link govuk-link--no-visited-state" target="_blank">
             how to create a dashboard with Quicksight.</a></small>
           </p>
           {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -90,9 +90,10 @@
       {% endif %}
 
       {% if related_data or related_visualisations %}
-        <aside class="app-related-items" role="complementary">
+      <aside class="app-related-items" role="complementary">
+        <p class="govuk-body sidebar-section">
           {% if related_data %}
-            <h3 class="govuk-heading-s">Source datasets</h3>
+            <h3 class="govuk-heading-s govuk-!-margin-top-2">Source datasets</h3>
             <nav role="navigation">
               <ul class="govuk-list">
                 {% for master in related_data %}
@@ -102,9 +103,11 @@
                 {% endfor %}
               </ul>
             </nav>
-          </aside> 
-          {% endif %}
-          <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related dashboards</h3>
+        </p>
+      </aside> 
+      {% endif %}
+        <aside class="app-related-items" role="complementary">
+          <h3 class="govuk-heading-s govuk-!-margin-top-2">Related dashboards</h3>
           {% if related_visualisations %}
             <nav role="navigation">
               <ul class="govuk-list">
@@ -135,8 +138,9 @@
             class="govuk-link govuk-link--no-visited-state">
             how to create a dashboard with Quicksight.</a></small>
           </p>
-        {% endif %}
-        <p class="govuk-body sidebar-section">
+          {% endif %}
+        </aside> 
+      <p class="govuk-body sidebar-section"></p>
     </div>
   </div>
 
@@ -233,7 +237,7 @@
                     <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
                       <summary class="govuk-details__summary">
                                   <span class="govuk-details__summary-text">
-                                    Use this data<span
+                                    Use this data for analysis<span
                                     class="govuk-visually-hidden"> "{{ source_table.schema }}"."{{ source_table.table }}"</span>
                                   </span>
                       </summary>

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -31,7 +31,7 @@
           <li class="govuk-breadcrumbs__list-item">
             <a class="govuk-breadcrumbs__link" href="/">Home</a>
           </li>
-          <li class="govuk-breadcrumbs__list-item">
+          <li class="govuk-breadcrumbs__list-item" style="text-overflow:ellipsis; white-space:nowrap; overflow:hidden; max-width: 330px">
             {{ model.name }}
           </li>
           {% if perms.datasets_dataset.change %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -44,7 +44,7 @@
       </div>
     </div>
     <div class="govuk-grid-column-one-half govuk-!-margin-top-2" style="text-align: right;">
-      {% flag NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG %}
+      {% flag NOTIFY_ON_DATACUT_CHANGE_FLAG %}
       {% include "partials/subscription_link.html" with subscription=subscription dataset=dataset dataset_uuid=dataset.id %}
       &nbsp;&nbsp;&nbsp;
       {% endflag %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -25,7 +25,7 @@
 
 {% block breadcrumbs %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-one-half">
       <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
           <li class="govuk-breadcrumbs__list-item">
@@ -43,7 +43,11 @@
         </ol>
       </div>
     </div>
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-2" style="text-align: right;">
+    <div class="govuk-grid-column-one-half govuk-!-margin-top-2" style="text-align: right;">
+      {% flag NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG %}
+      {% include "partials/subscription_link.html" with subscription=subscription dataset=dataset dataset_uuid=dataset.id %}
+      &nbsp;&nbsp;&nbsp;
+      {% endflag %}
       {% include "partials/bookmark-link.html" with dataset_uuid=model.id is_bookmarked=is_bookmarked %}
     </div>
   </div>
@@ -72,11 +76,6 @@
       {% endif %}
     </div>
     <div class="govuk-grid-column-one-third">
-      {% flag NOTIFY_ON_DATACUT_CHANGE_FLAG %}
-        <p class="govuk-body sidebar-section">
-          {% include "partials/subscription_link.html" with subscription=subscription dataset=dataset dataset_uuid=dataset.id %}
-        </p>
-      {% endflag %}
       {% if model.enquiries_contact %}
       <p class="govuk-body sidebar-section">
         <a href="mailto:{{ model.enquiries_contact.email }}?subject=Reporting an issue - {{ model.name }}" class="govuk-link govuk-link--no-visited-state">

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -102,32 +102,41 @@
                 {% endfor %}
               </ul>
             </nav>
+          </aside> 
           {% endif %}
-
+          <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related dashboards</h3>
           {% if related_visualisations %}
-            <h3 class="govuk-heading-s {% if related_data %}govuk-!-margin-top-8{% endif %}">Related dashboards</h3>
             <nav role="navigation">
               <ul class="govuk-list">
                 {% for master in related_visualisations|slice:":4" %}
                   <li>
-                  {% include "partials/related_data_link.html" with dataset=master css_classname="related-dashboard" %}
+                    {% include "partials/related_data_link.html" with dataset=master css_classname="related-dashboard" %}
+                  </lusingi>
                 {% endfor %}
-                </li>
+
                 {% if related_visualiations|length > 4 %}
-                <li class="govuk-!-margin-top-4">
-                  <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
-                     class="govuk-link govuk-link--no-visited-state">
-                    Show all related dashboards
-                  </a>
-                </li>
+                  <li class="govuk-!-margin-top-4">
+                    <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
+                      class="govuk-link govuk-link--no-visited-state">
+                      Show all related dashboards
+                    </a>
+                  </li>
                 {% endif %}
               </ul>
             </nav>
+            {% else %}
+            <p class="govuk-body">
+              This data currently has no related dashboards.
+            </p>
           {% endif %}
-
-        </aside>
-      {% endif %}
-      {% include 'partials/using_data_dropdown.html' %}
+          <p class="govuk-body">
+            <small>If you'd like to create a dashboard using this data then you can see                   
+            <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
+            class="govuk-link govuk-link--no-visited-state">
+            how to create a dashboard with Quicksight.</a></small>
+          </p>
+        {% endif %}
+        <p class="govuk-body sidebar-section">
     </div>
   </div>
 

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -245,7 +245,7 @@
                   <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
                     <summary class="govuk-details__summary">
                       <span class="govuk-details__summary-text">
-                        Use this data <span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
+                        Use this data for analysis<span class="govuk-visually-hidden">for "{{ source_table.schema }}"."{{ source_table.table }}"</span>
                       </span>
                     </summary>
                     <div class="govuk-details__text">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -95,8 +95,11 @@
           </p>
         {% endflag %}
       {% endif %}
+
       {% if related_data %}
-        <aside class="app-related-items" role="complementary">
+      <aside class="app-related-items" role="complementary">
+        <p class="govuk-body sidebar-section">
+
           <h3 class="govuk-heading-s" id="subsection-title">
             Related Data
           </h3>
@@ -118,43 +121,42 @@
               {% endif %}
             </ul>
           </nav>
-        </aside>
+      </aside>
       {% endif %}
-        <aside class="govuk-!-margin-top-8" role="complementary">
-          <h3 class="govuk-heading-s" id="subsection-title">
-            Related dashboards
-          </h3>
-          {% if related_visualisations %}
-            <nav role="navigation" aria-labelledby="subsection-title">
-              <ul class="govuk-list">
-                {% for dataset in related_visualisations|slice:":4" %}
-                  <li>
-                    {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
-                  </li>
-                {% endfor %}
 
-                {% if related_visualisations|length > 4 %}
-                  <li class="govuk-!-margin-top-4">
-                    <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
-                      class="govuk-link govuk-link--no-visited-state">
-                      Show all related dashboards
-                    </a>
-                  </li>
-                  {% endif %}
-              </ul>
-            </nav>
-          {% else %}
-            <p class="govuk-body">
-              This data currently has no related dashboards.
-            </p>
-          {% endif %}
-          <p class="govuk-body">
-            <small>If you'd like to create a dashboard using this data then you can see                   
-            <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
-            class="govuk-link govuk-link--no-visited-state">
-            how to create a dashboard with Quicksight.</a></small>
-          </p>
-          <p class="govuk-body sidebar-section">
+      <aside class="app-related-items" role="complementary">
+      <h3 class="govuk-heading-s govuk-!-margin-top-2" id="subsection-title">Related dashboards</h3>
+      {% if related_visualisations %}
+        <nav role="navigation" aria-labelledby="subsection-title">
+          <ul class="govuk-list">
+            {% for dataset in related_visualisations|slice:":4" %}
+              <li>
+                {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
+              </li>
+            {% endfor %}
+
+            {% if related_visualisations|length > 4 %}
+              <li class="govuk-!-margin-top-4">
+                <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
+                  class="govuk-link govuk-link--no-visited-state">
+                  Show all related dashboards
+                </a>
+              </li>
+              {% endif %}
+          </ul>
+        </nav>
+      {% else %}
+        <p class="govuk-body">
+          This data currently has no related dashboards.
+        </p>
+      {% endif %}
+      <p class="govuk-body">
+        <small>If you'd like to create a dashboard using this data then you can see                   
+        <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
+        class="govuk-link govuk-link--no-visited-state">
+        how to create a dashboard with Quicksight.</a></small>
+      </p>
+      <p class="govuk-body sidebar-section"></p>
     </div>
   </div>
 

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -118,34 +118,43 @@
               {% endif %}
             </ul>
           </nav>
-
         </aside>
       {% endif %}
-      {% if related_visualisations %}
         <aside class="govuk-!-margin-top-8" role="complementary">
           <h3 class="govuk-heading-s" id="subsection-title">
             Related dashboards
           </h3>
-          <nav role="navigation" aria-labelledby="subsection-title">
-            <ul class="govuk-list">
-              {% for dataset in related_visualisations|slice:":4" %}
-                <li>
-                  {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
-                </li>
-              {% endfor %}
+          {% if related_visualisations %}
+            <nav role="navigation" aria-labelledby="subsection-title">
+              <ul class="govuk-list">
+                {% for dataset in related_visualisations|slice:":4" %}
+                  <li>
+                    {% include "partials/related_data_link.html" with dataset=dataset css_classname="related-dashboard" %}
+                  </li>
+                {% endfor %}
 
-              {% if related_visualisations|length > 4 %}
-                <li class="govuk-!-margin-top-4">
-                  <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
-                     class="govuk-link govuk-link--no-visited-state">
-                    Show all related dashboards
-                  </a>
-                </li>
-                {% endif %}
-            </ul>
-          </nav>
-      {% endif %}
-      {% include 'partials/using_data_dropdown.html' %}
+                {% if related_visualisations|length > 4 %}
+                  <li class="govuk-!-margin-top-4">
+                    <a href="{% url "datasets:related_visualisations" dataset_uuid=model.id %}"
+                      class="govuk-link govuk-link--no-visited-state">
+                      Show all related dashboards
+                    </a>
+                  </li>
+                  {% endif %}
+              </ul>
+            </nav>
+          {% else %}
+            <p class="govuk-body">
+              This data currently has no related dashboards.
+            </p>
+          {% endif %}
+          <p class="govuk-body">
+            <small>If you'd like to create a dashboard using this data then you can see                   
+            <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
+            class="govuk-link govuk-link--no-visited-state">
+            how to create a dashboard with Quicksight.</a></small>
+          </p>
+          <p class="govuk-body sidebar-section">
     </div>
   </div>
 

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -16,7 +16,7 @@
           <li class="govuk-breadcrumbs__list-item">
             <a class="govuk-breadcrumbs__link" href="/">Home</a>
           </li>
-          <li class="govuk-breadcrumbs__list-item">
+          <li class="govuk-breadcrumbs__list-item" style="text-overflow:ellipsis; white-space:nowrap; overflow:hidden; max-width: 330px">
             {{ model.name }}
           </li>
           {% if perms.datasets_dataset.change %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -153,7 +153,7 @@
       <p class="govuk-body">
         <small>If you'd like to create a dashboard using this data then you can see                   
         <a href="https://data-services-help.trade.gov.uk/data-workspace/how-to/see-tools-specific-guidance/quicksight/create-a-dashboard/"
-        class="govuk-link govuk-link--no-visited-state">
+        class="govuk-link govuk-link--no-visited-state" target="_blank" >
         how to create a dashboard with Quicksight.</a></small>
       </p>
       <p class="govuk-body sidebar-section"></p>

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -179,7 +179,7 @@
         </thead>
         <tbody>
 
-        {% for source_table, code_snippets, columns in master_datasets_info %}
+        {% for source_table, code_snippets, columns, tools_links in master_datasets_info %}
           <tr class="govuk-table__row">
             <td class="govuk-table__cell app-table_cell--no-border">{{ source_table.name }}</td>
             <td class="govuk-table__cell app-table_cell--no-border">
@@ -251,7 +251,7 @@
                       </span>
                     </summary>
                     <div class="govuk-details__text">
-                      {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=source_table %}
+                      {% include 'partials/code_snippets.html' with code_snippets=code_snippets source_table=source_table tools_links=tools_links %}
                     </div>
                   </details>
                 {% endif %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-one-half">
       <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
           <li class="govuk-breadcrumbs__list-item">
@@ -27,7 +27,11 @@
         </ol>
       </div>
     </div>
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-2" style="text-align: right;">
+    <div class="govuk-grid-column-one-half govuk-!-margin-top-2" style="text-align: right;">
+      {% flag NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG %}
+      {% include "partials/subscription_link.html" with subscription=subscription dataset=dataset dataset_uuid=dataset.id %}
+      &nbsp;&nbsp;&nbsp;
+      {% endflag %}
       {% include "partials/bookmark-link.html" with dataset_uuid=model.id is_bookmarked=is_bookmarked %}
     </div>
 
@@ -72,11 +76,6 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      {% flag NOTIFY_ON_MASTER_DATASET_CHANGE_FLAG %}
-        <p class="govuk-body sidebar-section">
-          {% include "partials/subscription_link.html" with subscription=subscription dataset=dataset dataset_uuid=dataset.id %}
-        </p>
-      {% endflag %}
       {% if model.enquiries_contact %}
         <p class="govuk-body sidebar-section">
           <a href="mailto:{{ model.enquiries_contact.email }}?subject=Reporting an issue - {{ model.name }}" class="govuk-link govuk-link--no-visited-state">

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -153,7 +153,6 @@
         </a>
       </p>
       {% endif %}
-      {% include 'partials/using_data_dropdown.html' %}
     </div>
   </div>
 

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -39,7 +39,7 @@
 {% endblock footer_scripts %}
 {% block breadcrumbs %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-one-half">
       <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
           <li class="govuk-breadcrumbs__list-item">
@@ -58,7 +58,11 @@
         </ol>
       </div>
     </div>
-    <div class="govuk-grid-column-one-quarter govuk-!-margin-top-2" style="text-align: right;">
+    <div class="govuk-grid-column-one-half govuk-!-margin-top-2" style="text-align: right;">
+      {% flag NOTIFY_ON_REFERENCE_DATASET_CHANGE_FLAG %}
+      {% include "partials/subscription_link.html" with subscription=subscription dataset=model dataset_uuid=model.uuid %}
+      &nbsp;&nbsp;&nbsp;
+      {% endflag %}
       {% include "partials/bookmark-link.html" with dataset_uuid=model.uuid is_bookmarked=is_bookmarked %}
     </div>
   </div>
@@ -142,11 +146,6 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      {% flag NOTIFY_ON_REFERENCE_DATASET_CHANGE_FLAG %}
-        <p class="govuk-body">
-          {% include "partials/subscription_link.html" with subscription=subscription dataset=model dataset_uuid=model.uuid %}
-        </p>
-      {% endflag %}
       {% if model.enquiries_contact %}
       <p class="govuk-body sidebar-section">
         <a href="mailto:{{ model.enquiries_contact.email }}?subject=Reporting an issue - {{ model.name }}" class="govuk-link govuk-link--no-visited-state">

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -45,7 +45,7 @@
           <li class="govuk-breadcrumbs__list-item">
             <a class="govuk-breadcrumbs__link" href="/">Home</a>
           </li>
-          <li class="govuk-breadcrumbs__list-item">
+          <li class="govuk-breadcrumbs__list-item" style="text-overflow:ellipsis; white-space:nowrap; overflow:hidden; max-width: 330px">
             {{ model.name }}
           </li>
           {% if perms.datasets_referencedataset.change %}

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -16,7 +16,7 @@
           <li class="govuk-breadcrumbs__list-item">
             <a class="govuk-breadcrumbs__link" href="/">Home</a>
           </li>
-          <li class="govuk-breadcrumbs__list-item">
+          <li class="govuk-breadcrumbs__list-item" style="text-overflow:ellipsis; white-space:nowrap; overflow:hidden; max-width: 330px">
             {{ model.name }}
           </li>
           {% if perms.datasets_dataset.change %}

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -43,7 +43,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5" id="launch-jupyter-lab">
-          <a class="govuk-button" href="{{ application_url }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
+          <a class="govuk-button" href="{{ code_snippets.jupyterlab_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
@@ -57,7 +57,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5"" id="launch-r-studio">
-        <a class="govuk-button" href="{{ application_url }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
+        <a class="govuk-button" href="{{ code_snippets.rstudio_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
         <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -28,7 +28,10 @@
         </pre>
       </div>
 
-      <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>in Data Explorer</a>
+      <div class="govuk-button-group">
+        <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>in Data Explorer</a>            
+          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+      </div>
     </div>
 
     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="code-snippet-python-{{ source_table.name|slugify }}">
@@ -37,6 +40,11 @@
         <pre data-module="app-copy" style="white-space: pre-wrap;">
           <code class="hljs python">{{ code_snippets.python }}</code>
         </pre>
+      </div>
+
+      <div class="govuk-button-group">
+        <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>JupyterLab</a>            
+          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
 
@@ -47,7 +55,12 @@
           <code class="hljs r">{{ code_snippets.r }}</code>
         </pre>
       </div>
+
+      <div class="govuk-button-group">
+        <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>R Studio</a>            
+          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+      </div>
     </div>
-  </div>
+
   {% endif %}
 {% endif %}

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -43,7 +43,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5" id="launch-jupyter-lab">
-          <a class="govuk-button" href="{{ code_snippets.jupyterlab_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
+          <a class="govuk-button" href="{{ tools_links.jupyterlab_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
@@ -57,7 +57,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5"" id="launch-r-studio">
-        <a class="govuk-button" href="{{ code_snippets.rstudio_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
+        <a class="govuk-button" href="{{ tools_links.rstudio_link }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
         <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -42,8 +42,10 @@
         </pre>
       </div>
 
-      <div class="govuk-button-group">
-        <a id="launch-jupyter-lab" class="govuk-button govuk-!-margin-top-5" href="{{ application_url }}" target="_blank">Open <span class="govuk-visually-hidden"></span>JupyterLab</a>            
+      <div class="govuk-button-group govuk-!-margin-top-5" id="launch-jupyter-lab">
+          <form action="{{ application_url where nice_name == 'Jupyter Lab' }}" method="GET" style="display: inline-block" target="_blank">
+            <button class="govuk-button">Open <span class="govuk-visually-hidden"></span>Jupyter Lab</button>
+          </form>
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
@@ -56,9 +58,11 @@
         </pre>
       </div>
 
-      <div class="govuk-button-group">
-        <a id="launch-r-studio" class="govuk-button govuk-!-margin-top-5" href="{{ application_url }}" target="_blank">Open <span class="govuk-visually-hidden"></span>R Studio</a>
-          <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
+      <div class="govuk-button-group govuk-!-margin-top-5"" id="launch-r-studio">
+        <form action="{{ application_url where nice_name == 'Rstudio' }}" method="GET" style="display: inline-block" target="_blank">
+          <button class="govuk-button">Open <span class="govuk-visually-hidden"></span>R Studio</button>
+        </form>
+        <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
 

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -43,9 +43,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5" id="launch-jupyter-lab">
-          <form action="{{ application_url where nice_name == 'Jupyter Lab' }}" method="GET" style="display: inline-block" target="_blank">
-            <button class="govuk-button">Open <span class="govuk-visually-hidden"></span>Jupyter Lab</button>
-          </form>
+          <a class="govuk-button" href="{{ application_url }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>JupyterLab</a>
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
@@ -59,9 +57,7 @@
       </div>
 
       <div class="govuk-button-group govuk-!-margin-top-5"" id="launch-r-studio">
-        <form action="{{ application_url where nice_name == 'Rstudio' }}" method="GET" style="display: inline-block" target="_blank">
-          <button class="govuk-button">Open <span class="govuk-visually-hidden"></span>R Studio</button>
-        </form>
+        <a class="govuk-button" href="{{ application_url }}" target="_blank" >Open <span class="govuk-visually-hidden"></span>R Studio</a>
         <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>

--- a/dataworkspace/dataworkspace/templates/partials/code_snippets.html
+++ b/dataworkspace/dataworkspace/templates/partials/code_snippets.html
@@ -43,7 +43,7 @@
       </div>
 
       <div class="govuk-button-group">
-        <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>JupyterLab</a>            
+        <a id="launch-jupyter-lab" class="govuk-button govuk-!-margin-top-5" href="{{ application_url }}" target="_blank">Open <span class="govuk-visually-hidden"></span>JupyterLab</a>            
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>
@@ -57,7 +57,7 @@
       </div>
 
       <div class="govuk-button-group">
-        <a id="launch-data-explorer" class="govuk-button govuk-!-margin-top-5" href="{% url 'explorer:index' %}?sql={{ code_snippets.sql|quote_plus }}" target="_blank">Open <span class="govuk-visually-hidden">first 50 rows of "{{ source_table.schema }}"."{{ source_table.table }}" </span>R Studio</a>            
+        <a id="launch-r-studio" class="govuk-button govuk-!-margin-top-5" href="{{ application_url }}" target="_blank">Open <span class="govuk-visually-hidden"></span>R Studio</a>
           <a href="{{ tools_url }}" class="govuk-link govuk-link--no-visited-state">View all tools</a>
       </div>
     </div>


### PR DESCRIPTION
### Description of change

Updates to the data catalogue pages, including:

- _'Get updated when this dataset changes'_ moved to the left of _'Bookmark'_ for all catalogue types
- _'Use this data'_ link changed to _'use this data for analysis'_ link
- Text ellipsis added to model name in breadcrumbs for all catalogue types
- '_View all tools_' link added to code snippet sections
- Related data/related dashboards/source dataset sections re-formatted into sidebar sections 
- New text added to related dashboard section with a link to Quicksight help centre article
- _'Ways to use our data'_ removed from all catalogue pages
- _'Open JupyterLab'_ and _'Open R Studio'_ buttons added to code snippet sections 


### Checklist

* [ ] Have tests been added to cover any changes?
