### PR TITLE
Fix/improved dataset authorised user search

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1514,14 +1514,17 @@ class UserSearchFormView(EditBaseView, FormView):
         self.form = form
         search_query = self.request.POST["search"]
         if search_query:
-            self.request.session[f'search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}'] = search_query
-
+            self.request.session[
+                f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
+            ] = search_query
 
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        search_query = self.request.session.get(f'search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}')
+        search_query = self.request.session.get(
+            f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
+        )
         if search_query:
             if "\n" in search_query:
                 email_filter = Q(pk__in=[])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1536,8 +1536,8 @@ class UserSearchFormView(EditBaseView, FormView):
                     last_name__icontains=search_query.strip()
                 )
                 users = get_user_model().objects.filter(Q(email_filter | name_filter))
-        context["search_results"] = users
-        context["search_query"] = search_query
+            context["search_results"] = users
+            context["search_query"] = search_query
         context["obj"] = self.obj
         context["obj_edit_url"] = (
             reverse("datasets:edit_dataset", args=[self.obj.pk])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1513,10 +1513,9 @@ class UserSearchFormView(EditBaseView, FormView):
     def form_valid(self, form):
         self.form = form
         search_query = self.request.POST["search"]
-        if search_query:
-            self.request.session[
-                f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
-            ] = search_query
+        self.request.session[
+            f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
+        ] = search_query
 
         return super().form_valid(form)
 

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -49,7 +49,7 @@
           </form>
             {% if search_results %}
                 <table class="govuk-table">
-                    <caption class="govuk-table__caption govuk-table__caption--m">Found {{ search_results.count }} result{% if search_results.count > 1 %}s{% else %} for {{ search_query }}{% endif %}</caption>
+                    <caption class="govuk-table__caption govuk-table__caption--m">Found {{ search_results.count }} matching user{% if search_results.count > 1 %}s{% endif %}</caption>
                     <tbody class="govuk-table__body">
                         {% for result in search_results %}
                         <tr class="govuk-table__row">


### PR DESCRIPTION
### Description of change
Searching for users to add to dataset previously passed the search query and user information to a global dictionary in order to be passed to the context. Now, the search query is instead stored in the session, and used to retrieve the search results in the context.

### Checklist

* [ ] Have tests been added to cover any changes?
