### PR TITLE
fix: hide suggested search menu on enter

### DIFF
--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -102,16 +102,6 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOV
     }.bind(this)
   );
 
-  this.$form.find("input[type=text]").keypress(
-    function (e) {
-      if (e.keyCode == 13) {
-        // 13 is the return key
-        this.formChange();
-        e.preventDefault();
-      }
-    }.bind(this)
-  );
-
   this.$form.find("select").change(
     function (e) {
       this.formChange();

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -41,6 +41,7 @@ function replaceBlock(selector, html) {
   }
 }
 
+
 var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOVUKFrontend) {
 
   this.GOVUKFrontend = GOVUKFrontend;
@@ -82,6 +83,26 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOV
   this.$form.on(
     "keydown",
     "input[type=text]",
+    function (e) {
+      if (e.keyCode == 13) {
+        // 13 is the return key
+        this.formChange();
+
+        var inputElement = document.getElementById("app-site-search__input")
+        inputElement.ariaExpanded = "false"
+        inputElement.classList.remove('app-site-search__input--focused')
+
+        var searchMenu = document.getElementById('app-site-search__input__listbox')
+        searchMenu.classList.remove('app-site-search__menu--visible')
+        searchMenu.classList.add('app-site-search__menu--hidden');
+
+        e.preventDefault();
+        inputElement.blur()
+      }
+    }.bind(this)
+  );
+
+  this.$form.find("input[type=text]").keypress(
     function (e) {
       if (e.keyCode == 13) {
         // 13 is the return key

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -90,14 +90,12 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOV
 
         var inputElement = document.getElementById("app-site-search__input")
         inputElement.ariaExpanded = "false"
-        inputElement.classList.remove('app-site-search__input--focused')
 
         var searchMenu = document.getElementById('app-site-search__input__listbox')
         searchMenu.classList.remove('app-site-search__menu--visible')
         searchMenu.classList.add('app-site-search__menu--hidden');
 
         e.preventDefault();
-        inputElement.blur()
       }
     }.bind(this)
   );


### PR DESCRIPTION
### Description of change
At the moment if you type an input and press enter on something not on the suggested dropdown list, it still shows the menu. This PR resolves this problem

### Checklist

* [ ] Have tests been added to cover any changes?
