### PR TITLE
Feat/dataset user search bad matches displayed

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1543,9 +1543,7 @@ class UserSearchFormView(EditBaseView, FormView):
                 users = get_user_model().objects.filter(Q(email_filter))
 
                 for query in search_query.splitlines():
-                    if users.filter(Q(email=query.strip())):
-                        continue
-                    else:
+                    if not users.filter(Q(email=query.strip())):
                         non_email_matches.append(query)
                 context["non_matches"] = non_email_matches
 

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1536,16 +1536,28 @@ class UserSearchFormView(EditBaseView, FormView):
         )
         if search_query:
             if "\n" in search_query:
+                email_matches = []
                 non_email_matches = []
-                email_filter = Q(pk__in=[])
                 for query in search_query.splitlines():
-                    email_filter = email_filter | (Q(email=query.strip()))
-                users = get_user_model().objects.filter(Q(email_filter))
-
-                for query in search_query.splitlines():
-                    if not users.filter(Q(email=query.strip())):
+                    if not query.strip():
+                        continue
+                    matches_for_query = get_user_model().objects.filter(Q(email=query.strip()))
+                    for match in matches_for_query:
+                        email_matches.append(match)
+                    if not matches_for_query:
                         non_email_matches.append(query)
+                context["search_results"] = email_matches
                 context["non_matches"] = non_email_matches
+                # non_email_matches = []
+                # email_filter = Q(pk__in=[])
+                # for query in search_query.splitlines():
+                #     email_filter = email_filter | (Q(email=query.strip()))
+                # users = get_user_model().objects.filter(Q(email_filter))
+
+                # for query in search_query.splitlines():
+                #     if not users.filter(Q(email=query.strip())):
+                #         non_email_matches.append(query)
+                # context["non_matches"] = non_email_matches
 
             else:
                 email_filter = Q(email__icontains=search_query.strip())
@@ -1553,7 +1565,7 @@ class UserSearchFormView(EditBaseView, FormView):
                     last_name__icontains=search_query.strip()
                 )
                 users = get_user_model().objects.filter(Q(email_filter | name_filter))
-            context["search_results"] = users
+                context["search_results"] = users
             context["search_query"] = search_query
         context["obj"] = self.obj
         context["obj_edit_url"] = (

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1513,7 +1513,6 @@ class UserSearchFormView(EditBaseView, FormView):
     def form_valid(self, form):
         self.form = form
         search_query = self.request.POST["search"]
-        self.request.POST["search"]
         self.request.session[
             f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
         ] = search_query

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1548,16 +1548,6 @@ class UserSearchFormView(EditBaseView, FormView):
                         non_email_matches.append(query)
                 context["search_results"] = email_matches
                 context["non_matches"] = non_email_matches
-                # non_email_matches = []
-                # email_filter = Q(pk__in=[])
-                # for query in search_query.splitlines():
-                #     email_filter = email_filter | (Q(email=query.strip()))
-                # users = get_user_model().objects.filter(Q(email_filter))
-
-                # for query in search_query.splitlines():
-                #     if not users.filter(Q(email=query.strip())):
-                #         non_email_matches.append(query)
-                # context["non_matches"] = non_email_matches
 
             else:
                 email_filter = Q(email__icontains=search_query.strip())

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1558,7 +1558,12 @@ class UserSearchFormView(EditBaseView, FormView):
                 users = get_user_model().objects.filter(Q(email_filter | name_filter))
                 context["search_results"] = users
             context["search_query"] = search_query
-            del self.request.session[f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"]
+            try:
+                search_query = self.request.session.pop(
+                    f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
+                )
+            except KeyError:
+                search_query = None
         context["obj"] = self.obj
         context["obj_edit_url"] = (
             reverse("datasets:edit_dataset", args=[self.obj.pk])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1543,7 +1543,7 @@ class UserSearchFormView(EditBaseView, FormView):
                 users = get_user_model().objects.filter(Q(email_filter))
 
                 for query in search_query.splitlines():
-                    if users.filter(Q(email_icontains=query)):
+                    if users.filter(Q(email=query.strip())):
                         continue
                     else:
                         non_email_matches.append(query)

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1512,10 +1512,11 @@ class UserSearchFormView(EditBaseView, FormView):
 
     def form_valid(self, form):
         self.form = form
-        search_query = self.request.POST["search"]
+        search_terms = self.request.POST["search"]
+        self.request.POST["search"]
         self.request.session[
             f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
-        ] = search_query
+        ] = search_terms
 
         return super().form_valid(form)
 
@@ -1557,6 +1558,7 @@ class UserSearchFormView(EditBaseView, FormView):
                 users = get_user_model().objects.filter(Q(email_filter | name_filter))
                 context["search_results"] = users
             context["search_query"] = search_query
+            del self.request.session[f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"]
         context["obj"] = self.obj
         context["obj_edit_url"] = (
             reverse("datasets:edit_dataset", args=[self.obj.pk])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1547,6 +1547,7 @@ class UserSearchFormView(EditBaseView, FormView):
                         continue
                     else:
                         non_email_matches.append(query)
+                context["non_matches"] = non_email_matches
 
             else:
                 email_filter = Q(email__icontains=search_query.strip())
@@ -1556,7 +1557,6 @@ class UserSearchFormView(EditBaseView, FormView):
                 users = get_user_model().objects.filter(Q(email_filter | name_filter))
             context["search_results"] = users
             context["search_query"] = search_query
-            context["non_matches"] = non_email_matches
         context["obj"] = self.obj
         context["obj_edit_url"] = (
             reverse("datasets:edit_dataset", args=[self.obj.pk])

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1512,11 +1512,11 @@ class UserSearchFormView(EditBaseView, FormView):
 
     def form_valid(self, form):
         self.form = form
-        search_terms = self.request.POST["search"]
+        search_query = self.request.POST["search"]
         self.request.POST["search"]
         self.request.session[
             f"search-query--edit-dataset-permissions--{self.obj.pk}--{self.summary.id}"
-        ] = search_terms
+        ] = search_query
 
         return super().form_valid(form)
 

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -48,7 +48,7 @@
         </fieldset>
       </form>
       {% if non_matches %}
-      <h1 class="govuk-heading-l">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</h1>
+      <h1 class="govuk-heading-l">Unable to match {{non_matches|length}}{% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</h1>
       <ul class="govuk-list govuk-!-margin-bottom-6">
         {% for non_match in non_matches %}
         <li class="govuk-body">

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -72,8 +72,7 @@
         <fieldset class="govuk-fieldset" aria-describedby="search-hint">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Found {{ search_results.count }} matching user{% if search_results.count > 1 %}s{% else %} for
-              {{ search_query }}{% endif %}
+              Found {{ search_results|length }} matching user{% if search_results|length > 1 %}s{% endif %}
             </h1>
           </legend>
         </fieldset>

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -49,7 +49,7 @@
       </form>
       {% if non_matches %}
       <h1 class="govuk-heading-l">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</h1>
-      <ul class="govuk-list">
+      <ul class="govuk-list govuk-!-margin-bottom-6">
         {% for non_match in non_matches %}
         <li class="govuk-body">
             {{ non_match }}

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -47,6 +47,26 @@
           <button type="submit" class="govuk-button" data-prevent-double-click="true">Search</button>
         </fieldset>
       </form>
+      {% if waffle_flag %} 
+      {% if non_matches %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</caption>
+        <tbody class="govuk-table__body">
+        {% if non_matches|length > 1%} 
+        {% for non_match in non_matches %}
+            <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ non_match }}</td>
+              </tr>
+        {% endfor %}
+        {% else %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{ non_matches }}</td>
+            </tr>
+        {% endif %} 
+            </tbody>
+            </table>
+      {% endif %} 
+      {% endif %}
       {% if search_results %}
         {% if waffle_flag %}
         <fieldset class="govuk-fieldset" aria-describedby="search-hint">

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -47,26 +47,16 @@
           <button type="submit" class="govuk-button" data-prevent-double-click="true">Search</button>
         </fieldset>
       </form>
-      {% if waffle_flag %} 
       {% if non_matches %}
-      <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</caption>
-        <tbody class="govuk-table__body">
-        {% if non_matches|length > 1%} 
+      <h1 class="govuk-heading-l">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</h1>
+      <ul class="govuk-list">
         {% for non_match in non_matches %}
-            <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ non_match }}</td>
-              </tr>
+        <li class="govuk-listitem">
+            {{ non_match }}
+        </li>
         {% endfor %}
-        {% else %}
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">{{ non_matches }}</td>
-            </tr>
-        {% endif %} 
-            </tbody>
-            </table>
+      </ul>
       {% endif %} 
-      {% endif %}
       {% if search_results %}
         {% if waffle_flag %}
         <fieldset class="govuk-fieldset" aria-describedby="search-hint">

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -102,9 +102,9 @@
                   </table>
           {% endif %}
       {% else %}
-        {% if search_query %}
-          <h2 class="govuk-heading-m">Found 0 results</h2>
-        {% endif %}
+          {% if search_query and not non_matches %}
+            <h2 class="govuk-heading-m">Found 0 results</h2>
+          {% endif %}
       {% endif %}
     </div>
   </div>

--- a/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
+++ b/dataworkspace/dataworkspace/templates/datasets/search_authorised_users.html
@@ -51,7 +51,7 @@
       <h1 class="govuk-heading-l">Unable to match {{non_matches|length}} {% if non_matches|length == 1 %} email address to a user{% else %} email addresses to users{% endif %}</h1>
       <ul class="govuk-list">
         {% for non_match in non_matches %}
-        <li class="govuk-listitem">
+        <li class="govuk-body">
             {{ non_match }}
         </li>
         {% endfor %}


### PR DESCRIPTION
### Description of change
When searching for multiple dataset users, bad matches are now listed above the correct matches, although the styling of this is subject to change with PM review and more design information in the future. Matches are strictly filtered by exact email addresses, and so substrings of a real address will still result in a bad match.


### Checklist

* [ ] Have tests been added to cover any changes?
