### PR TITLE
fix: re-select same file in Chrome

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/App.jsx
+++ b/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/App.jsx
@@ -105,6 +105,7 @@ export default class App extends React.Component {
       selectedFiles: files,
     });
     this.showPopup(popupTypes.UPLOAD_FILES);
+    this.fileInputRef.current.value = null;
   };
 
   onBreadcrumbClick = async (e, breadcrumb) => {


### PR DESCRIPTION
### Description of change

In Chrome, attempting to re-select the same file after doing it once didn't trigger the onChange event. Clearing the file input's value at the end of the change handler fixes this.

The behaviour was already correct in Firefox


https://user-images.githubusercontent.com/13877/197386025-e201b786-5f1b-4628-9c4f-99552b0c2c87.mov


### Checklist

* [ ] Have tests been added to cover any changes?
