### PR TITLE
feat: tweak spacing and sizes of shared team folder icon

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/FileList.jsx
+++ b/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/FileList.jsx
@@ -86,7 +86,8 @@ function TableRowSharedFolder(props) {
       >
           <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg"
                x="0px" y="0px"
-               width="80%" viewBox="0 0 400 400" enable-background="new 0 0 400 400">
+               width="80%" viewBox="0 0 400 400" enable-background="new 0 0 400 400"
+               style={{marginLeft: "-4px", marginTop: "7px", height: "30px"}}>
 <path fill="#FEFEFE" opacity="1.000000" stroke="none"
       d="
 M1.000000,149.000000


### PR DESCRIPTION
### Description of change

<img width="1162" alt="Screenshot 2022-10-22 at 09 14 35" src="https://user-images.githubusercontent.com/13877/197328646-7e92e950-adc6-4848-99ff-f989e351f9e7.png">

### Checklist

* [ ] Have tests been added to cover any changes?
