### PR TITLE
feature: remove mlflow default-artifact-root param as it isn't needed

### DIFF
--- a/infra/ecs_main_mlflow.tf
+++ b/infra/ecs_main_mlflow.tf
@@ -10,7 +10,6 @@ locals {
         artifact_bucket_name = "${aws_s3_bucket.mlflow[0].bucket}"
         jwt_public_key       = "${var.jwt_public_key}"
         mlflow_hostname      = "http://mlflow--${var.mlflow_instances_long[0]}.${var.admin_domain}"
-        tracking_server_host = "http://mlflow--${var.mlflow_instances_long[0]}.${var.admin_domain}:${local.mlflow_port}"
         database_uri         = "postgresql://${aws_rds_cluster.mlflow[0].master_username}:${random_string.aws_db_instance_mlflow_password[0].result}@${aws_rds_cluster.mlflow[0].endpoint}:5432/${aws_rds_cluster.mlflow[0].database_name}"
         proxy_port           = "${local.mlflow_port}"
     }

--- a/infra/ecs_main_mlflow_container_definitions.json
+++ b/infra/ecs_main_mlflow_container_definitions.json
@@ -14,10 +14,6 @@
         "value": "${mlflow_hostname}"
       },
       {
-        "name": "TRACKING_SERVER_HOST",
-        "value": "${tracking_server_host}"
-      },
-      {
         "name": "DATABASE_URI",
         "value": "${database_uri}"
       },

--- a/mlflow/start.sh
+++ b/mlflow/start.sh
@@ -7,6 +7,6 @@ set -e
 
     echo "Starting mlflow server and proxy..."
     parallel --will-cite --line-buffer --jobs 2 --halt now,done=1 ::: \
-        "mlflow server --host 0.0.0.0 --port 5000 --serve-artifacts --artifacts-destination s3://${ARTIFACT_BUCKET_NAME} --backend-store-uri ${DATABASE_URI} --default-artifact-root ${TRACKING_SERVER_HOST}/api/2.0/mlflow-artifacts/artifacts/experiments --gunicorn-opts '--log-level debug'" \
+        "mlflow server --host 0.0.0.0 --port 5000 --serve-artifacts --artifacts-destination s3://${ARTIFACT_BUCKET_NAME} --backend-store-uri ${DATABASE_URI} --gunicorn-opts '--log-level debug'" \
         "PROXY_PORT=${PROXY_PORT} UPSTREAM_ROOT='http://0.0.0.0:5000' python3 -m proxy"
 )


### PR DESCRIPTION
### Description of change
This isn't needed when using the proxied artifact set-up


### Checklist

* [ ] Have tests been added to cover any changes?
