### PR TITLE
fix: ensure wording for user search form is correct dependent on flag

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -647,7 +647,7 @@ class UserSearchForm(GOVUKDesignSystemForm):
         widget=GOVUKDesignSystemTextareaWidget(
             label_is_heading=False, extra_label_classes="govuk-!-font-weight-bold"
         ),
-        error_messages={"required": "You must provide a search terms."},
+        error_messages={"required": "You must provide a search term."},
     )
 
 

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -39,7 +39,7 @@
                     {{ form.search }}
                     {% else %}
                     <label class="govuk-label  govuk-!-font-weight-bold" for="id_search">
-                        {{ form.search.label }}
+                        Search by email address or name
                       </label>
                     <input class="govuk-input" type="text" name="search" id="id_search" value="{{ search_query }}">
                     {% endif %}


### PR DESCRIPTION
### Description of change
Minor issues regarding the wording due to the waffle flag that has been put in place

### Checklist

* [ ] Have tests been added to cover any changes?
