### PR TITLE
feat: case-insenstive search suggestions and fix ordering of search suggestions

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -834,7 +834,7 @@ def suggested_searches(request):
             .values("lower_query")  # So GROUP BY is only on "lower_query", not "id, lower_query"
             .annotate(occurrences=Count("lower_query"))
             .values("lower_query")  # Prevents "occurrences" from being output needlessly
-            .order_by("occurrences")[:5]
+            .order_by("-occurrences")[:5]
         )
 
         return JsonResponse(

--- a/dataworkspace/dataworkspace/apps/datasets/search.py
+++ b/dataworkspace/dataworkspace/apps/datasets/search.py
@@ -23,6 +23,8 @@ from django.db.models import (
     FilteredRelation,
 )
 from django.db.models import QuerySet
+from django.db.models.functions import Lower
+from django.db.models.fields.json import KeyTextTransform
 from django.http import JsonResponse
 from pytz import utc
 import redis
@@ -814,23 +816,29 @@ def update_datasets_average_daily_users():
 def suggested_searches(request):
     if waffle.flag_is_active(request, settings.SUGGESTED_SEARCHES_FLAG):
         query = request.GET.get("query", None)
+
+        # Using Django's standard '__' on JSON fields in keword arguments uses the '->' operator
+        # in the resulting SQL query. But we can't pass the result of that to the PostgreSQL
+        # function LOWER for a case-insensitive GROUP BY since PostreSQL won't know the result is
+        # text. Instead, need to use '->>'. But to do that we have to use KeyTextTransform
+        query_as_text = KeyTextTransform("query", "extra")
+
         recent_searches = (
-            EventLog.objects.filter(
+            EventLog.objects.annotate(lower_query=Lower(query_as_text))
+            .filter(
+                lower_query__startswith=query.lower().strip(),
                 event_type=EventLog.TYPE_DATASET_FIND_FORM_QUERY,
-                extra__query__startswith=query,
                 extra__number_of_results__gt=0,
                 timestamp__gt=datetime.today() - timedelta(days=30),
             )
-            .values("extra__query")
-            .annotate(occurrences=Count("extra__query"))
+            .values("lower_query")  # So GROUP BY is only on "lower_query", not "id, lower_query"
+            .annotate(occurrences=Count("lower_query"))
+            .values("lower_query")  # Prevents "occurrences" from being output needlessly
             .order_by("occurrences")[:5]
         )
 
         return JsonResponse(
-            [
-                {"name": search["extra__query"].lower(), "type": "", "url": ""}
-                for search in recent_searches
-            ],
+            [{"name": search["lower_query"], "type": "", "url": ""} for search in recent_searches],
             safe=False,
             status=200,
         )


### PR DESCRIPTION
### Description of change

This results in SQL like:

```
SELECT
  LOWER("eventlog_eventlog"."extra" ->> 'query') AS "lower_query"
FROM
  "eventlog_eventlog"
WHERE
  "eventlog_eventlog"."event_type" = 29
  AND "eventlog_eventlog"."extra" -> 'number_of_results' > '0'
  AND LOWER("eventlog_eventlog"."extra" ->> 'query')::text LIKE 'my search query'
  AND "eventlog_eventlog"."timestamp" > '2022-08-24T06:47:25.269903+00:00'::timestamptz
GROUP BY
  LOWER("eventlog_eventlog"."extra" ->> 'query')
ORDER BY
  COUNT(LOWER("eventlog_eventlog"."extra" ->> 'query')) DESC
LIMIT
  5
```

As in comments in the code, there is a bit of faff to force Django to use `->>`to allow the result to be passed to `LOWER`.

Also includes a fix where the least popular searches were shown, when it should have been the most popular
  
### Checklist

* [ ] Have tests been added to cover any changes?
