### PR TITLE
set null source download_limit to 5000

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -438,7 +438,7 @@ def build_filtered_dataset_query(inner_query, download_limit, column_config, par
     column_map = {x["field"]: x for x in column_config}
     query_params = {
         "offset": int(params.get("start", 0)),
-        "limit": params.get("limit"),
+        "limit": params.get("limit") or download_limit,
     }
     sort_dir = "DESC" if params.get("sortDir", "").lower() == "desc" else "ASC"
     sort_fields = [column_config[0]["field"]]

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -438,7 +438,7 @@ def build_filtered_dataset_query(inner_query, download_limit, column_config, par
     column_map = {x["field"]: x for x in column_config}
     query_params = {
         "offset": int(params.get("start", 0)),
-        "limit": params.get("limit") or download_limit,
+        "limit": params.get("limit"),
     }
     sort_dir = "DESC" if params.get("sortDir", "").lower() == "desc" else "ASC"
     sort_fields = [column_config[0]["field"]]

--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -576,8 +576,6 @@ def build_filtered_dataset_query(inner_query, download_limit, column_config, par
     )
 
     where_clause = Composed(where_clause)
-    if download_limit is None:
-        download_limit = 5000
     download_limit += 1
     limit_clause = Composed([SQL(f" LIMIT {download_limit}")])
     inner_query = inner_query + where_clause + limit_clause

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1145,10 +1145,6 @@ class DataCutSourceDetailView(DetailView):
 
 
 class DataGridDataView(DetailView):
-    def _user_can_access(self):
-        source = self.get_object()
-        return source.dataset.user_has_access(self.request.user) and source.data_grid_enabled
-
     def get_object(self, queryset=None):
         dataset = find_dataset(self.kwargs.get("dataset_uuid"), self.request.user)
         return get_object_or_404(
@@ -1158,8 +1154,13 @@ class DataGridDataView(DetailView):
         )
 
     def dispatch(self, request, *args, **kwargs):
-        if not self._user_can_access():
-            return HttpResponseForbidden()
+        source = self.get_object()
+        if not source.data_grid_enabled:
+            raise DatasetPreviewDisabledError(source.dataset)
+
+        if not source.dataset.user_has_access(self.request.user):
+            raise DatasetPermissionDenied(source.dataset)
+
         return super().dispatch(request, *args, **kwargs)
 
     @staticmethod
@@ -1204,9 +1205,12 @@ class DataGridDataView(DetailView):
             column_config = source.get_column_config()
 
         original_query = source.get_data_grid_query()
+        download_limit = source.data_grid_download_limit
+        if download_limit is None:
+            download_limit = 5000
         rowcount_query, query, params = build_filtered_dataset_query(
             original_query,
-            source.data_grid_download_limit,
+            download_limit,
             column_config,
             post_data,
         )
@@ -1251,7 +1255,7 @@ class DataGridDataView(DetailView):
         return JsonResponse(
             {
                 "rowcount": rowcount[0],
-                "download_limit": source.data_grid_download_limit,
+                "download_limit": download_limit,
                 "records": records,
             }
         )

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1813,9 +1813,13 @@ class CreateGridChartView(WaffleFlagMixin, View):
         chart_data = form.cleaned_data
 
         original_query = source.get_data_grid_query()
+        download_limit = source.data_grid_download_limit
+        if download_limit is None:
+            download_limit = 5000
+
         _, query, params = build_filtered_dataset_query(
             original_query,
-            source.data_grid_download_limit,
+            download_limit,
             json.loads(request.POST.get("columns", "[]")),
             {
                 "filters": chart_data["filters"],

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1255,7 +1255,7 @@ class DataGridDataView(DetailView):
         return JsonResponse(
             {
                 "rowcount": rowcount[0],
-                "download_limit": download_limit,
+                "download_limit": source.data_grid_download_limit,
                 "records": records,
             }
         )

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -179,15 +179,11 @@ function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, expo
                 if (rowcount) { rowcount.innerText = '5000+ rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data' }
               }
-              if ((dlimit == null) && (rc < 5000)){
-                if (rowcount) { rowcount.innerText = '5000 rows' }
-                if (dl_count) { dl_count.innerText = 'Download this data' }
-              }
               if ((dlimit != null) && (rc > dlimit)){
                 if (rowcount) { rowcount.innerText = dlimit+'+ rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data ('+dlimit+' rows)' }
               }
-              if ((dlimit != null) && rc < dlimit) {
+              if ((rc <= dlimit) || ((dlimit == null) && (rc < 5000))){              
                 if (rowcount) { rowcount.innerText = rc+' rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data ('+rc+' rows)' }
               }

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -175,11 +175,19 @@ function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, expo
               var dlimit = response.download_limit
               const rowcount = document.getElementById('data-grid-rowcount')
               const dl_count = document.getElementById('data-grid-download')
-              if ((rc > dlimit) && (dlimit != null)) {
+              if (dlimit == null) && (rc > 5000){
+                if (rowcount) { rowcount.innerText = '5000+ rows' }
+                if (dl_count) { dl_count.innerText = 'Download this data' }
+              }
+              if (dlimit == null) && (rc < 5000){
+                if (rowcount) { rowcount.innerText = '5000 rows' }
+                if (dl_count) { dl_count.innerText = 'Download this data' }
+              }
+              if ((dlimit != null) && (rc > dlimit)){
                 if (rowcount) { rowcount.innerText = dlimit+'+ rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data ('+dlimit+' rows)' }
               }
-              else {
+              if ((dlimit != null) && rc < dlimit) {
                 if (rowcount) { rowcount.innerText = rc+' rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data ('+rc+' rows)' }
               }

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -175,11 +175,11 @@ function initDataGrid(columnConfig, dataEndpoint, downloadSegment, records, expo
               var dlimit = response.download_limit
               const rowcount = document.getElementById('data-grid-rowcount')
               const dl_count = document.getElementById('data-grid-download')
-              if (dlimit == null) && (rc > 5000){
+              if ((dlimit == null) && (rc > 5000)){
                 if (rowcount) { rowcount.innerText = '5000+ rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data' }
               }
-              if (dlimit == null) && (rc < 5000){
+              if ((dlimit == null) && (rc < 5000)){
                 if (rowcount) { rowcount.innerText = '5000 rows' }
                 if (dl_count) { dl_count.innerText = 'Download this data' }
               }

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -3346,7 +3346,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "name": "the last record",
@@ -3384,7 +3384,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3429,7 +3429,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3467,7 +3467,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": None,
@@ -3511,7 +3511,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2020-01-01",
@@ -3548,7 +3548,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": None,
@@ -3586,7 +3586,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3624,7 +3624,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3662,7 +3662,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2020-01-01",
@@ -3700,7 +3700,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3738,7 +3738,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": None,
@@ -3783,7 +3783,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3821,7 +3821,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": 5000,
+            "download_limit": None,
             "records": [
                 {
                     "date": "2019-01-01",

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -3346,7 +3346,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "name": "the last record",
@@ -3384,7 +3384,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3429,7 +3429,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3467,7 +3467,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": None,
@@ -3511,7 +3511,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2020-01-01",
@@ -3548,7 +3548,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": None,
@@ -3586,7 +3586,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3624,7 +3624,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3662,7 +3662,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2020-01-01",
@@ -3700,7 +3700,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3738,7 +3738,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": None,
@@ -3783,7 +3783,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 1},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",
@@ -3821,7 +3821,7 @@ class TestGridDataView:
         assert response.status_code == 200
         assert response.json() == {
             "rowcount": {"count": 2},
-            "download_limit": None,
+            "download_limit": 5000,
             "records": [
                 {
                     "date": "2019-01-01",


### PR DESCRIPTION
### Description of change

The source's download_limit was being set to 5000 in utils.py if it was None, it needs to be set in the View and passed back to the client in the JSON response.

The rowcount query from the utils package will return download_limit+1, with logic in data-grid.js to compare rc and dlimit to display "5000+ rows".

Fix for what was likely a regression in PR #2137. 

### Checklist

* [x] Have tests been added to cover any changes?
