### PR TITLE
refactor: make generating JWT token independant of user

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/core/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/core/views.py
@@ -127,7 +127,11 @@ def invalidate_superset_user_cached_credentials():
 
 def generate_mlflow_jwt(request):
     user = get_user_model().objects.get(profile__sso_id=request.headers["sso-profile-user-id"])
-    jwt = generate_jwt_token(user)
+    authorised_hosts = list(
+        user.authorised_mlflow_instances.all().values_list("instance__hostname", flat=True)
+    )
+    sub = user.email
+    jwt = generate_jwt_token(authorised_hosts, sub)
     return JsonResponse({"jwt": jwt})
 
 

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -86,7 +86,11 @@ def spawn(
         valid_for=datetime.timedelta(days=31),
     )
 
-    jwt_token = generate_jwt_token(user)
+    authorised_hosts = list(
+        user.authorised_mlflow_instances.all().values_list("instance__hostname", flat=True)
+    )
+    sub = user.email
+    jwt_token = generate_jwt_token(authorised_hosts, sub)
 
     if application_instance.application_template.application_type == "TOOL":
         # For AppStream to access credentials

--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1413,7 +1413,7 @@ def b64encode_nopadding(to_encode):
     return urlsafe_b64encode(to_encode).rstrip(b"=")
 
 
-def generate_jwt_token(user):
+def generate_jwt_token(authorised_hosts, sub):
     private_key = load_pem_private_key(settings.JWT_PRIVATE_KEY.encode(), password=None)
     header = {
         "typ": "JWT",
@@ -1421,11 +1421,9 @@ def generate_jwt_token(user):
         "crv": "Ed25519",
     }
     payload = {
-        "sub": user.email,
+        "sub": sub,
         "exp": int(time.time() + 60 * 60 * 24),
-        "authorised_hosts": list(
-            user.authorised_mlflow_instances.all().values_list("instance__hostname", flat=True)
-        ),
+        "authorised_hosts": authorised_hosts,
     }
     to_sign = (
         b64encode_nopadding(json.dumps(header).encode("utf-8"))


### PR DESCRIPTION
### Description of change

This is a step towards granting custom visualisations access to MLFlow (which uses JWT tokens for auth) independently from the user that launched it

https://trello.com/c/xmJyHE8k/2-custom-visualisations-for-ml-flows

### Checklist

* [ ] Have tests been added to cover any changes?
