### PR TITLE
perf: speculative removal of server side cursor for data grid

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1166,10 +1166,10 @@ class DataGridDataView(DetailView):
     @staticmethod
     def _get_rows(source, query, query_params):
         with psycopg2.connect(
-            database_dsn(settings.DATABASES_DATA[source.database.memorable_name])
+            database_dsn(settings.DATABASES_DATA[source.database.memorable_name]),
+            application_name="data-grid-data",
         ) as connection:
             with connection.cursor(
-                name="data-grid-data",
                 cursor_factory=psycopg2.extras.RealDictCursor,
             ) as cursor:
                 cursor.execute(query, query_params)


### PR DESCRIPTION
### Description of change

For some reason sometimes a server side cursor can make a query less performant. Here, we don't need to take that risk since we're fetching all the rows and loading them into memory anyway, so there is no benefit of a server side cursor.

To help debugging production issues, we now set application_name instead, which is viewable by (for example) pg_activity

### Checklist

* [ ] Have tests been added to cover any changes?
