### PR TITLE
feat: remove skip for certain custom visualisations, and unnecessary padding

### DIFF
--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -77,9 +77,9 @@
   <body class="govuk-template__body">
     {% include 'partials/gtm_body.html' %}
 
-    <a href="{{ request.path }}#visualisation" class="govuk-skip-link">Skip to main content</a>
-
     {% if wrap == 'IFRAME_WITH_VISUALISATIONS_HEADER' %}
+      <a href="{{ request.path }}#visualisation" class="govuk-skip-link">Skip to main content</a>
+
       <div class="header-wrap">
         <header class="govuk-header" role="banner" data-module="govuk-header">
           <div class="govuk-header__container govuk-grid-row">

--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -22,7 +22,7 @@
 
   <style>
     html, body {
-      height: 100%;
+      height: 100%; margin: 0;
     }
     .govuk-header__link, .govuk-phase-banner, .govuk-breadcrumbs {
       padding-left: 10px;


### PR DESCRIPTION
### Description of change

Two changes:

1. When visualisations are in FULL_HEIGHT_IFRAME then the margin made it not actually full height - there was a visual border that looked bad. This must have snuck in - it's not how it was originally designed.

2. When the visualisation in FULL_HEIGHT_IFRAME, then there is no header/navigation to skip, so it's strictly worse having the "Skip to main content" link than not having it.

### Checklist

* [ ] Have tests been added to cover any changes?
