### PR TITLE
feat: DT-1000 - Security Classification message on Tool launch screen

### DIFF
--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -84,8 +84,27 @@
           {{ loading_message.body }}
         </p>
       </div>
-      <p class="govuk-body">Remember you have a personal responsibility - alongside DIT’s corporate responsibility - to protect data.</p>
-      <p class="govuk-body">If you’re unsure about what you can and can’t do, contact the Data Protection team (<a class="govuk-link" href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>) or talk to your line manager.</p>
+      {% flag SECURITY_CLASSIFICATION_FLAG %}
+      <p class="govuk-body">
+        It is your personal responsibility, alongside DIT’s corporate responsibility, to protect and handle data
+        appropriately. This includes adhering to the Data Protection Act 2018 and General Data Protection Regulation
+        (GDPR).
+        <br><br>
+        Before you work with a dataset, check the Government Security Classification and usage restrictions on the <a
+        href="{{ root_href }}">Data Workspace catalogue</a>.
+        <br><br>
+        If you are unsure about what you can and can’t do, contact the dataset’s Information Asset Owner.
+        <br><br>
+        If you need to share or publish data that contains Personally Identifiable Information (PII), contact the Data
+        Protection team (<a href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>).
+      </p>
+      {% else %}
+      <p class="govuk-body">Remember you have a personal responsibility - alongside DIT’s corporate responsibility - to
+        protect data.</p>
+      <p class="govuk-body">If you’re unsure about what you can and can’t do, contact the Data Protection team (<a
+        class="govuk-link" href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>) or talk to your
+        line manager.</p>
+      {% endflag %}
     </div>
   </div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -1,5 +1,7 @@
 {% extends '_main.html' %}
 
+{% load waffle_tags %}
+
 {% block page_title %}{{ application_nice_name }} - {{ block.super }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -75,9 +75,13 @@
     </h2>
   </div>
   {% flag SECURITY_CLASSIFICATION_FLAG %}
-  <p class="govuk-body">
-    {{ application_nice_name }} will be stopped automatically if left inactive for more than two hours.
-  </p>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        {{ application_nice_name }} will be stopped automatically if left inactive for more than two hours.
+      </strong>
+    </div>
     {% else %}
     <p class="govuk-body">
       {{ application_nice_name }} will be automatically stopped after two hours of inactivity

--- a/dataworkspace/dataworkspace/templates/spawning.html
+++ b/dataworkspace/dataworkspace/templates/spawning.html
@@ -74,39 +74,45 @@
       This will take 2 minutes approximately<br />
     </h2>
   </div>
+  {% flag SECURITY_CLASSIFICATION_FLAG %}
   <p class="govuk-body">
-    {{ application_nice_name }} will be automatically stopped after two hours of inactivity
+    {{ application_nice_name }} will be stopped automatically if left inactive for more than two hours.
   </p>
-  <div class="govuk-grid-row govuk-!-margin-top-6">
+    {% else %}
+    <p class="govuk-body">
+      {{ application_nice_name }} will be automatically stopped after two hours of inactivity
+    </p>
+    <div class="govuk-grid-row govuk-!-margin-top-6">
     <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-inset-text">
-        <p class="govuk-body">
-          {{ loading_message.title }}
-          <br />
-          {{ loading_message.body }}
-        </p>
-      </div>
-      {% flag SECURITY_CLASSIFICATION_FLAG %}
+    <div class="govuk-inset-text">
       <p class="govuk-body">
-        It is your personal responsibility, alongside DIT’s corporate responsibility, to protect and handle data
-        appropriately. This includes adhering to the Data Protection Act 2018 and General Data Protection Regulation
-        (GDPR).
-        <br><br>
-        Before you work with a dataset, check the Government Security Classification and usage restrictions on the <a
-        href="{{ root_href }}">Data Workspace catalogue</a>.
-        <br><br>
-        If you are unsure about what you can and can’t do, contact the dataset’s Information Asset Owner.
-        <br><br>
-        If you need to share or publish data that contains Personally Identifiable Information (PII), contact the Data
-        Protection team (<a href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>).
+        {{ loading_message.title }}
+        <br/>
+        {{ loading_message.body }}
       </p>
-      {% else %}
-      <p class="govuk-body">Remember you have a personal responsibility - alongside DIT’s corporate responsibility - to
-        protect data.</p>
-      <p class="govuk-body">If you’re unsure about what you can and can’t do, contact the Data Protection team (<a
-        class="govuk-link" href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>) or talk to your
-        line manager.</p>
-      {% endflag %}
+    </div>
+  {% endflag %}
+  {% flag SECURITY_CLASSIFICATION_FLAG %}
+    <p class="govuk-body">
+      It is your personal responsibility, alongside DIT’s corporate responsibility, to protect and handle data
+      appropriately. This includes adhering to the Data Protection Act 2018 and General Data Protection Regulation
+      (GDPR).
+      <br><br>
+      Before you work with a dataset, check the Government Security Classification and usage restrictions on the <a
+      href="{{ root_href }}">Data Workspace catalogue</a>.
+      <br><br>
+      If you are unsure about what you can and can’t do, contact the dataset’s Information Asset Owner.
+      <br><br>
+      If you need to share or publish data that contains Personally Identifiable Information (PII), contact the Data
+      Protection team (<a href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>).
+    </p>
+    {% else %}
+    <p class="govuk-body">Remember you have a personal responsibility - alongside DIT’s corporate responsibility - to
+      protect data.</p>
+    <p class="govuk-body">If you’re unsure about what you can and can’t do, contact the Data Protection team (<a
+      class="govuk-link" href="mailto:data.protection@trade.gov.uk">data.protection@trade.gov.uk</a>) or talk to your
+      line manager.</p>
+  {% endflag %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
### Description of change
GIVEN that the user launches a tool and sees the launch screen
THEN the screen includes new security information in this PR
AND the link to the Data Workspace catalogue is https://data.trade.gov.uk/

(behind a feature flag)

### Checklist

* [ ] Have tests been added to cover any changes?
