### PR TITLE
fix: convert descriptions to rich text fields for datasets and catalogue items

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/forms.py
+++ b/dataworkspace/dataworkspace/apps/applications/forms.py
@@ -21,6 +21,7 @@ from dataworkspace.forms import (
     GOVUKDesignSystemCharField,
     GOVUKDesignSystemEmailValidationModelChoiceField,
     GOVUKDesignSystemBooleanField,
+    GOVUKDesignSystemRichTextField,
 )
 
 
@@ -58,10 +59,8 @@ class VisualisationsUICatalogueItemForm(GOVUKDesignSystemModelForm):
         widget=GOVUKDesignSystemTextWidget(label_is_heading=False),
         error_messages={"required": "The visualisation must have a summary"},
     )
-    description = GOVUKDesignSystemCharField(
-        label="Description",
+    description = GOVUKDesignSystemRichTextField(
         required=False,
-        widget=GOVUKDesignSystemTextareaWidget(label_is_heading=False),
     )
     enquiries_contact = GOVUKDesignSystemEmailValidationModelChoiceField(
         label="Enquiries contact",

--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -22,6 +22,7 @@ from ...forms import (
     GOVUKDesignSystemTextareaWidget,
     GOVUKDesignSystemPlainTextareaWidget,
     GOVUKDesignSystemPlainTextareaField,
+    GOVUKDesignSystemRichTextField,
 )
 
 logger = logging.getLogger("app")
@@ -468,11 +469,7 @@ class DatasetEditForm(GOVUKDesignSystemModelForm):
         ),
         error_messages={"required": "You must provide a short description for this dataset."},
     )
-    description = GOVUKDesignSystemCharField(
-        label="Description *",
-        widget=GOVUKDesignSystemTextareaWidget(
-            label_is_heading=False, extra_label_classes="govuk-!-font-weight-bold"
-        ),
+    description = GOVUKDesignSystemRichTextField(
         error_messages={"required": "You must provide a description for this dataset."},
     )
     enquiries_contact = GOVUKDesignSystemCharField(

--- a/dataworkspace/dataworkspace/templates/datasets/edit_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/edit_dataset.html
@@ -41,6 +41,9 @@
                 <fieldset class="govuk-fieldset">
                     {{ form.name }}
                     {{ form.short_description }}
+                    <label class="govuk-label  govuk-!-font-weight-bold" for="id_description">
+                      Description *
+                    </label>
                     {{ form.description }}
                     <div class="govuk-form-group {% if form.enquiries_contact.errors %}govuk-form-group--error{% endif %}">
                         <label class="govuk-label  govuk-!-font-weight-bold" for="id_information_asset_owner">
@@ -92,3 +95,7 @@
         </div>
     </div>
 {% endblock %}
+
+{% block footer_scripts %}
+  {{ form.media }}
+{% endblock footer_scripts %}

--- a/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_catalogue_item.html
@@ -41,7 +41,12 @@
 
   {{ form.short_description }}
 
-  {{ form.description }}
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="id_description">
+      Description
+    </label>
+    {{ form.description }}
+  </div>
 
   {{ form.enquiries_contact }}
   {{ form.secondary_enquiries_contact }}
@@ -62,6 +67,7 @@
 {% endblock %}
 
 {% block footer_scripts %}
+  {{ form.media }}
   {{ block.super }}
 
   <script nonce="{{ request.csp_nonce }}">


### PR DESCRIPTION
### Description of change
Convert descriptions in both the dataset and catalogue item front end edit UI to rich text fields

### Checklist

* [ ] Have tests been added to cover any changes?
