### PR TITLE
fix: improving unit test timings 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
   docker-test-unit:
     docker:
       - image: circleci/python:3.9
+    parallelism: 5
     steps:
       - checkout
       - setup_remote_docker:
@@ -58,11 +59,12 @@ jobs:
           name: Run test
           command: |
             touch .envs/dev.env
-            make docker-test-unit
+            make docker-test-unit TESTS=$(circleci tests glob "dataworkspace/dataworkspace/tests/**/test_*.py" | circleci tests split --split-by=timings)
 
   docker-test-integration:
     docker:
       - image: circleci/python:3.9
+    parallelism: 3
     steps:
       - checkout
       - setup_remote_docker:
@@ -78,7 +80,7 @@ jobs:
           name: Run test
           command: |
             touch .envs/dev.env
-            make docker-test-integration
+            make docker-test-integration TESTS=$(circleci tests glob "test/**/test_*.py" | circleci tests split --split-by=timings)
 
   check-linting:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,15 @@ docker-build:
 
 
 .PHONY: docker-test-unit
+docker-test-unit: TESTS ?= /dataworkspace/dataworkspace
 docker-test-unit: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest /dataworkspace/dataworkspace
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest $(TESTS)
 
 
 .PHONY: docker-test-integration
+docker-test-integration: TESTS ?= test/
 docker-test-integration: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest test/
+	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest $(TESTS)
 
 
 .PHONY: docker-test


### PR DESCRIPTION
### Description of change
Shaving unit test timings from about 10 minutes to approx 3-4 minutes using parrallelism. 

![Screenshot 2022-12-16 at 10 49 11](https://user-images.githubusercontent.com/113979857/208082594-bd2303bc-e5c3-4f21-a605-0e73d8be37ac.png)

### Checklist

* [ ] Have tests been added to cover any changes?
