### PR TITLE
fix: update search query to ignore case

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1541,7 +1541,9 @@ class UserSearchFormView(EditBaseView, FormView):
                 for query in search_query.splitlines():
                     if not query.strip():
                         continue
-                    matches_for_query = get_user_model().objects.filter(Q(email=query.strip()))
+                    matches_for_query = get_user_model().objects.filter(
+                        Q(email__iexact=query.strip())
+                    )
                     for match in matches_for_query:
                         email_matches.append(match)
                     if not matches_for_query:


### PR DESCRIPTION
### Description of change
Ned Burton is trying to add a group of users to the Business Intelligence dashboard (https://data.trade.gov.uk/datasets/61a8066f-a3b9-4b59-baf3-ac39b663897f/search-authorized-users/408). However, a number of valid users are refusing to be added due to case sensitivity 

### Checklist

* [ ] Have tests been added to cover any changes?
