### PR TITLE
fix: allow superusers to manage catalogue item

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -75,7 +75,7 @@
         </a>
       </p>
       {% endif %}
-      {% if request.user == model.information_asset_owner or request.user == model.information_asset_manager %}
+      {% if request.user == model.information_asset_owner or request.user == model.information_asset_manager or request.user.is_superuser %}
       <p class="govuk-body sidebar-section">
         <a href="{% url 'datasets:edit_visualisation_catalogue_item' model.id %}" class="govuk-link govuk-link--no-visited-state">Manage this page</a>
       </p>


### PR DESCRIPTION
### Description of change
The Manage this dataset link (or equivalent of) on visualisation pages does not seem to appear for superusers.

### Checklist

* [ ] Have tests been added to cover any changes?
