### PR TITLE
feat: add fields to CatalogueItemsInstance viewset on API

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -46,6 +46,10 @@ class CatalogueItemSerializer(serializers.Serializer):
     eligibility_criteria = serializers.ListField()
     source_tables = serializers.SerializerMethodField()
     slug = serializers.CharField()
+    licence_url = serializers.CharField()
+    restrictions_on_usage = serializers.CharField()
+    user_access_type = serializers.CharField()
+    authorized_email_domains = serializers.ListField()
     is_draft = serializers.BooleanField(source="draft")
     dictionary_published = serializers.BooleanField(source="dictionary")
 
@@ -61,6 +65,8 @@ class CatalogueItemSerializer(serializers.Serializer):
         instance["licence"] = instance["licence"] or None
         instance["personal_data"] = instance["personal_data"] or None
         instance["retention_policy"] = instance["retention_policy"] or None
+        instance["user_access_type"] = instance["user_access_type"]
+        instance["authorized_email_domains"] = instance["authorized_email_domains"]
         return instance
 
     def get_source_tables(self, instance):

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -328,6 +328,10 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "personal_data",
         "retention_policy",
         "eligibility_criteria",
+        "licence_url",
+        "restrictions_on_usage",
+        "user_access_type",
+        "authorized_email_domains",
     ]
     queryset = (
         DataSet.objects.live()
@@ -348,6 +352,8 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             .annotate(personal_data=_static_char(None))
             .annotate(retention_policy=_static_char(None))
             .annotate(eligibility_criteria=_static_char(None))
+            .annotate(user_access_type=_static_int(None))
+            .annotate(authorized_email_domains=_static_int(None))
             .annotate(purpose=_static_int(DataSetType.REFERENCE))
             .annotate(
                 source_tags=ArrayAgg(

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -465,6 +465,14 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             if dataset.type == DataSetType.MASTER
             else [],
             "slug": dataset.slug,
+            "licence_url": dataset.licence_url,
+            "restrictions_on_usage": dataset.restrictions_on_usage,
+            "user_access_type": None
+            if isinstance(dataset, ReferenceDataset)
+            else str(dataset.user_access_type),
+            "authorized_email_domains": None
+            if isinstance(dataset, ReferenceDataset)
+            else dataset.authorized_email_domains,
         }
 
     def test_success(self, unauthenticated_client):


### PR DESCRIPTION
### Description of change
The following fields are recorded in Django but are not present in public.dataworkspace__catalogue_items

a.       License url

b.       Restrictions on usage

c.       User access type

d.       Authorised email domains

DNA-178

### Checklist

* [ ] Have tests been added to cover any changes?
