### PR TITLE
fix: make iframe full height

### DIFF
--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -46,6 +46,7 @@
       }
       iframe {
         flex: 1;
+        height: 100%;
       }
     </style>
   {% endif %}


### PR DESCRIPTION
### Description of change

Without `height: 100%` the quicksight vis iframe is buggy and either doesn't display full page or flickers and disappears. 

### Checklist

* [ ] Have tests been added to cover any changes?
