### PR TITLE
fix: html structure/spacing on collection page

### DIFF
--- a/dataworkspace/dataworkspace/templates/data_collections/collection_detail.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_detail.html
@@ -35,53 +35,52 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <h2 class="govuk-heading-l">Data</h2>
-      </div>
-    <div class="govuk-grid-column-one-third">
-        <h2 class="govuk-heading-s">Owner</h2>
-        <p class="govuk-body">{{ source_object.owner.get_full_name|default_if_none:"Not assigned" }}<br>{% if source_object.owner %}(<a href="mailto:{{ source_object.owner.email }}">{{ source_object.owner.email }}</a>){% endif %}</p>
-      </div>
-    </div>
-      <div class="search-result" style="border-bottom: none">
-        {% for dataset in source_object.datasets.all %}
-          <h3 class="govuk-heading-m">
-            <a class="govuk-heading-m govuk-link dataset-link"
-               href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}">{{ dataset.name }}</a>
-          </h3>
-          <p class="govuk-body">{{ dataset.short_description }}</p>
-          <div class="govuk-body">
-            <dl>
-              <dt>Data type:</dt>
-              <dd>{{ dataset.get_type_display }}</dd>
-              <dt>Last updated:</dt>
-              <dd>
-                {{ dataset.last_updated|date_with_gmt_offset|default_if_none:"N/A" }}
-              </dd>
-              <dt>Source:</dt>
-              <dd>
-                {% for source in dataset.sources %}
-                  <a class="govuk-link"
-                     href="{% url "datasets:find_datasets" %}?source={{ source.id }}">{{ source.name }}</a>
-                  {% empty %}
-                  N/A
-                {% endfor %}
-              </dd>
-              {% if dataset.topics %}
-                <dt>Topics:</dt>
+        <div class="search-result" style="border-bottom: none">
+          {% for dataset in source_object.datasets.all %}
+            <h3 class="govuk-heading-m">
+              <a class="govuk-heading-m govuk-link dataset-link"
+                 href="{% url "datasets:dataset_detail" dataset_uuid=dataset.id %}">{{ dataset.name }}</a>
+            </h3>
+            <p class="govuk-body">{{ dataset.short_description }}</p>
+            <div class="govuk-body">
+              <dl>
+                <dt>Data type:</dt>
+                <dd>{{ dataset.get_type_display }}</dd>
+                <dt>Last updated:</dt>
                 <dd>
-                  {% for topic in dataset.topics %}
+                  {{ dataset.last_updated|date_with_gmt_offset|default_if_none:"N/A" }}
+                </dd>
+                <dt>Source:</dt>
+                <dd>
+                  {% for source in dataset.sources %}
                     <a class="govuk-link"
-                       href="{% url "datasets:find_datasets" %}?topic={{ topic.id }}">{{ topic.name }}</a>
+                       href="{% url "datasets:find_datasets" %}?source={{ source.id }}">{{ source.name }}</a>
                     {% empty %}
-                    &nbsp;
+                    N/A
                   {% endfor %}
                 </dd>
-              {% endif %}
-            </dl>
-          </div>
-        {% endfor %}
-        <p class="govuk-body" style="margin-bottom: 40px"><a href="">Search for data</a> you'd like to add.</p>
-        </div><h2 class="govuk-heading-l">Dashboards</h2>
-        <p class="govuk-body"><a href="https://data.trade.gov.uk/datasets/?q=&sort=relevance&data_type=3">Search for
-          dashboards</a> you'd like to add.</p>
+                {% if dataset.topics %}
+                  <dt>Topics:</dt>
+                  <dd>
+                    {% for topic in dataset.topics %}
+                      <a class="govuk-link"
+                         href="{% url "datasets:find_datasets" %}?topic={{ topic.id }}">{{ topic.name }}</a>
+                      {% empty %}
+                      &nbsp;
+                    {% endfor %}
+                  </dd>
+                {% endif %}
+              </dl>
+            </div>
+          {% endfor %}
+          <p class="govuk-body" style="margin-bottom: 40px"><a href="">Search for data</a> you'd like to add.</p>
+          </div><h2 class="govuk-heading-l">Dashboards</h2>
+          <p class="govuk-body"><a href="https://data.trade.gov.uk/datasets/?q=&sort=relevance&data_type=3">Search for
+            dashboards</a> you'd like to add.</p>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <h2 class="govuk-heading-s">Owner</h2>
+      <p class="govuk-body">{{ source_object.owner.get_full_name|default_if_none:"Not assigned" }}<br>{% if source_object.owner %}(<a href="mailto:{{ source_object.owner.email }}">{{ source_object.owner.email }}</a>){% endif %}</p>
+    </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
### Description of change

The "Owner" section was between the "Data" title and the list of data items. This caused some strange spacing.

<img width="1321" alt="Screenshot 2022-11-01 at 14 05 14" src="https://user-images.githubusercontent.com/13877/199253008-c1b36783-aeca-4488-a0dd-d508a5326ecc.png">


DT-739

### Checklist

* [ ] Have tests been added to cover any changes?
