### PR TITLE
feat: include dots in identifiers from the point of view of auto-completion

### DIFF
--- a/dataworkspace/dataworkspace/static/explorer_query.js
+++ b/dataworkspace/dataworkspace/static/explorer_query.js
@@ -15,6 +15,7 @@ var editor = ace.edit("ace-sql-editor", {
 var table_list = JSON.parse(document.getElementById("schema_tables").textContent);
 
 var staticWordCompleter = {
+  identifierRegexps: [/[a-zA-Z_0-9\.]/],  // The default does not include dots
   getCompletions: function(editor, session, pos, prefix, callback) {
       var wordList = table_list
 


### PR DESCRIPTION
### Description of change
The table list is formed of schema.table_name pairs, but the default regex used to find the current identifier does not include dots. This mis-match caused the autocompletion to ignore the schema name in the existing query, and re-add the whole schema.table_name pair, resulting in schema.schema.table_name, which then resulted in the server complaining about cross database references not being implemented.

### Checklist

* [ ] Have tests been added to cover any changes?
