### PR TITLE
fix: force mobius3 to use ipv4 only

### DIFF
--- a/s3sync/Dockerfile
+++ b/s3sync/Dockerfile
@@ -1,17 +1,27 @@
-FROM alpine:3.16
+FROM debian:bullseye
+
+RUN \
+	# Try to disable ipv6 AAAA lookups, which our DNS rewrite proxy doesn't support
+	# Not 100% sure that this really does have an effect
+	echo "precedence ::ffff:0:0/96  100" >> /etc/gai.conf
+
+RUN \
+	apt update && \
+	apt install -y sudo python3-pip && \
+	apt autoremove -y && \
+	apt autoclean -y && \
+	rm -rf /tmp/* && \
+	rm -rf /var/lib/apt/lists/*
+
+RUN \
+	addgroup --system --gid 4356 s3sync && \
+	adduser --disabled-password --gecos '' --ingroup s3sync --uid 4357 s3sync
 
 COPY requirements.txt /app/
-RUN \
-	apk add --no-cache \
-		py3-pip \
-		python3 && \
-	pip3 install \
-		-r /app/requirements.txt
 
 RUN \
-	apk add sudo && \
-	addgroup -S -g 4356 s3sync && \
-	adduser -S -u 4357 s3sync -G s3sync
+	pip3 install \
+		-r /app/requirements.txt
 
 COPY start.sh /
 

--- a/s3sync/requirements.txt
+++ b/s3sync/requirements.txt
@@ -12,17 +12,15 @@ certifi==2022.9.24
     #   httpx
 fifolock==0.0.20
     # via mobius3
-h11==0.12.0
+h11==0.14.0
     # via httpcore
-httpcore==0.15.0
+httpcore==0.16.2
     # via httpx
-httpx==0.23.0
+httpx==0.23.1
     # via mobius3
 idna==3.4
-    # via
-    #   anyio
-    #   rfc3986
-mobius3==0.0.37
+    # via anyio
+mobius3==0.0.38
     # via -r requirements.in
 rfc3986[idna2008]==1.5.0
     # via httpx

--- a/s3sync/start.sh
+++ b/s3sync/start.sh
@@ -23,4 +23,5 @@ sudo -E -u s3sync mobius3 \
     --credentials-source ecs-container-endpoint \
     --exclude-remote '(.*(/|^)\.checkpoints/)|(.*(/|^)bigdata/.*)' \
     --exclude-local '(.*(/|^)\.__mobius3_flush__.*)|(.*(/|^)bigdata/.*)|.*(/|^)\.vnc/.*' \
-    --upload-on-create '^.*/\.git/.*$'
+    --upload-on-create '^.*/\.git/.*$' \
+    --force-ipv4


### PR DESCRIPTION
### Description of change

It looks like s3sync wasn't responding well to AAAA request failures from our DNS Rewrite proxy. Rather than supporting AAAA, trying best to not use ipv6 to KISS (since this is all internal).

The main thing that I think makes this more robust is the move to Debian and trying to get it to prefer A records.  Although I still see requests in the DNS rewrite proxy for AAAA records, s3sync doesn't seem to be going wrong in response to them. While it's not great to not completely understand everything that's going on, might have to live with the fact that this seems to be working now.

Requires merge and release of https://github.com/uktrade/mobius3/pull/50 

### Checklist

* [ ] Have tests been added to cover any changes?
