### PR TITLE
feat: DT-933 - Display security classification on catalogue pages

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/dataset_info.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info.html
@@ -1,6 +1,30 @@
-{% load humanize datasets_tags %}
+{% load humanize datasets_tags waffle_tags %}
 
 <dl class="govuk-summary-list">
+  {% flag SECURITY_CLASSIFICATION_FLAG %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Security classifications</dt>
+      <dd class="govuk-summary-list__value">
+        {% if model.get_government_security_classification_display == "OFFICIAL" %}
+          <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
+        {% else %}
+          {% if model.sensitivity.all %}
+            {% for sensitivity in model.sensitivity.all %}
+              <strong
+                class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }} {{ sensitivity }}</strong>
+            {% endfor %}
+          {% else %}
+            <strong class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}</strong>
+          {% endif %}
+        {% endif %}
+        <br>
+        <a
+          href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/information-classification-and-handling/"
+          class="govuk-link">Find out more about security classifications</a>
+      </dd>
+    </div>
+  {% endflag %}
+
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Date added</dt>
     <dd class="govuk-summary-list__value">{{ model.published_at|format_date_uk }}</dd>

--- a/dataworkspace/dataworkspace/templates/partials/dataset_info.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info.html
@@ -3,7 +3,7 @@
 <dl class="govuk-summary-list">
   {% flag SECURITY_CLASSIFICATION_FLAG %}
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Security classifications</dt>
+      <dt class="govuk-summary-list__key">Government Security Classification</dt>
       <dd class="govuk-summary-list__value">
         {% if model.get_government_security_classification_display == "OFFICIAL" %}
           <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
@@ -20,7 +20,7 @@
         <br>
         <a
           href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/information-classification-and-handling/"
-          class="govuk-link">Find out more about security classifications</a>
+          class="govuk-link">About security classifications</a>
       </dd>
     </div>
   {% endflag %}


### PR DESCRIPTION
### Description of change
User story
As a Data Workspace user, I need to know the Security Classification of data before I use it, so I can use it appropriately

Acceptance criteria
GIVEN that the user is on a catalogue page
THEN the table of metadata contains a new row called “Government Security Classification”
AND the row shows the current classification
AND the row includes a link “About security classifications“
AND the link goes to https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/information-classification-and-handling/

![image](https://user-images.githubusercontent.com/57753415/214372314-931afe34-278b-4df2-a14a-d13deb9f6109.png)


### Checklist

~* [ ] Have tests been added to cover any changes?~
