### PR TITLE
feat: carry on syncing quicksight users even if some failed

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -877,7 +877,8 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
                     data_client, account_id, quicksight_user, creds
                 )
 
-        except redis.exceptions.LockError:
+        # We want to sync as many users as possible even if some failed
+        except Exception:  # pylint: disable=broad-except
             logger.exception("Unable to sync permissions for %s", quicksight_user["Arn"])
 
 


### PR DESCRIPTION
### Description of change

I've seen "tuple concurrently updated errors" when granting privileges on the database. Our locking means this shouldn't happen. But it has. If it does, we at least do the remaining users.

### Checklist

* [ ] Have tests been added to cover any changes?
