### PR TITLE
fix: allow authorisation by email domain for visualisations

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -231,6 +231,8 @@ def application_api_is_allowed(request, public_host):
         )
 
     def is_published_visualisation_and_requires_authorisation_and_has_authorisation():
+        user_email_domain = request.user.email.split("@")[1]
+
         vis_requires_auth = (
             not is_preview
             and application_template.visible is True
@@ -243,6 +245,7 @@ def application_api_is_allowed(request, public_host):
             and not request.user.visualisationuserpermission_set.filter(
                 visualisation=visualisation_catalogue_item
             ).exists()
+            and user_email_domain not in visualisation_catalogue_item.authorized_email_domains
         ):
             raise DatasetPermissionDenied(visualisation_catalogue_item)
         return vis_requires_auth


### PR DESCRIPTION
### Description of change

Suspect this was just an oversight that it wasn't done when the authorisation by email domain feature was added

DT-984

### Checklist

* [ ] Have tests been added to cover any changes?


[DT-984]: https://uktrade.atlassian.net/browse/DT-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ