### PR TITLE
Fix/edit permissions summary add users wording

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1620,6 +1620,9 @@ class DatasetEditPermissionsSummaryView(EditBaseView, TemplateView):
         context["authorised_users"] = get_user_model().objects.filter(
             id__in=json.loads(self.summary.users if self.summary.users else "[]")
         )
+        context["waffle_flag"] = waffle.flag_is_active(
+            self.request, "ALLOW_USER_ACCESS_TO_DASHBOARD_IN_BULK"
+        )
         return context
 
     def post(self, request, *args, **kwargs):

--- a/dataworkspace/dataworkspace/templates/datasets/edit_permissions_summary.html
+++ b/dataworkspace/dataworkspace/templates/datasets/edit_permissions_summary.html
@@ -46,7 +46,11 @@
               </tbody>
             </table>
             <div class="govuk-body">
+              {% if waffle_flag %}
+              <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary.id %}">Add users</a>
+              {% else %}
               <a class="govuk-link" href="{% url 'datasets:search_authorized_users' obj.id summary.id %}">Add another user</a>
+              {% endif %}
             </div>
             <div class="govuk-body">
               <a class="govuk-link" href="{{ obj.get_usage_history_url }}">View usage history</a>

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4444,7 +4444,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )
@@ -4476,7 +4476,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4542,7 +4542,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4639,7 +4639,7 @@ class TestVisualisationCatalogueItemEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4444,7 +4444,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4444,7 +4444,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )
@@ -4476,7 +4476,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4542,7 +4542,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4639,7 +4639,7 @@ class TestVisualisationCatalogueItemEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4444,7 +4444,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")["href"]
         response = client.post(
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )
@@ -4476,7 +4476,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4542,7 +4542,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4639,7 +4639,7 @@ class TestVisualisationCatalogueItemEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add users")["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -4444,7 +4444,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(
             search_url, data={"search": "john@example.com\njohn@example2.com"}, follow=True
         )
@@ -4476,7 +4476,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4542,7 +4542,7 @@ class TestDatasetEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content
@@ -4639,7 +4639,7 @@ class TestVisualisationCatalogueItemEditView:
         assert b"There are currently no authorized users" in response.content
 
         soup = BeautifulSoup(response.content.decode(response.charset))
-        search_url = soup.findAll("a", href=True, text="Add users")[0]["href"]
+        search_url = soup.findAll("a", href=True, text="Add another user")[0]["href"]
         response = client.post(search_url, data={"search": "John"}, follow=True)
         assert response.status_code == 200
         assert b"Found 1 matching user" in response.content


### PR DESCRIPTION
### Description of change
With the addition of the ability to bulk add users to a dataset, the previous wording of "Add another user" no longer made sense. Now, when the waffle_flag for the bulk addition of new users is active, the text "Add users" is displayed instead, reflecting that multiple can be added at the same time.


### Checklist

* [ ] Have tests been added to cover any changes?
