### PR TITLE
Feat: DT-915 - add columns to collection admin list display

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/admin.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/admin.py
@@ -102,7 +102,7 @@ class CollectionAdmin(CSPRichTextEditorMixin, DeletableTimeStampedUserAdmin):
         "datasets_count",
         "dashboards_count",
         "users_count",
-        "notes_truncated",
+        "notes_available",
         "owner",
         "deleted",
     )
@@ -122,13 +122,17 @@ class CollectionAdmin(CSPRichTextEditorMixin, DeletableTimeStampedUserAdmin):
     )
 
     def get_queryset(self, request):
-        return self.model.objects.all().annotate(
-            datasets_count=Count("datasets", filter=Q(datasets__deleted=False)),
-            dashboards_count=Count(
-                "visualisation_catalogue_items",
-                filter=Q(visualisation_catalogue_items__deleted=False),
-            ),
-            users_count=Count("user_memberships", filter=Q(user_memberships__deleted=False)),
+        return (
+            super()
+            .get_queryset(request)
+            .annotate(
+                datasets_count=Count("datasets", filter=Q(datasets__deleted=False)),
+                dashboards_count=Count(
+                    "visualisation_catalogue_items",
+                    filter=Q(visualisation_catalogue_items__deleted=False),
+                ),
+                users_count=Count("user_memberships", filter=Q(user_memberships__deleted=False)),
+            )
         )
 
 

--- a/dataworkspace/dataworkspace/apps/data_collections/admin.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/admin.py
@@ -95,7 +95,14 @@ class CollectionUserItemMembershipInlineAdmin(admin.TabularInline):
 
 
 class CollectionAdmin(CSPRichTextEditorMixin, DeletableTimeStampedUserAdmin):
-    list_display = ("name", "description", "owner")
+    list_display = (
+        "name",
+        "datasets_count",
+        "dashboards_count",
+        "users_count",
+        "notes_truncated",
+        "owner",
+    )
     search_fields = ["name"]
     fieldsets = [
         (

--- a/dataworkspace/dataworkspace/apps/data_collections/admin.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Count, Q
 from dataworkspace.apps.data_collections.forms import (
     CollectionDatasetForm,
     CollectionUserForm,
@@ -121,7 +122,14 @@ class CollectionAdmin(CSPRichTextEditorMixin, DeletableTimeStampedUserAdmin):
     )
 
     def get_queryset(self, request):
-        return self.model.objects.all()
+        return self.model.objects.all().annotate(
+            datasets_count=Count("datasets", filter=Q(datasets__deleted=False)),
+            dashboards_count=Count(
+                "visualisation_catalogue_items",
+                filter=Q(visualisation_catalogue_items__deleted=False),
+            ),
+            users_count=Count("user_memberships", filter=Q(user_memberships__deleted=False)),
+        )
 
 
 admin.site.register(Collection, CollectionAdmin)

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -50,6 +50,18 @@ class Collection(DeletableTimestampedUserModel):
 
     notes_truncated.boolean = True
 
+    datasets_count.admin_order_field = "datasets_count"
+    datasets_count.description = "Datasets count"
+
+    dashboards_count.admin_order_field = "dashboards_count"
+    dashboards_count.description = "Dashboards count"
+
+    users_count.admin_order_field = "users_count"
+    users_count.description = "Users count"
+
+    notes_truncated.order_field = "notes"
+    notes_truncated.description = "Notes truncated"
+
 
 class CollectionDatasetMembership(DeletableTimestampedUserModel):
     dataset = models.ForeignKey(DataSet, on_delete=models.CASCADE, related_name="datasets")

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -36,6 +36,18 @@ class Collection(DeletableTimestampedUserModel):
     def get_absolute_url(self):
         return reverse("data_collections:collections_view", args=(self.id,))
 
+    def datasets_count(self):
+        return self.datasets.live().count()
+
+    def dashboards_count(self):
+        return self.visualisation_catalogue_items.live().count()
+
+    def users_count(self):
+        return self.user_memberships.live().count() + 1 if self.owner else 0
+
+    def notes_truncated(self):
+        return f"{self.notes[:100]}..." if self.notes else None
+
 
 class CollectionDatasetMembership(DeletableTimestampedUserModel):
     dataset = models.ForeignKey(DataSet, on_delete=models.CASCADE, related_name="datasets")

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -3,7 +3,7 @@ import uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models, transaction
-from django.db.models import Q, Count
+from django.db.models import Q
 from django.urls import reverse
 
 from dataworkspace.apps.core.models import DeletableTimestampedUserModel, RichTextField

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -43,10 +43,12 @@ class Collection(DeletableTimestampedUserModel):
         return self.visualisation_catalogue_items.live().count()
 
     def users_count(self):
-        return self.user_memberships.live().count() + 1 if self.owner else 0
+        return self.user_memberships.live().count()
 
     def notes_truncated(self):
-        return f"{self.notes[:100]}..." if self.notes else None
+        return True if self.notes else False
+
+    notes_truncated.boolean = True
 
 
 class CollectionDatasetMembership(DeletableTimestampedUserModel):

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -46,7 +46,7 @@ class Collection(DeletableTimestampedUserModel):
         return obj.users_count
 
     def notes_available(self):
-        return True if self.notes else False
+        bool(self.notes)
 
     notes_available.boolean = True
 

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -3,7 +3,7 @@ import uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models, transaction
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.urls import reverse
 
 from dataworkspace.apps.core.models import DeletableTimestampedUserModel, RichTextField
@@ -36,19 +36,19 @@ class Collection(DeletableTimestampedUserModel):
     def get_absolute_url(self):
         return reverse("data_collections:collections_view", args=(self.id,))
 
-    def datasets_count(self):
-        return self.datasets.live().count()
+    def datasets_count(self, obj):
+        return obj.datasets_count
 
-    def dashboards_count(self):
-        return self.visualisation_catalogue_items.live().count()
+    def dashboards_count(self, obj):
+        return obj.dashboards_count
 
-    def users_count(self):
-        return self.user_memberships.live().count()
+    def users_count(self, obj):
+        return obj.users_count
 
-    def notes_truncated(self):
+    def notes_available(self):
         return True if self.notes else False
 
-    notes_truncated.boolean = True
+    notes_available.boolean = True
 
     datasets_count.admin_order_field = "datasets_count"
     datasets_count.description = "Datasets count"
@@ -59,8 +59,8 @@ class Collection(DeletableTimestampedUserModel):
     users_count.admin_order_field = "users_count"
     users_count.description = "Users count"
 
-    notes_truncated.order_field = "notes"
-    notes_truncated.description = "Notes truncated"
+    notes_available.order_field = "notes"
+    notes_available.description = "Notes truncated"
 
 
 class CollectionDatasetMembership(DeletableTimestampedUserModel):

--- a/dataworkspace/dataworkspace/apps/data_collections/models.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/models.py
@@ -46,7 +46,7 @@ class Collection(DeletableTimestampedUserModel):
         return obj.users_count
 
     def notes_available(self):
-        bool(self.notes)
+        return bool(self.notes)
 
     notes_available.boolean = True
 

--- a/dataworkspace/dataworkspace/templates/data_collections/collection_form.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_form.html
@@ -40,7 +40,7 @@
       <div class="govuk-grid-row govuk-!-width-three-quarters">
         <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
           <h1 class="govuk-heading-xl govuk-!-margin-bottom-3">
-            {% if collection %}Edit or delete{% else %}Create{% endif %} collection
+            {% if collection %}Edit{% if collection.owner == request.user %} or delete{% endif %}{% else %}Create{% endif %} collection
           </h1>
         </div>
         <div class="govuk-grid-column-full">
@@ -54,13 +54,13 @@
                 Save
               </button>
                <a
-                 class="govuk-link govuk-link--no-visited-state"
+                 class="govuk-link govuk-link--no-visited-state govuk-!-margin-top-2"
                  href="{% if collection %}{{ collection.get_absolute_url }}{% else %}{% url 'data_collections:collections-list' %}{% endif %}"
                >
                  Cancel
                </a>
             {% if collection and collection.owner == request.user %}
-              <a class="govuk-button govuk-button--warning" style="float: right; margin-right: 0" data-module="govuk-button"
+              <a class="govuk-button govuk-button--secondary" style="float: right; margin-right: 0" data-module="govuk-button"
                  href="{% url 'data_collections:remove-collection-confirmation' collections_id=collection.id %}">
                 Delete
               </a>


### PR DESCRIPTION
### Description of change
So we can see the details of Collections in Django admin without needing to open each one, the following columns are being added:

- Datasets (total number)
- Dashboards (total number)
- Users (total number)
- Notes (Text snippet, ie truncated) - we just need to see if Notes have been added. It isn’t important to be able to read the whole string.

### Checklist

~* [ ] Have tests been added to cover any changes?~
