### PR TITLE
feat: queries don't needlessly select_related on data they don't use

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/schema.py
+++ b/dataworkspace/dataworkspace/apps/explorer/schema.py
@@ -144,13 +144,15 @@ def match_datasets_with_schema_info(schema):
     source_tables = (
         SourceTable.objects.alias(schema_table=Func(F("schema"), F("table"), function="Row"))
         .filter(schema_table__in=schema_table_names)
-        .select_related("dataset", "dataset__reference_code")
-        .only("schema", "table", "dataset__dictionary_published", "dataset__reference_code")
+        .only("schema", "table", "dataset__dictionary_published")
+        .values("schema", "table", "dataset__dictionary_published")
     )
 
     # Attach the dictionary_published to each table in schema
     dictionary_published = {
-        (source_table.schema, source_table.table): source_table.dataset.dictionary_published
+        (source_table["schema"], source_table["table"]): source_table[
+            "dataset__dictionary_published"
+        ]
         for source_table in source_tables
     }
 


### PR DESCRIPTION
### Description of change

The Datasets have code inside `__init__ `that cause N+1 problems, which were previously solved with select_related. However, almost none of that data is used, to the queries were joining needlessly and returning unused data.

It's much simpler, quicker, and more robust to use `values` which doesn't call `__init__` on each model instance.

### Checklist

* [ ] Have tests been added to cover any changes?
