### PR TITLE
feat: allow user to select checkbox for specific user from list

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/urls.py
+++ b/dataworkspace/dataworkspace/apps/datasets/urls.py
@@ -261,6 +261,11 @@ urlpatterns = [
         name="add_authorized_user",
     ),
     path(
+        "<uuid:pk>/add-authorized-users/<int:summary_id>",
+        login_required(views.DatasetAddAuthorisedUsersView.as_view()),
+        name="add_authorized_users",
+    ),
+    path(
         "<uuid:pk>/remove-authorized-user/<int:summary_id>/<int:user_id>",
         login_required(views.DatasetRemoveAuthorisedUserView.as_view()),
         name="remove_authorized_user",

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1709,8 +1709,9 @@ class DatasetAddAuthorisedUsersView(EditBaseView, View):
 
             if user.id not in users:
                 users.append(user.id)
-                summary.users = json.dumps(users)
-                summary.save()
+
+        summary.users = json.dumps(users)
+        summary.save()
 
         return HttpResponseRedirect(
             reverse(

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1700,6 +1700,29 @@ class DatasetAddAuthorisedUserView(EditBaseView, View):
         )
 
 
+class DatasetAddAuthorisedUsersView(EditBaseView, View):
+    def post(self, request, *args, **kwargs):
+        summary = PendingAuthorizedUsers.objects.get(id=self.kwargs.get("summary_id"))
+        users = json.loads(summary.users if summary.users else "[]")
+        for selected_user in self.request.POST.getlist("selected-user"):
+            user = get_user_model().objects.get(id=selected_user)
+
+            if user.id not in users:
+                users.append(user.id)
+                summary.users = json.dumps(users)
+                summary.save()
+
+        return HttpResponseRedirect(
+            reverse(
+                "datasets:edit_permissions_summary",
+                args=[
+                    self.obj.id,
+                    self.kwargs.get("summary_id"),
+                ],
+            )
+        )
+
+
 class DatasetRemoveAuthorisedUserView(EditBaseView, View):
     def get(self, request, *args, **kwargs):
         summary = PendingAuthorizedUsers.objects.get(id=self.kwargs.get("summary_id"))

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -52,7 +52,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="search-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Found {{ search_results.count }} result{% if search_results.count > 1 %}s{% else %} for
+              Found {{ search_results.count }} matching user{% if search_results.count > 1 %}s{% else %} for
               {{ search_query }}{% endif %}
             </h1>
           </legend>

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -80,7 +80,7 @@
         </form>
           {% else %}
           <table class="govuk-table">
-                    <caption class="govuk-table__caption govuk-table__caption--m">Found {{ search_results.count }}  matching user{% if search_results.count > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
+                    <caption class="govuk-table__caption govuk-table__caption--m">Found {{ search_results.count }} matching user{% if search_results.count > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
                     <tbody class="govuk-table__body">
                         {% for result in search_results %}
                         <tr class="govuk-table__row">

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -27,28 +27,59 @@
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            {% include 'design_system/error_summary.html' with form=form %}
-            <h1 class="govuk-heading-l">Edit permissions for {{ obj.name }}</h1>
-            <form method="post" enctype="multipart/form-data" novalidate>
-              {% csrf_token %}
-              <fieldset class="govuk-fieldset">
-                  <div class="govuk-form-group ">
-                    {% if waffle_flag %}
-                    {{ form.search }}
-                    {% else %}
-                    <label class="govuk-label  govuk-!-font-weight-bold" for="id_search">
-                        {{ form.search.label }}
-                      </label>
-                    <input class="govuk-input" type="text" name="search" id="id_search" value="{{ search_query }}">
-                    {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% include 'design_system/error_summary.html' with form=form %}
+      <h1 class="govuk-heading-l">Edit permissions for {{ obj.name }}</h1>
+      <form method="post" enctype="multipart/form-data" novalidate>
+        {% csrf_token %}
+        <fieldset class="govuk-fieldset">
+          <div class="govuk-form-group">
+            {% if waffle_flag %}
+              {{ form.search }}
+            {% else %}
+              <label class="govuk-label  govuk-!-font-weight-bold" for="id_search">
+                {{ form.search.label }}
+              </label>
+              <input class="govuk-input" type="text" name="search" id="id_search" value="{{ search_query }}">
+            {% endif %}
+          </div>
+          <button type="submit" class="govuk-button" data-prevent-double-click="true">Search</button>
+        </fieldset>
+      </form>
+      {% if search_results %}
+        {% if waffle_flag %}
+        <fieldset class="govuk-fieldset" aria-describedby="search-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              Found {{ search_results.count }} result{% if search_results.count > 1 %}s{% else %} for
+              {{ search_query }}{% endif %}
+            </h1>
+          </legend>
+        </fieldset>
+        <form action="{% url 'datasets:add_authorized_users' obj.id summary_id %}" method="post"
+              enctype="multipart/form-data" novalidate>
+          {% csrf_token %}
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-form-group">
+              <div class="govuk-checkboxes govuk-!-margin-bottom-6" data-module="govuk-checkboxes">
+                {% for result in search_results %}
+                  <div class="govuk-checkboxes__item">
+                    <input class="govuk-checkboxes__input" id="{{ result.id }}" name="selected-user"
+                           type="checkbox"
+                           value="{{ result.id }}">
+                    <label class="govuk-label govuk-checkboxes__label" for="{{ result.id }}">
+                      {{ result.first_name }} {{ result.last_name }} ({{ result.email }})
+                    </label>
                   </div>
-                  <button type="submit" class="govuk-button" data-prevent-double-click="true" >Search</button>
-              </fieldset>
-          </form>
-            {% if search_results %}
-                <table class="govuk-table">
+                {% endfor %}
+              </div>
+            </div>
+            <button type="submit" class="govuk-button" data-prevent-double-click="true">Add selected users</button>
+          </fieldset>
+        </form>
+          {% else %}
+          <table class="govuk-table">
                     <caption class="govuk-table__caption govuk-table__caption--m">Found {{ search_results.count }} result{% if search_results.count > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
                     <tbody class="govuk-table__body">
                         {% for result in search_results %}
@@ -60,11 +91,12 @@
                         {% endfor %}
                     </tbody>
                   </table>
-            {% else %}
-              {% if search_query %}
-                <h2 class="govuk-heading-m">Found 0 results</h2>
-              {% endif %}
-            {% endif %}
-        </div>
+          {% endif %}
+      {% else %}
+        {% if search_query %}
+          <h2 class="govuk-heading-m">Found 0 results</h2>
+        {% endif %}
+      {% endif %}
     </div>
+  </div>
 {% endblock %}


### PR DESCRIPTION
### Description of change
This is a follow on from [DT-859: Ability to give users access to datasets/dashboards in bulkREVIEW](https://uktrade.atlassian.net/browse/DT-859) to allow the user to choose and add multiple users at the same time.

Note: IAO/IAMs may be adding up to 1,000 users at once, so it needs to accommodate this. Pagination is not in-scope at the moment. We could add that later if necessary.

It includes:

Checkboxes against each valid user

A button to add the selected users in one go

### Checklist

* [ ] Have tests been added to cover any changes?
