### PR TITLE
fix: limit suggested searches to 30 days to prevent performance issues

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -815,7 +815,7 @@ def suggested_searches(request):
             event_type=EventLog.TYPE_DATASET_FIND_FORM_QUERY,
             extra__query__startswith=query,
             extra__number_of_results__gt=0,
-            timestamp__date__gt=datetime.today() - timedelta(days=30)
+            timestamp__date__gt=datetime.today() - timedelta(days=30),
         )
         .values("extra__query")
         .annotate(occurrences=Count("extra__query"))

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -815,6 +815,7 @@ def suggested_searches(request):
             event_type=EventLog.TYPE_DATASET_FIND_FORM_QUERY,
             extra__query__startswith=query,
             extra__number_of_results__gt=0,
+            timestamp__date__gt=datetime.today() - timedelta(days=30)
         )
         .values("extra__query")
         .annotate(occurrences=Count("extra__query"))


### PR DESCRIPTION
### Description of change
Limit suggested searches to past 30 days to prevent performance load issues on DW

### Checklist

~* [ ] Have tests been added to cover any changes?~
