### PR TITLE
feat: more frequently attempt to sync Quicksight permissions

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -882,6 +882,16 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
 
 
 @celery_app.task()
+def full_quicksight_permissions_sync():
+    with cache.lock(
+        "full_quicksight_permissions_sync",
+        blocking_timeout=0,
+        timeout=360,
+    ):
+        sync_quicksight_permissions()
+
+
+@celery_app.task()
 @close_all_connections_if_not_in_atomic_block
 def sync_quicksight_permissions(user_sso_ids_to_update=tuple()):
     logger.info(

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -333,8 +333,8 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "args": (),
         },
         "full-quicksight-permissions-sync": {
-            "task": "dataworkspace.apps.applications.utils.sync_quicksight_permissions",
-            "schedule": crontab(minute=17, hour=1),
+            "task": "dataworkspace.apps.applications.utils.full_quicksight_permissions_sync",
+            "schedule": 60 * 10,
             "args": (),
         },
         "clean-up-old-data-explorer-playground-sql-queries": {


### PR DESCRIPTION
### Description of change

I assumed it did something like this already, but looks like it only attempted to do this in the middle of the night. Running more frequently at least for now _should_ help to surface problems (or even, just give it more of a chance of succeeding).

### Checklist

* [ ] Have tests been added to cover any changes?
