### PR TITLE
fix: ensure row count is limited to <download limit> to speed up grid

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -579,10 +579,13 @@ def build_filtered_dataset_query(inner_query, download_limit, column_config, par
     limit_clause = Composed([SQL(f" LIMIT {download_limit}")])
     rowcount_q = SQL(
         """
-        SELECT COUNT(iq.*) AS count
-        FROM ({}) AS iq
-        {}
-        {}
+        SELECT COUNT(*) AS count
+        FROM (
+            SELECT *
+            FROM ({}) iiq
+            {}
+            {}
+        ) AS iq
         """
     ).format(inner_query, SQL(" ").join(where_clause), limit_clause)
 

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -162,7 +162,7 @@ function initDataGrid(
     columnDefs: columnConfig,
     components: {
       loadingRenderer: function (params) {
-        if (params.value !== null && params.value !== undefined) {
+        if (params.data != null) {
           return params.valueFormatted !== null &&
             params.valueFormatted !== undefined
             ? params.valueFormatted


### PR DESCRIPTION
### Description of change

- Ensure the where and limit clauses are within the inner query so we only count the maximum number of rows we can download
- Fixes a small issue with the grid where an empty first column was displaying the loading spinner

### Checklist

* [ ] Have tests been added to cover any changes?
