### PR TITLE
fix: enter on search when there are suggested searches

### DIFF
--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -82,7 +82,7 @@ var LiveSearch = function (formSelector, wrapperSelector, GTM, linkSelector, GOV
 
   this.$form.on(
     "keydown",
-    "input[type=text]",
+    "input[type=search]",
     function (e) {
       if (e.keyCode == 13) {
         // 13 is the return key


### PR DESCRIPTION
### Description of change

We now have a search type of input rather than text, so we need to listen on type=search rather than type=text

### Checklist

* [ ] Have tests been added to cover any changes?
