### PR TITLE
fix: remove duplicate govuk-width-container

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/share.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/share.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="{% static 'assets/vendor/highlight/styles/a11y-light.css' %}">
 {% endblock styles %}
 {% block content %}
-  <div class="govuk-width-container">
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">
@@ -43,7 +43,7 @@
         </form>
       </div>
     </div>
-  </div>
+
 {% endblock content %}
 {% block javascript %}
   {{ block.super }}


### PR DESCRIPTION
### Description of change
The share.html page uses the `content` template block which is already inside a govuk-width-container

### Checklist

~* [ ] Have tests been added to cover any changes?~
