### PR TITLE
feat: fix multipart upload (for large files) in local dev environment

### DIFF
--- a/localstack/init/buckets.sh
+++ b/localstack/init/buckets.sh
@@ -2,4 +2,7 @@
 set -x
 awslocal s3 mb s3://notebooks.dataworkspace.local
 awslocal s3 mb s3://uploads.dataworkspace.local
+# Multipart file uploads from Your Files in the browser require ETag to be
+# exposed but by default it's not, so we add a CORS config to expose it
+awslocal s3api put-bucket-cors --bucket notebooks.dataworkspace.local --cors-configuration file:///docker-entrypoint-initaws.d/s3-cors.json
 set +x

--- a/localstack/init/s3-cors.json
+++ b/localstack/init/s3-cors.json
@@ -1,0 +1,9 @@
+{
+  "CORSRules": [
+    {
+      "AllowedOrigins": ["http://dataworkspace.test:8000"],
+      "AllowedMethods": ["HEAD", "GET" , "PUT", "POST", "DELETE", "OPTIONS", "PATCH"],
+      "ExposeHeaders": ["etag"]
+    }
+  ]
+}


### PR DESCRIPTION
### Description of change

The etag header is needed for multipart uploads, but it wasn't configured to be accessible from Javascript, CORS-wise.

There is a localstack environment variable, EXTRA_CORS_EXPOSE_HEADERS, but that didn't seem to work - it only returned the header names in Access-Control-Expose-Headers in response to the preflight request, not the request proper where it needs to to be.

Suspect that there is some conflict between EXTRA_CORS_EXPOSE_HEADERS and the "proper" CORS config for S3, where the S3 config takes priority for certain requests.


https://user-images.githubusercontent.com/13877/197385699-a526b468-46d8-409e-8b0f-ac5b78e2f054.mov



### Checklist

* [ ] Have tests been added to cover any changes?
