### PR TITLE
fix: Limit results to 5 max in backend instead of frontend

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -823,7 +823,7 @@ def suggested_searches(request):
             )
             .values("extra__query")
             .annotate(occurrences=Count("extra__query"))
-            .order_by("occurrences")
+            .order_by("occurrences")[:5]
         )
 
         return JsonResponse(

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -376,10 +376,8 @@ function accessibleAutocompleteOptions(data, dataSearchURL, GTM, liveSearchForm)
           suggestedSearchesName.shift()
         } else {
           for (var d = 0; d < response.length; ++d) {
-            if (suggestedSearchesName.length <= 5) {
               response[d]["length"] = query.length
               suggestedSearchesName.push(response[d])
-            }
           }
         }
         const searchResults = query == '' ? dataName : suggestedSearchesName;


### PR DESCRIPTION
### Description of change
Results were being limited to 5 in the frontend, this should be done in the backend to try reduce database query size

### Checklist

* [ ] Have tests been added to cover any changes?
