### PR TITLE
feat: filter for datasets a user is IAO/IAM of

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -153,6 +153,7 @@ class SourceTagField(forms.ModelMultipleChoiceField):
 class DatasetSearchForm(forms.Form):
     SUBSCRIBED = "subscribed"
     BOOKMARKED = "bookmarked"
+    OWNED = "owned"
 
     q = forms.CharField(required=False)
 
@@ -180,6 +181,7 @@ class DatasetSearchForm(forms.Form):
         choices=[
             (BOOKMARKED, "My bookmarks"),
             (SUBSCRIBED, "My subscriptions"),
+            (OWNED, "Data I own or manage"),
         ],
         required=False,
         widget=AccordionFilterWidget("My datasets"),

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -189,6 +189,8 @@ def _get_datasets_data_for_user_matching_query(
 
     datasets = _annotate_combined_published_date(datasets)
 
+    datasets = _annotate_is_owner(datasets, user)
+
     return datasets.values(
         id_field,
         "name",
@@ -211,6 +213,7 @@ def _get_datasets_data_for_user_matching_query(
         "is_subscribed",
         "published_date",
         "average_unique_users_daily",
+        "is_owner",
     )
 
 
@@ -512,6 +515,28 @@ def _annotate_has_access(datasets, user):
                 )
             ),
         )
+    return datasets
+
+
+def _annotate_is_owner(datasets, user):
+    """
+    Adds a boolean annotation to queryset which is set to True if the user
+    is an IAO or IAM of a dataset
+    @param datasets: django querysey
+    @param user: request.user
+    @return:
+    """
+    datasets = datasets.annotate(
+        is_owner=BoolOr(
+            Case(
+                When(
+                    Q(information_asset_owner=user) | Q(information_asset_manager=user), then=True
+                ),
+                default=False,
+                output_field=BooleanField(),
+            )
+        ),
+    )
     return datasets
 
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -135,22 +135,24 @@ def _matches_filters(
     user_inaccessible: bool = False,
     selected_user_datasets: Set = None,
 ):
-    subscribed_or_bookmarked = set()
+    users_datasets = set()
     if data["is_bookmarked"]:
-        subscribed_or_bookmarked.add("bookmarked")
+        users_datasets.add("bookmarked")
     if data["is_subscribed"]:
-        subscribed_or_bookmarked.add("subscribed")
+        users_datasets.add("subscribed")
+    if data["is_owner"]:
+        users_datasets.add("owned")
 
     return (
         (
             not selected_user_datasets
             or selected_user_datasets == [None]
-            or set(selected_user_datasets).intersection(subscribed_or_bookmarked)
+            or set(selected_user_datasets).intersection(users_datasets)
         )
         and (
             not selected_user_datasets
             or selected_user_datasets == [None]
-            or set(selected_user_datasets).intersection(subscribed_or_bookmarked)
+            or set(selected_user_datasets).intersection(users_datasets)
         )
         and (unpublished or data["published"])
         and (not opendata or data["is_open_data"])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -149,11 +149,6 @@ def _matches_filters(
             or selected_user_datasets == [None]
             or set(selected_user_datasets).intersection(users_datasets)
         )
-        and (
-            not selected_user_datasets
-            or selected_user_datasets == [None]
-            or set(selected_user_datasets).intersection(users_datasets)
-        )
         and (unpublished or data["published"])
         and (not opendata or data["is_open_data"])
         and (not withvisuals or data["has_visuals"])


### PR DESCRIPTION
### Description of change

https://trello.com/c/buNU0ZoZ/2679-add-filter-to-search-for-iaos-iams-to-filter-results-by-data-they-own-or-manage

### Checklist

* [x] Have tests been added to cover any changes?
