### PR TITLE
fix: hide table name field

### DIFF
--- a/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-data-types.html
+++ b/dataworkspace/dataworkspace/templates/your_files/create-table-confirm-data-types.html
@@ -12,7 +12,7 @@
       {% include 'design_system/error_summary.html' with form=form %}
       <form method="POST" novalidate>
         {% csrf_token %}
-        {{ form.table_name }}
+        {{ form.table_name.as_hidden }}
         {{ form.path }}
         {{ form.schema }}
         {{ form.force_overwrite }}


### PR DESCRIPTION
### Description of change
Hide the table name field from your files column definitions page
<img width="949" alt="Screenshot_2022-06-01_174718" src="https://user-images.githubusercontent.com/2064710/180200970-1c508225-ee79-44f3-9ce4-06993ac8289e.png">


### Checklist

~* [ ] Have tests been added to cover any changes?~
