### PR TITLE
fix: don't break event log when we can't reverse a related object to URL

### DIFF
--- a/dataworkspace/dataworkspace/apps/eventlog/admin.py
+++ b/dataworkspace/dataworkspace/apps/eventlog/admin.py
@@ -42,14 +42,17 @@ class EventLogAdmin(admin.ModelAdmin):
             return None
 
         try:
-            url = reverse(
-                admin_urlname(obj.related_object._meta, "change"),
-                args=(obj.related_object.id,),
-            )
+            try:
+                url = reverse(
+                    admin_urlname(obj.related_object._meta, "change"),
+                    args=(obj.related_object.id,),
+                )
+            except NoReverseMatch:
+                url = reverse("datasets:dataset_detail", args=(obj.related_object.id,))
         except NoReverseMatch:
-            url = reverse("datasets:dataset_detail", args=(obj.related_object.id,))
-
-        return format_html(f'<a href="{url}">{obj.related_object}</a>')
+            return str(obj.related_object)
+        else:
+            return format_html(f'<a href="{url}">{obj.related_object}</a>')
 
     related_object_link.short_description = "Related Object"
 


### PR DESCRIPTION
### Description of change

Suspect that the log addition to fb7a273e268418ea73f8b04e310e5286aed9ef0d broke the event log page in Django admin. Need to figure out something better, i.e. linking to something

DT-739

### Checklist

* [ ] Have tests been added to cover any changes?
