### PR TITLE
Fix/manage users spacing

### DIFF
--- a/dataworkspace/dataworkspace/templates/data_collections/collection_users.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_users.html
@@ -88,7 +88,9 @@
                   <dd class="govuk-summary-list__actions">
                     <form method="POST" action="{% url 'data_collections:remove-user' collection.id membership.id %}" >
                       {% csrf_token %}
-                      <button type="submit" class="govuk-button govuk-!-margin-bottom-0" aria-label="Remove {{ membership.user.get_full_name }} from this collection">Remove access</button>
+                      <button type="submit" class="govuk-button govuk-!-margin-bottom-0 govuk-!-font-size-16 govuk-!-padding-top-1
+                      govuk-!-padding-bottom-1 govuk-!-padding-left-2 govuk-!-padding-right-2" 
+                      aria-label="Remove {{ membership.user.get_full_name }} from this collection">Remove access</button>
                     </form>
                   </dd>
                 </div>

--- a/dataworkspace/dataworkspace/templates/data_collections/collection_users.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_users.html
@@ -73,17 +73,17 @@
         <div class="govuk-grid-column-full">
           <dl class="govuk-summary-list">
             <div class="govuk-summary-list__row">
-              <dd class="govuk-summary-list__value">
-                <p class="govuk-body govuk-!-font-weight-bold">{{ collection.owner.get_full_name }} <span class="govuk-!-font-weight-regular">(Owner)</span></p>
-                <p class="govuk-body">{{ collection.owner.email }}</p>
+              <dd class="govuk-summary-list__key">
+                {{ collection.owner.get_full_name }} <span class="govuk-!-font-weight-regular">(Owner)</span>
+                <span class="govuk-!-display-block govuk-!-font-weight-regular">{{ collection.owner.email }}</span>
               </dd>
               <dd class="govuk-summary-list__actions"></dd>
             </div>
                 {% for membership in user_memberships %}
                 <div class="govuk-summary-list__row">
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body govuk-!-font-weight-bold">{{ membership.user.get_full_name }}</p>
-                    <p class="govuk-body">{{ membership.user.email }}</p>
+                  <dd class="govuk-summary-list__key">
+                    {{ membership.user.get_full_name }}
+                    <span class="govuk-!-display-block govuk-!-font-weight-regular">{{ membership.user.email }}</span>
                   </dd>
                   <dd class="govuk-summary-list__actions">
                     <form method="POST" action="{% url 'data_collections:remove-user' collection.id membership.id %}" >


### PR DESCRIPTION
### Description of change
As per ticket DT-854

- Adjusted spacing around list items to match visualisation manage users page
- Adjusted button sizing and spacing to match visualisation manage users page

<img width="1440" alt="Screenshot 2022-11-18 at 12 52 55" src="https://user-images.githubusercontent.com/116172079/202709865-7af9fc7d-d9e3-48c8-b84a-79391bdba987.png">

### Checklist

* [ ] Have tests been added to cover any changes?
