### PR TITLE
feat: show upload and Delete errors

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/DeleteObjects.jsx
+++ b/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/DeleteObjects.jsx
@@ -29,7 +29,7 @@ function DeleteTableHeader() {
         <th
           scope="col"
           className="govuk-table__header govuk-table__header--numeric"
-          style={{ width: "6em" }}
+          style={{ width: "7em" }}
         >
           Status
         </th>
@@ -71,6 +71,7 @@ export class DeleteObjectsPopup extends React.Component {
     const maxConnections = 4;
     const queue = fileQueue(Math.min(maxConnections, numObjects));
 
+    var isErrored = false;
     var isAborted = false;
     var remainingDeleteCount = numObjects;
     var keysToDelete = [];
@@ -91,18 +92,25 @@ export class DeleteObjectsPopup extends React.Component {
     }
 
     const deleteKeys = async () => {
+      const rootFileOrFolders = keysToDelete.map(([rootFileOrFolder, key]) => rootFileOrFolder)
       try {
         await s3
           .deleteObjects({
             Bucket: bucketName,
-            Delete: { Objects: keysToDelete.map((key) => ({ Key: key })) },
+            Delete: { Objects: keysToDelete.map(([rootFileOrFolder, key]) => ({ Key: key })) },
           })
           .promise();
       } catch (err) {
-        console.error(err);
-        throw err;
+        isErrored = true;
+        for (const rootFileOrFolder of rootFileOrFolders) {
+          updateDeleteState(rootFileOrFolder, {deleteError: err.code || err.message || err })
+        }
+        throw err
       } finally {
         keysToDelete = [];
+      }
+      for (const rootFileOrFolder of rootFileOrFolders) {
+        updateDeleteState(rootFileOrFolder, { deleteFinished: true })
       }
     }
 
@@ -110,8 +118,8 @@ export class DeleteObjectsPopup extends React.Component {
       if (keysToDelete.length) await deleteKeys();
     }
 
-    const scheduleDelete = async (key) => {
-      keysToDelete.push(key);
+    const scheduleDelete = async (rootFolder, key) => {
+      keysToDelete.push([rootFolder, key]);
       if (keysToDelete.length > BULK_DELETE_MAX_FILES) {
         await deleteKeys();
       }
@@ -136,20 +144,14 @@ export class DeleteObjectsPopup extends React.Component {
             continuationToken = response.NextContinuationToken;
             isTruncated = response.IsTruncated;
           } catch (err) {
-            console.error(err);
+            isErrored = true;
             updateDeleteState(folder, { deleteError: err.code || err.message || err });
-            return;
+            throw err;
           }
           // ... and delete them
           for (let j = 0; j < response.Contents.length && !isAborted; ++j) {
-            try {
-              await scheduleDelete(response.Contents[j].Key);
-            } catch (err) {
-              updateDeleteState(folder, { deleteError: err.code || err.message || err });
-              return;
-            }
+            await scheduleDelete(folder, response.Contents[j].Key);
           }
-          updateDeleteState(folder, { deleteFinished: true });
         }
       });
     }
@@ -157,19 +159,18 @@ export class DeleteObjectsPopup extends React.Component {
       queue(async () => {
         if (isAborted) return;
         updateDeleteState(file, { deleteStarted: true });
-        try {
-          await scheduleDelete(file.Key);
-        } catch (err) {
-          updateDeleteState(file, { deleteError: err.code || err.message || err });
-        }
-        updateDeleteState(file, { deleteFinished: true });
+        await scheduleDelete(file, file.Key);
       });
     }
     queue(async () => {
       if (isAborted) return;
       await flushDelete();
+    });
+    queue(async () => {
       this.setState({ finished: true });
-      this.props.onSuccess();
+      if (!isErrored) {
+        this.props.onSuccess();
+      }
     });
   }
 
@@ -222,7 +223,7 @@ export class DeleteObjectsPopup extends React.Component {
 
                           {folder.deleteError ? (
                             <strong className={"govuk-tag progress-error"}>
-                              folder.deleteError
+                              {folder.deleteError}
                             </strong>
                           ) : null}
 

--- a/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/DeleteObjects.jsx
+++ b/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/DeleteObjects.jsx
@@ -120,7 +120,7 @@ export class DeleteObjectsPopup extends React.Component {
 
     const scheduleDelete = async (rootFolder, key) => {
       keysToDelete.push([rootFolder, key]);
-      if (keysToDelete.length > BULK_DELETE_MAX_FILES) {
+      if (keysToDelete.length >= BULK_DELETE_MAX_FILES) {
         await deleteKeys();
       }
     }

--- a/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/UploadFiles.jsx
+++ b/dataworkspace/dataworkspace/static/js/react_apps/src/your-files/popups/UploadFiles.jsx
@@ -19,7 +19,7 @@ function UploadHeaderRow() {
       </th>
       <th
         className="govuk-table__header govuk-table__header--numeric"
-        style={{ width: "6em" }}
+        style={{ width: "7em" }}
       >
         Status
       </th>
@@ -37,7 +37,7 @@ function UploadFileRow(props) {
       </td>
       <td className="govuk-table__cell govuk-table__cell--numeric govuk-table__cell-progress">
         {props.file.progress === undefined &&
-        props.file.errors === undefined ? (
+        props.file.error === undefined ? (
           <span>...</span>
         ) : null}
 
@@ -49,8 +49,8 @@ function UploadFileRow(props) {
         {/*<strong ng-if="file.progress !== undefined && file.error === undefined" className="govuk-tag progress-percentage" ng-class="{'progress-percentage-complete': file.progress == 100}">{{ file.progress + '%' }}</strong>*/}
 
         {props.file.error !== undefined ? (
-          <strong className="govuk-tag progress-error" title="{ file.error }">
-            {file.error}
+          <strong className="govuk-tag progress-error" title="{ props.file.error }">
+            {props.file.error}
           </strong>
         ) : null}
 
@@ -111,6 +111,7 @@ export class UploadFilesPopup extends React.Component {
     const prefix = this.props.currentPrefix;
 
     const files = this.state.selectedFiles
+    var isErrored = false;
     var isAborted = false;
     var remainingUploadCount = files.length;
     var uploads = [];
@@ -141,16 +142,21 @@ export class UploadFilesPopup extends React.Component {
             }).promise();
           }
         } catch (err) {
-          if (!isAborted) {
-            console.error(err);
-          }
+          isErrored = true;
+          file.error = err.code || err.message || err;
+          this.setState({
+            selectedFiles: files
+          })
+          throw err
         } finally {
           remainingUploadCount--;
         }
 
         if (remainingUploadCount === 0) {
           this.setState({ uploadsComplete: true, isUploading: false });
-          onComplete();
+          if (!isErrored) {
+            onComplete();
+          }f
         }
       });
     }


### PR DESCRIPTION
### Description of change

The delete one is slightly tricky since

- A user might have selected a folder which has lots of files
- And then files are deleted in batches, combining files inside folders and specifically selected

So a single selected item can correspond to multiple requests any of which can fail, and a single request can correspond to multiple selected items.

https://user-images.githubusercontent.com/13877/197370338-664183c7-f398-41ae-bbee-9e3dd19e57b5.mov



### Checklist

* [ ] Have tests been added to cover any changes?
