### PR TITLE
feat: DT-532 - Allow user to delete a collection

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/urls.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/urls.py
@@ -80,4 +80,14 @@ urlpatterns = [
         name="collection-create",
     ),
     path("", login_required(views.CollectionListView.as_view()), name="collections-list"),
+    path(
+        "<uuid:collections_id>/delete",
+        login_required(views.remove_collection_confirmation),
+        name="remove-collection-confirmation",
+    ),
+    path(
+        "<uuid:collections_id>/delete-confirmed",
+        login_required(views.remove_collection),
+        name="remove-collection",
+    ),
 ]

--- a/dataworkspace/dataworkspace/apps/data_collections/views.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/views.py
@@ -440,3 +440,28 @@ class CollectionListView(ListView):
         context["shared_collections_to_user"] = shared_collections_to_user
 
         return context
+
+
+@require_http_methods(["GET"])
+def remove_collection_confirmation(request, collections_id):
+    collection = get_authorised_collection(request, collections_id)
+
+    context = {
+        "collection": collection,
+        "action_url": reverse(
+            "data_collections:remove-collection",
+            kwargs={
+                "collections_id": collection.id,
+            },
+        ),
+    }
+    return render(request, "data_collections/delete_collection_confirmation_screen.html", context)
+
+
+@require_http_methods(["POST"])
+def remove_collection(request, collections_id):
+    collection = get_authorised_collection(request, collections_id)
+    collection.deleted = True
+    collection.save()
+    messages.success(request, f"{collection.name} collection has been deleted")
+    return HttpResponseRedirect(reverse("data_collections:collections-list"))

--- a/dataworkspace/dataworkspace/templates/data_collections/collection_form.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_form.html
@@ -49,7 +49,7 @@
             {% csrf_token %}
             {{ form.name }}
             {{ form.description }}
-            <div class="govuk-button-group">
+            <div class="govuk-button-group" style="display: inline">
               <button class="govuk-button" data-module="govuk-button">
                 Save
               </button>
@@ -59,6 +59,12 @@
                >
                  Cancel
                </a>
+            {% if collection %}
+              <a class="govuk-button govuk-button--warning" style="float: right" data-module="govuk-button"
+                 href="{% url 'data_collections:remove-collection-confirmation' collections_id=collection.id %}">
+                Delete
+              </a>
+            {% endif %}
             </div>
           </form>
         </div>

--- a/dataworkspace/dataworkspace/templates/data_collections/collections.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collections.html
@@ -16,6 +16,7 @@
 {% block main %}
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper" id="main-content" role="main">
+    {% include 'partials/messages.html' %}
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-6 govuk-!-margin-top-3">

--- a/dataworkspace/dataworkspace/templates/data_collections/delete_collection_confirmation_screen.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/delete_collection_confirmation_screen.html
@@ -1,0 +1,44 @@
+{% extends '_main.html' %}
+{% load core_tags %}
+{% load datasets_tags %}
+
+{% block initialGTMDataLayer %}
+  {{ block.super }}
+  <script nonce='{{ request.csp_nonce }}'>
+    document.addEventListener('DOMContentLoaded', function() {
+      document.getElementById("remove-form").addEventListener("submit", function() {
+        window.dataLayer.push({
+          'event': 'GAEvent',
+          'eventCategory': 'Collection',
+          'eventAction': 'Remove item',
+          'eventLabel': '{{ collection.name }} ({{ collection.id }})'
+        })
+      });
+    });
+  </script>
+{% endblock %}
+
+{% block page_title %}
+  Remove {{ collection.name }}
+{% endblock %}
+
+{% block go_back %}<a class="govuk-back-link govuk-link--no-visited-state" href="{{ collection.get_absolute_url }}">Back</a>{% endblock %}
+
+{% block content %}
+<form action="{{ action_url }}" method="POST" novalidate id="remove-form">
+  {% csrf_token %}
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          Are you sure you want to delete {{ collection.name }} collection?
+        </h1>
+      </legend>
+    </fieldset>
+    <div class="govuk-button-group">
+      <button class="govuk-button govuk-button--warning" data-module="govuk-button" type="submit">Yes, delete this collection</button>
+      <a class="govuk-link govuk-link--no-visited-state" href="{{ collection.get_absolute_url }}">Cancel</a>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/dataworkspace/dataworkspace/tests/data_collections/test_views.py
+++ b/dataworkspace/dataworkspace/tests/data_collections/test_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from dataworkspace.tests import factories
 from dataworkspace.tests.conftest import get_client, get_user_data
-from dataworkspace.apps.data_collections.models import CollectionUserMembership
+from dataworkspace.apps.data_collections.models import CollectionUserMembership, Collection
 
 
 def test_collection(client, user):
@@ -802,3 +802,17 @@ def test_collections_page(client, user):
     # Need to flesh this out with collections this user owns and is a member of and those they are not allowed to access
     response = client.get(reverse("data_collections:collections-list"))
     assert response.status_code == 200
+
+
+def test_collection_successfully_removed(client, user):
+    c = factories.CollectionFactory.create(name="test-collections", owner=user)
+    collection_objects = Collection.objects.all().count()
+    response = client.post(
+        reverse(
+            "data_collections:remove-collection",
+            kwargs={"collections_id": c.id},
+        ),
+        follow=True,
+    )
+    assert response.status_code == 200
+    assert Collection.objects.live().count() == collection_objects - 1


### PR DESCRIPTION
### Description of change
This is the ability for Collection owners to delete collections (although they are not actually deleted in Django admin, so we can restore them if necessary).

It includes:

Confirmation screen

The delete action itself

### Checklist

* [X] Have tests been added to cover any changes?
