### PR TITLE
fix: use queryset distinct to get team users

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/migrations/0011_auto_20221017_1448.py
+++ b/dataworkspace/dataworkspace/apps/core/migrations/0011_auto_20221017_1448.py
@@ -10,9 +10,9 @@ def migrate_team_members(apps, _):
     Loop through users with team membership and update their
     s3 perms to allow for team prefixes
     """
-    user_ids = {x.user_id for x in apps.get_model("core", "TeamMembership").objects.all()}
-    for user_id in user_ids:
-        update_tools_access_policy_task.delay(user_id)
+    users = apps.get_model("core", "TeamMembership").objects.values("user_id").distinct()
+    for user in users:
+        update_tools_access_policy_task.delay(user["user_id"])
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
### Description of change

Use `.distinct()` to get distinct users from the `TeamMembership` queryset as using a `set()` does not work

### Checklist

* [ ] Have tests been added to cover any changes?
