### PR TITLE
fix: allow user to select dataset by tabbing

### DIFF
--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -81,6 +81,7 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOV
 
   this.$form.on(
     "keydown",
+    "input[type=text]",
     function (e) {
       if (e.keyCode == 13) {
         // 13 is the return key


### PR DESCRIPTION
### Description of change
At the moment if a user tries to tab to a dataset link and click it, it runs the form change instead of navigating them to that dataset page. This is a fix to ensure the form is only changed if input has enter key pressed or one of the dropdown options

### Checklist

* [ ] Have tests been added to cover any changes?
