### PR TITLE
fix: update people url to specifically link to page rather than search results

### DIFF
--- a/dataworkspace/dataworkspace/apps/data_collections/views.py
+++ b/dataworkspace/dataworkspace/apps/data_collections/views.py
@@ -35,7 +35,6 @@ from dataworkspace.apps.datasets.models import Tag
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.notify import EmailSendFailureException, send_email
-from dataworkspace.zendesk import get_people_url
 
 logger = logging.getLogger("app")
 
@@ -587,7 +586,9 @@ class RequestAccessToCollection(FormView):
                         "data_collections:collections_view", args=(collection.id,)
                     ),
                     "user_email": form.cleaned_data["email"],
-                    "people_url": get_people_url(self.request.user.get_full_name()),
+                    "people_url": "https://people.trade.gov.uk/people/get-by-staff-sso-id/{}".format(
+                        self.request.user.profile.sso_id
+                    ),
                 },
             )
         except EmailSendFailureException:

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -149,7 +149,7 @@ Username:   Frank Exampleson
 Journey:    Dataset access
 Dataset:    A master
 SSO Login:  frank.exampleson@test.com
-People search: https://people.trade.gov.uk/search?search_filters[]=people&query=Frank%20Exampleson
+People search: https://people.trade.gov.uk/people-and-teams/search/?query=Frank%20Exampleson&filters=teams&filters=people
 
 
 Details for the request can be found at
@@ -342,7 +342,7 @@ Username:   Frank Exampleson
 Journey:    Tools access
 Dataset:    A master
 SSO Login:  frank.exampleson@test.com
-People search: https://people.trade.gov.uk/search?search_filters[]=people&query=Frank%20Exampleson
+People search: https://people.trade.gov.uk/people-and-teams/search/?query=Frank%20Exampleson&filters=teams&filters=people
 
 
 Details for the request can be found at

--- a/dataworkspace/dataworkspace/zendesk.py
+++ b/dataworkspace/dataworkspace/zendesk.py
@@ -19,7 +19,7 @@ def get_username(user):
 
 
 def get_people_url(name):
-    return "https://people.trade.gov.uk/search?search_filters[]=people&query={}".format(
+    return "https://people.trade.gov.uk/people-and-teams/search/?query={}&filters=teams&filters=people".format(
         urllib.parse.quote(name)
     )
 


### PR DESCRIPTION
### Description of change
People url was returning a list of search results, after a conversation, we want this to return a link directly to user people finder page

### Checklist

* [ ] Have tests been added to cover any changes?
