### PR TITLE
feat: use `values` to better avoid N+1 issues when querying ReferenceDataset in bulk

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from dataworkspace.cel import celery_app
+from dataworkspace.apps.core.models import Database
 from dataworkspace.apps.applications.models import (
     ApplicationInstance,
     ApplicationInstanceDbUsers,
@@ -133,7 +134,7 @@ class ProcessSpawner:
             for creds in credentials:
                 ApplicationInstanceDbUsers.objects.create(
                     application_instance=application_instance,
-                    db_id=creds["db_id"],
+                    db_id=Database.objects.get(memorable_name=creds["memorable_name"]).id,
                     db_username=creds["db_user"],
                     db_persistent_role=creds["db_persistent_role"],
                 )
@@ -258,7 +259,7 @@ class FargateSpawner:
             for creds in credentials:
                 ApplicationInstanceDbUsers.objects.create(
                     application_instance=application_instance,
-                    db_id=creds["db_id"],
+                    db_id=Database.objects.get(memorable_name=creds["memorable_name"]).id,
                     db_username=creds["db_user"],
                     db_persistent_role=creds["db_persistent_role"],
                 )

--- a/dataworkspace/dataworkspace/apps/explorer/utils.py
+++ b/dataworkspace/dataworkspace/apps/explorer/utils.py
@@ -15,7 +15,6 @@ from django.contrib.auth.views import LoginView
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
 
-from dataworkspace.apps.core.models import Database
 from dataworkspace.apps.core.utils import (
     close_admin_db_connection_if_not_in_atomic_block,
     new_private_database_credentials,
@@ -193,9 +192,7 @@ def get_user_explorer_connection_settings(user, alias):
                     db_user,
                     user,
                     valid_for=duration,
-                    force_create_for_databases=Database.objects.filter(
-                        memorable_name__in=connections.keys()
-                    ).all(),
+                    force_create_for_databases=list(connections.keys()),
                 )
                 cache.set(cache_key, user_credentials, timeout=cache_duration)
 

--- a/test/test_application.py
+++ b/test/test_application.py
@@ -1637,7 +1637,6 @@ class TestApplication(unittest.TestCase):
         )
         assert superset_requests[0].headers["Credentials-Db-User"].endswith("superset")
         assert "Credentials-Db-Password" in superset_requests[0].headers
-        assert "Credentials-Db-Id" in superset_requests[0].headers
 
     @async_test
     async def test_superset_public_headers(self):


### PR DESCRIPTION
### Description of change

Looking at APM, we still have N+1 queries in Data Explorer in some cases for ReferenceDataset. Suspect this is due to code it has in its `__init__` method.

We could do more "selected_related" and/or "prefetch_related", but it's much easier, and robust, and likely quicker, to avoid these and call "values" that doesn't run` __init__` at all because model instances are not constructed.

Note that `Credentials-Db-Id` isn't used by Superset, and so can be removed.

### Checklist

* [ ] Have tests been added to cover any changes?
