### PR TITLE
feat: disable sending of notification emails

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -397,11 +397,11 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "schedule": crontab(minute=0, hour=6),
             "args": (),
         },
-        "send-notification-emails": {
-            "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
-            "schedule": 60 * 5,
-            "args": (),
-        },
+        # "send-notification-emails": {
+        #     "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
+        #     "schedule": 60 * 5,
+        #     "args": (),
+        # },
         "update-search-popularity": {
             "task": "dataworkspace.apps.datasets.search.update_datasets_average_daily_users",
             "schedule": crontab(minute=30),


### PR DESCRIPTION
### Description of change

This is a very speculative attempt at fixing Quicksight permissions syncing. Quicksight permissions syncing starts, but then just seems to stop. However, notification email sending seems to carry on.

So guessing, but maybe one is blocking the other? At the very least would make logs less noisy.

### Checklist

* [ ] Have tests been added to cover any changes?
