### PR TITLE
Feat: DT-888 create collection when adding dataset

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/forms.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/forms.py
@@ -2,6 +2,7 @@ import re
 
 from django import forms
 from django.contrib.auth import get_user_model
+from django.shortcuts import redirect
 
 from dataworkspace.apps.data_collections.models import (
     Collection,
@@ -33,6 +34,9 @@ class SelectCollectionForMembershipForm(GOVUKDesignSystemForm):
         self.user_collections = kwargs.pop("user_collections")
         super().__init__(*args, **kwargs)
         self.fields["collection"].choices = ((x.id, x.name) for x in self.user_collections)
+        self.fields["collection"].choices.append(
+            ("add_to_new_collection", "Add to new collection")
+        )
 
     def clean_collection(self):
         collection = self.cleaned_data.get("collection")

--- a/dataworkspace/dataworkspace/apps/data_collections/urls.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/urls.py
@@ -80,4 +80,24 @@ urlpatterns = [
         name="collection-create",
     ),
     path("", login_required(views.CollectionListView.as_view()), name="collections-list"),
+    path(
+        "create/dataset/<uuid:dataset_id>",
+        login_required(views.CollectionCreateView.as_view()),
+        {
+            "dataset_class": DataSet,
+            "membership_model_class": CollectionDatasetMembership,
+            "membership_model_relationship_name": "dataset",
+        },
+        name="collection-create-with-selected-dataset",
+    ),
+    path(
+        "create/visualisation/<uuid:dataset_id>",
+        login_required(views.CollectionCreateView.as_view()),
+        {
+            "dataset_class": VisualisationCatalogueItem,
+            "membership_model_class": CollectionVisualisationCatalogueItemMembership,
+            "membership_model_relationship_name": "visualisation",
+        },
+        name="collection-create-with-selected-visualisation",
+    ),
 ]

--- a/dataworkspace/dataworkspace/templates/data_collections/select_collection_for_membership.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/select_collection_for_membership.html
@@ -30,14 +30,30 @@
         <div class="govuk-grid-column-two-thirds">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">Select a collection</h1>
           {% include 'design_system/error_summary.html' with form=form %}
-          <form method="post" id="add-form">
-            {% csrf_token %}
-            {{ form.collection }}
+          {% if form.collection|length > 1 %}
+            <form method="post" id="add-form">
+            <p class="govuk-hint">{{ form.collection.label }}</p>
+              {% csrf_token %}
+              {% for collection in form.collection %}
+                {% if collection != form.collection|last %}
+                  {{ collection }}
+                {% endif %}
+              {% endfor %}
+              <p class="govuk-body">or</p>
+              {{ form.collection|last }}
+              <div class="govuk-button-group">
+                <input class="govuk-button govuk-!-margin-top-2" type="submit" value="Continue">
+                <a class="govuk-link govuk-link--no-visited-state" href="{{ dataset.get_absolute_url }}">Cancel</a>
+              </div>
+            </form>
+          {% else %}
+            <p class="govuk-body govuk-!-margin-top-6">You don't currently have any collections</p>
             <div class="govuk-button-group">
-              <input class="govuk-button" type="submit" value="Continue">
-              <a class="govuk-link govuk-link--no-visited-state" href="{{ dataset.get_absolute_url }}">Cancel</a>
+              <a class="govuk-button govuk-!-margin-top-2"
+                 href="{{ collection_url }}">Create
+                a collection</a>
             </div>
-          </form>
+          {% endif %}
         </div>
       </div>
     </main>


### PR DESCRIPTION
### Description of change
Following [DT-3: Ability to create a CollectionDONE](https://uktrade.atlassian.net/browse/DT-3) we need to update the “Select a collection” screen so that users can create a collection as part of the “add item” journey.

It includes:

Handling when a user has no collections to add to, by giving them the option to create their first collection

If they do have collections, adding a final 'Add to new collection' radio option to the Select a collection screen

### Checklist

* [ ] Have tests been added to cover any changes?
