### PR TITLE
fix: use .localstack and ignore it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ ssl.crt
 node_modules
 dataworkspace/dataworkspace/static/*.css.map
 .local
+.localstack

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -77,7 +77,7 @@ services:
       - SERVICES=s3,sts,iam
       - EXTRA_CORS_ALLOWED_ORIGINS=http://dataworkspace.test:8000
     volumes:
-      - "./localstack:/tmp/localstack"
+      - "./.localstack:/tmp/localstack"
 
 volumes:
   db-data-dev:


### PR DESCRIPTION
### Description of change

small cleanup for the localstack work.

- Move the mounted config dir to `.localstack` as we don't need to see it. 
- Add `.localstack` to gitignore

### Checklist

* [ ] Have tests been added to cover any changes?
