### PR TITLE
feat: set statement timeout for data-grid queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1172,6 +1172,10 @@ class DataGridDataView(DetailView):
             with connection.cursor(
                 cursor_factory=psycopg2.extras.RealDictCursor,
             ) as cursor:
+                # This is in the request/response cycle, so by 60 seconds of execution,
+                # the user would have received a 504 anyway
+                statement_timeout = 60 * 1000
+                cursor.execute("SET statement_timeout = %s", (statement_timeout,))
                 cursor.execute(query, query_params)
                 return cursor.fetchall()
 


### PR DESCRIPTION
### Description of change

Suspecting that data grid queries were holding locks that prevented swap table task from running


### Checklist

* [ ] Have tests been added to cover any changes?
