### PR TITLE
fix: spacing adjustment for request access page and text resizing of collection detail

### DIFF
--- a/dataworkspace/dataworkspace/templates/data_collections/collection_detail.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/collection_detail.html
@@ -199,7 +199,7 @@
           </div>
           <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
             <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Collection owner</h2>
-            <p class="govuk-body">{{ source_object.owner.get_full_name|default_if_none:"Not assigned" }}<br>
+            <p class="govuk-body-s">{{ source_object.owner.get_full_name|default_if_none:"Not assigned" }}<br>
               {% if source_object.owner %}(<a class="govuk-link govuk-link--no-visited-state"
                                               href="mailto:{{ source_object.owner.email }}">{{ source_object.owner.email }}</a>
                 ){% endif %}</p>
@@ -207,7 +207,7 @@
           {% if user_memberships.count > 0 %}
             <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
               <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Collection users</h2>
-              <p class="govuk-body">
+              <p class="govuk-body-s">
                 {% for membership in user_memberships|slice:":5" %}
                   {{ membership.user.get_full_name }}{% if not forloop.last %}, {% endif %}
                 {% endfor %}
@@ -218,7 +218,7 @@
             </div>
           {% endif %}
           <div class="govuk-grid-column-one-third govuk-!-margin-bottom-2">
-            <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state"
+            <p class="govuk-body-s"><a class="govuk-link govuk-link--no-visited-state"
                                      href="{% url 'data_collections:collection-users' source_object.id %}">View and edit
               collection users</a></p>
           </div>

--- a/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
+++ b/dataworkspace/dataworkspace/templates/data_collections/request_access_to_collection_form.html
@@ -39,7 +39,7 @@
 
       <form method="post" novalidate>
         {% csrf_token %}
-        <div class="govuk-form-group {% if form.errors %}govuk-form-group--error{% endif %}">
+        <div class="govuk-form-group govuk-!-margin-bottom-7 {% if form.errors %}govuk-form-group--error{% endif %}">
               <h1 class="govuk-label-wrapper">
                 <label class="govuk-label govuk-!-font-weight-bold govuk-!-margin-bottom-3" for="id_email">
                   {{ form.email.label }}
@@ -59,7 +59,7 @@
                 </p>
               {% endif %}
               <input
-                class="govuk-input govuk-!-width-two-thirds govuk-!-margin-bottom-6 {% if form.email.errors %} govuk-input--error{% endif %}"
+                class="govuk-input govuk-!-width-two-thirds govuk-!-margin-bottom-7 {% if form.email.errors %} govuk-input--error{% endif %}"
                 type="email"
                 name="email"
                 id="id_email"


### PR DESCRIPTION
### Description of change
Request from content designer to increase the following on request access for collections page:
- the margin between the button and the footer an extra 10px
- the margin between the field and the buttons by  10px

and for the collection detail page to have govuk-body-s be used instead of govuk-body for the following:

- The name of the owner and their email address underneath the title
- The names of users underneath the title
- The link ‘View and edit collection users’

### Checklist

~* [ ] Have tests been added to cover any changes?~
