### PR TITLE
fix: chart data aggregation fixes

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1783,7 +1783,7 @@ class CreateGridChartView(WaffleFlagMixin, View):
 
         if chart_data["aggregate"] != AggregationType.NONE.value:
             query = (
-                sql.SQL("SELECT {{}}, {{}}({{}}) FROM (").format(
+                sql.SQL("SELECT {}, {}({}) FROM (").format(
                     sql.Identifier(chart_data["group_by"]),
                     sql.Identifier(chart_data["aggregate"]),
                     sql.Literal("*")

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -387,7 +387,7 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "args": (),
         },
         "refresh-published-chart-data": {
-            "task": "dataworkspace.apps.explorer.tasks.refresh_published_chart_data",
+            "task": "dataworkspace.apps.core.charts.tasks.refresh_published_chart_data",
             "schedule": crontab(minute=0, hour=6),
             "args": (),
         },


### PR DESCRIPTION
### Description of change

- Task config was pointing to the explorer tasks rather than the new core charts module
- Remove incorrect use of double curly braces `{{}}` in aggregate query

### Checklist

* [ ] Have tests been added to cover any changes?
