### PR TITLE
fix: catch spawning ThrottlingException within ClientError

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -529,11 +529,11 @@ class FargateSpawner:
 
         except ClientError as exception_obj:
             logger.exception("FARGATE %s %s", spawner_application_id_parsed, proxy_url)
-            if exception_obj.response['Error']['Code'] == 'ThrottlingException':
-                return 'RUNNING'
-            return 'STOPPED'
-        except Exception:
-            return 'STOPPED'
+            if exception_obj.response["Error"]["Code"] == "ThrottlingException":
+                return "RUNNING"
+            return "STOPPED"
+        except Exception:  # pylint: disable=broad-except
+            return "STOPPED"
 
     @staticmethod
     def stop(application_instance_id):

--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -527,9 +527,13 @@ class FargateSpawner:
             # ... and the spawner is stopped not if it's not
             return "STOPPED"
 
-        except Exception:  # pylint: disable=broad-except
+        except ClientError as exception_obj:
             logger.exception("FARGATE %s %s", spawner_application_id_parsed, proxy_url)
-            return "RUNNING"
+            if exception_obj.response['Error']['Code'] == 'ThrottlingException':
+                return 'RUNNING'
+            return 'STOPPED'
+        except Exception:
+            return 'STOPPED'
 
     @staticmethod
     def stop(application_instance_id):


### PR DESCRIPTION
### Description of change
Create two separate except clauses to deal with other errors where it should be STOPPED (since I think in the case of other errors there is a good chance that the tool has died and then the IP address re-used)

### Checklist

* [ ] Have tests been added to cover any changes?
