### PR TITLE
fix: ensure row count works for queries with filters

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -575,11 +575,16 @@ def build_filtered_dataset_query(inner_query, download_limit, column_config, par
         SQL(",").join(map(Identifier, sort_fields)),
     )
 
-    where_clause = Composed(where_clause)
     download_limit += 1
     limit_clause = Composed([SQL(f" LIMIT {download_limit}")])
-    inner_query = inner_query + where_clause + limit_clause
-    rowcount_q = SQL("SELECT COUNT(iq.*) AS count FROM ({}) AS iq").format(inner_query)
+    rowcount_q = SQL(
+        """
+        SELECT COUNT(iq.*) AS count
+        FROM ({}) AS iq
+        {}
+        {}
+        """
+    ).format(inner_query, SQL(" ").join(where_clause), limit_clause)
 
     return rowcount_q, query, query_params
 


### PR DESCRIPTION
### Description of change

The row count query was failing for dataset queries with filters. This was due to the way the query and the where clause were joined. 

DT-944

### Checklist

* [ ] Have tests been added to cover any changes?
