### PR TITLE
Fix/improved dataset authorised user search

### DIFF
--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4449,7 +4449,7 @@ class TestDatasetEditView:
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )
         assert response.status_code == 200
-        assert b"Found 2 results" in response.content
+        assert b"Found 2 matching users" in response.content
         assert user_1.email.encode() in response.content
         assert user_1.first_name.encode() in response.content
         assert user_2.email.encode() in response.content
@@ -4479,7 +4479,7 @@ class TestDatasetEditView:
         search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
-        assert b"Found 1 result for John" in response.content
+        assert b"Found 1 matching user" in response.content
         assert user_1.email.encode() in response.content
         assert user_1.first_name.encode() in response.content
 
@@ -4545,7 +4545,7 @@ class TestDatasetEditView:
         search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
-        assert b"Found 1 result for John" in response.content
+        assert b"Found 1 matching user" in response.content
         assert user_1.email.encode() in response.content
         assert user_1.first_name.encode() in response.content
 
@@ -4642,7 +4642,7 @@ class TestVisualisationCatalogueItemEditView:
         search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
-        assert b"Found 1 result for John" in response.content
+        assert b"Found 1 matching user" in response.content
         assert user_1.email.encode() in response.content
         assert user_1.first_name.encode() in response.content
 


### PR DESCRIPTION
### Description of change
Searching for users to add to dataset previously passed the search query and user information to a global dictionary in order to be passed to the context. Now, the search query is instead stored in the session, and used to retrieve the search results in the context. In addition, unit tests have been updated to reflect the new wording of search results.

### Checklist

* [ ] Have tests been added to cover any changes?
