### PR TITLE
build(deps): bump d3-color and remove no-long needed resolutions

### DIFF
--- a/dataworkspace/dataworkspace/static/js/react_apps/package-lock.json
+++ b/dataworkspace/dataworkspace/static/js/react_apps/package-lock.json
@@ -2875,11 +2875,6 @@
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
-    "d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-    },
     "d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
@@ -2907,6 +2902,13 @@
       "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
         "d3-color": "1"
+      },
+      "dependencies": {
+        "d3-color": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+          "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+        }
       }
     },
     "d3-path": {

--- a/dataworkspace/dataworkspace/static/js/react_apps/package.json
+++ b/dataworkspace/dataworkspace/static/js/react_apps/package.json
@@ -39,10 +39,6 @@
     "format": "prettier src/your-files --write"
   },
   "resolutions": {
-    "ansi-regex": "5.0.1",
-    "glob-parent": "5.1.2",
-    "node-fetch": "2.6.7",
-    "node-forge": "1.3.0",
     "d3-color": "3.1.0"
   },
   "author": "",


### PR DESCRIPTION
### Description of change

The change in 4cfde1c961966832050793b93edb0c75056e0c05 was committed without an `npm install` which runs force-resolutions, so have now run that. Also noticed that some dependencies don't need to be in resolutions any more it seems, so removed to allow them to be upgraded.

DT-773

### Checklist

* [ ] Have tests been added to cover any changes?
