### PR TITLE
fix: use dateutil to parse airflow dates

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
+++ b/dataworkspace/dataworkspace/apps/datasets/templatetags/datasets_tags.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from typing import Optional
 from urllib import parse
+
+from dateutil import parser
 from dateutil.relativedelta import relativedelta
 import pytz
 
@@ -102,7 +104,7 @@ def format_date_uk(date: Optional[datetime.date]) -> Optional[str]:
 def parse_date_string(date_string: Optional[str]) -> Optional[str]:
     if date_string is None:
         return None
-    return datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%SZ")
+    return parser.parse(date_string)
 
 
 @register.simple_tag()


### PR DESCRIPTION
### Description of change

airflow have changed their date format. Use dateutil to parse it for use in templates

### Checklist

* [ ] Have tests been added to cover any changes?
