### PR TITLE
feat: include people finder link in request access for collections

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/views.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/views.py
@@ -35,6 +35,7 @@ from dataworkspace.apps.datasets.models import Tag
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.notify import EmailSendFailureException, send_email
+from dataworkspace.zendesk import get_people_url
 
 logger = logging.getLogger("app")
 
@@ -586,6 +587,7 @@ class RequestAccessToCollection(FormView):
                         "data_collections:collections_view", args=(collection.id,)
                     ),
                     "user_email": form.cleaned_data["email"],
+                    "people_url": get_people_url(self.request.user.get_full_name()),
                 },
             )
         except EmailSendFailureException:


### PR DESCRIPTION
### Description of change
We want to include people finder link as an enhancement to the access request (this person has asked for access - view their profile)

### Checklist

* [ ] Have tests been added to cover any changes?
