### PR TITLE
fix: missing level in heading structure on tools page

### DIFF
--- a/dataworkspace/dataworkspace/templates/tools.html
+++ b/dataworkspace/dataworkspace/templates/tools.html
@@ -51,7 +51,7 @@
 
       {% for key, group in tools.items %}
         <div class="govuk-!-margin-bottom-8">
-          <h3 class="govuk-heading-l">{{ group.group_name }}</h3>
+          <h2 class="govuk-heading-l">{{ group.group_name }}</h2>
           <div class="govuk-inset-text">Use these tools to
             {% if group.group_link %}
               <a class="govuk-link" href="{{ group.group_link }}" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
### Description of change

The individual tools are h3, the "Tools" heading is h1, so the sections/groups should be h2

### Checklist

* [ ] Have tests been added to cover any changes?
