### PR TITLE
fix: Add name key to accessibleAutocomplete dict

### DIFF
--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -402,6 +402,7 @@ function accessibleAutocompleteOptions(data, GTM) {
   accessibleAutocomplete({
     element: container,
     id: 'app-site-search__input',
+    name: 'q',
     cssNamespace: 'app-site-search',
     displayMenu: 'overlay',
     placeholder: 'Search by dataset name or description',


### PR DESCRIPTION
### Description of change
Add name key to accessibleAutocomplete to allow search functionality to perform

### Checklist

* [ ] Have tests been added to cover any changes?
