### PR TITLE
fix: dataset authorised users search preservation

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1522,7 +1522,7 @@ class UserSearchFormView(EditBaseView, FormView):
     def get_initial(self):
         initial = super().get_initial()
         try:
-            initial['search'] = self.request.session[
+            initial["search"] = self.request.session[
                 f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
             ]
         except KeyError:

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1519,6 +1519,16 @@ class UserSearchFormView(EditBaseView, FormView):
 
         return super().form_valid(form)
 
+    def get_initial(self):
+        initial = super().get_initial()
+        try:
+            initial['search'] = self.request.session[
+                f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
+            ]
+        except KeyError:
+            pass
+        return initial
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         search_query = self.request.session.get(


### PR DESCRIPTION
### Description of change
Searching for authorised users to add to dataset now retains the search data in the textarea upon displaying results, which it previously did not.


### Checklist

* [ ] Have tests been added to cover any changes?
