### PR TITLE
build(ci): inherit from built in asyncio test

### DIFF
--- a/test/test_application.py
+++ b/test/test_application.py
@@ -6,7 +6,6 @@ import unittest
 import uuid
 
 from test.utility_functions import (
-    async_test,
     add_user_to_team,
     client_session,
     create_application,
@@ -33,23 +32,18 @@ from test.utility_functions import (
 from aiohttp import web
 
 
-class TestApplication(unittest.TestCase):
+class TestApplication(unittest.IsolatedAsyncioTestCase):
     """Tests the behaviour of the application, including Proxy"""
 
-    def add_async_cleanup(self, coroutine):
-        loop = asyncio.get_event_loop()
-        self.addCleanup(loop.run_until_complete, coroutine())
-
-    @async_test
     async def test_application_shows_content_if_authorized(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -65,7 +59,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -193,7 +187,7 @@ class TestApplication(unittest.TestCase):
         # we load up the application succesfully
         await cleanup_application_1()
         cleanup_application_2 = await create_application()
-        self.add_async_cleanup(cleanup_application_2)
+        self.addAsyncCleanup(cleanup_application_2)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -227,16 +221,15 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
 
-    @async_test
     async def test_db_application_can_read_and_write_to_private_and_team_schemas(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -252,7 +245,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -372,16 +365,15 @@ class TestApplication(unittest.TestCase):
         ) as response:
             await response.text()
 
-    @async_test
     async def test_visualisation_shows_content_if_authorized_and_published(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -397,7 +389,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -522,16 +514,15 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
 
-    @async_test
     async def test_visualisation_commit_shows_content_if_authorized(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -547,7 +538,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -588,7 +579,7 @@ class TestApplication(unittest.TestCase):
                 web.get("/{path:.*}", handle_general_gitlab),
             ],
         )
-        self.add_async_cleanup(gitlab_cleanup)
+        self.addAsyncCleanup(gitlab_cleanup)
 
         # Ensure the user doesn't have access to the application
         async with session.request(
@@ -638,16 +629,15 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content["headers"]["from-downstream"], "downstream-header-value")
         self.assertEqual(received_headers["from-upstream"], "upstream-header-value")
 
-    @async_test
     async def test_visualisation_shows_dataset_if_authorised(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -663,7 +653,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -767,7 +757,7 @@ class TestApplication(unittest.TestCase):
                 web.get("/{path:.*}", handle_general_gitlab),
             ],
         )
-        self.add_async_cleanup(gitlab_cleanup)
+        self.addAsyncCleanup(gitlab_cleanup)
 
         stdout, stderr, code = await give_user_dataset_perms("dataset_1")
         self.assertEqual(stdout, b"")
@@ -989,16 +979,15 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_content, {"data": list(range(1, 20001))})
         self.assertEqual(received_status, 200)
 
-    @async_test
     async def test_application_spawn(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application_1 = await create_application()
-        self.add_async_cleanup(cleanup_application_1)
+        self.addAsyncCleanup(cleanup_application_1)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -1014,7 +1003,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -1108,23 +1097,22 @@ class TestApplication(unittest.TestCase):
         self.assertEqual(received_binary_content, b"some-\0binary-data")
         self.assertEqual(received_text_content, "some-text-data")
 
-    @async_test
     async def test_application_redirects_to_sso_if_initially_not_authorized(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_application = await create_application()
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         is_logged_in = False
         codes = iter([])
         tokens = iter([])
         auth_to_me = {}
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 

--- a/test/test_application_2.py
+++ b/test/test_application_2.py
@@ -3,7 +3,6 @@ import unittest
 import asyncio
 
 from test.utility_functions import (
-    async_test,
     client_session,
     create_application,
     create_private_dataset,
@@ -19,21 +18,16 @@ from test.utility_functions import (
 )
 
 
-class TestApplication(unittest.TestCase):
-    def add_async_cleanup(self, coroutine):
-        loop = asyncio.get_event_loop()
-        self.addCleanup(loop.run_until_complete, coroutine())
-
-    @async_test
+class TestApplication(unittest.IsolatedAsyncioTestCase):
     async def test_application_shows_forbidden_if_not_auth_ip(self):
         await flush_database()
         await flush_redis()
 
         cleanup_sentry, sentry_requests = await create_sentry()
-        self.add_async_cleanup(cleanup_sentry)
+        self.addAsyncCleanup(cleanup_sentry)
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         # Create application with a non-open whitelist
         cleanup_application = await create_application(
@@ -42,7 +36,7 @@ class TestApplication(unittest.TestCase):
                 "APPLICATION_IP_ALLOWLIST_GROUPS__my_group__1": "4.3.1.1/32",
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         is_logged_in = True
         codes = iter(
@@ -67,7 +61,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -127,7 +121,7 @@ class TestApplication(unittest.TestCase):
                 "SENTRY_ENVIRONMENT": "Test",
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -242,13 +236,12 @@ class TestApplication(unittest.TestCase):
         self.assertIn("You do not have access to this page", content)
         self.assertEqual(response.status, 403)
 
-    @async_test
     async def test_integrated_data_explorer_has_ip_restrictions(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         # Create application with a non-open whitelist
         # Explorer/DB credentials generator cannot handle two database connections which point to the sme
@@ -261,7 +254,7 @@ class TestApplication(unittest.TestCase):
                 "EXPLORER_CONNECTIONS": '{"Postgres": "my_database"}',
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         is_logged_in = True
         codes = iter(
@@ -299,7 +292,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -358,7 +351,7 @@ class TestApplication(unittest.TestCase):
                 "EXPLORER_CONNECTIONS": '{"Postgres": "my_database"}',
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -423,16 +416,15 @@ class TestApplication(unittest.TestCase):
         self.assertIn("You do not have access to this page", content)
         self.assertEqual(response.status, 403)
 
-    @async_test
     async def test_superset_editor_headers(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_superset, superset_requests = await create_superset()
-        self.add_async_cleanup(cleanup_superset)
+        self.addAsyncCleanup(cleanup_superset)
 
         cleanup_application = await create_application(
             env=lambda: {
@@ -442,7 +434,7 @@ class TestApplication(unittest.TestCase):
                 "SUPERSET_ROOT": "http://localhost:8008/",
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -458,7 +450,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 
@@ -517,16 +509,15 @@ class TestApplication(unittest.TestCase):
         assert superset_requests[0].headers["Credentials-Db-User"].endswith("superset")
         assert "Credentials-Db-Password" in superset_requests[0].headers
 
-    @async_test
     async def test_superset_public_headers(self):
         await flush_database()
         await flush_redis()
 
         session, cleanup_session = client_session()
-        self.add_async_cleanup(cleanup_session)
+        self.addAsyncCleanup(cleanup_session)
 
         cleanup_superset, superset_requests = await create_superset()
-        self.add_async_cleanup(cleanup_superset)
+        self.addAsyncCleanup(cleanup_superset)
 
         cleanup_application = await create_application(
             env=lambda: {
@@ -536,7 +527,7 @@ class TestApplication(unittest.TestCase):
                 "SUPERSET_ROOT": "http://localhost:8008/",
             }
         )
-        self.add_async_cleanup(cleanup_application)
+        self.addAsyncCleanup(cleanup_application)
 
         is_logged_in = True
         codes = iter(["some-code"])
@@ -552,7 +543,7 @@ class TestApplication(unittest.TestCase):
             }
         }
         sso_cleanup, _ = await create_sso(is_logged_in, codes, tokens, auth_to_me)
-        self.add_async_cleanup(sso_cleanup)
+        self.addAsyncCleanup(sso_cleanup)
 
         await until_succeeds("http://dataworkspace.test:8000/healthcheck")
 

--- a/test/utility_functions.py
+++ b/test/utility_functions.py
@@ -13,15 +13,6 @@ from elasticsearch import AsyncElasticsearch, helpers
 from lxml import html
 
 
-def async_test(func):
-    def wrapper(*args, **kwargs):
-        future = func(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(future)
-
-    return wrapper
-
-
 def client_session():
     session = aiohttp.ClientSession()
 


### PR DESCRIPTION
### Description of change

It looked like the test decorator was causing pytest to consider the test as being un utility_functions.py. This is fine for pass/fail, but it was reporting timings are part of that file, which then messed up the test parallelisation in CircleCI

DT-270

### Checklist

* [ ] Have tests been added to cover any changes?
