### PR TITLE
feat: allow mirror access from not behind the whitelist

### DIFF
--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -1247,7 +1247,6 @@ async def async_main():
             ip_whitelist_required = (
                 is_app_requested(request)
                 or is_superset_requested(request)
-                or is_mirror_requested(request)
                 or is_requesting_credentials(request)
                 or is_requesting_files(request)
                 or is_data_explorer_requested(request)


### PR DESCRIPTION
### Description of change

This is specifically to allow access to the Data Workspace video on the welcome page.

But we don't put anything with any  access restrictions in the mirror, and it's still behind SSO auth. So we're KISS and opening up the whole mirror up to everyone with Data Workspace access.

### Checklist

* [ ] Have tests been added to cover any changes?
