### PR TITLE
feat: make catalogue page description on front end editable

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/forms.py
+++ b/dataworkspace/dataworkspace/apps/applications/forms.py
@@ -58,7 +58,11 @@ class VisualisationsUICatalogueItemForm(GOVUKDesignSystemModelForm):
         widget=GOVUKDesignSystemTextWidget(label_is_heading=False),
         error_messages={"required": "The visualisation must have a summary"},
     )
-
+    description = GOVUKDesignSystemCharField(
+        label="Description",
+        required=False,
+        widget=GOVUKDesignSystemTextareaWidget(label_is_heading=False),
+    )
     enquiries_contact = GOVUKDesignSystemEmailValidationModelChoiceField(
         label="Enquiries contact",
         queryset=get_user_model().objects.all(),
@@ -165,7 +169,6 @@ class VisualisationsUICatalogueItemForm(GOVUKDesignSystemModelForm):
             "eligibility_criteria",
         ]
         widgets = {"retention_policy": Textarea, "restrictions_on_usage": Textarea}
-        labels = {"description": "Description"}
 
     def __init__(self, *args, **kwargs):
         kwargs["initial"] = kwargs.get("initial", {})

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -41,12 +41,7 @@
 
   {{ form.short_description }}
 
-  <div class="govuk-form-group">
-    <label class="govuk-label" for="id_description">
-      Description
-    </label>
-    {{ form.description }}
-  </div>
+  {{ form.description }}
 
   {{ form.enquiries_contact }}
   {{ form.secondary_enquiries_contact }}


### PR DESCRIPTION
### Description of change
When trying to fill in these details for publication, the box appears but can't be edited/added to. This then prevents users from publishing and requires us to add descriptions on the admin side.

### Checklist

* [ ] Have tests been added to cover any changes?
