### PR TITLE
Revert "feat: disable sending of notification emails"

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -397,11 +397,11 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
             "schedule": crontab(minute=0, hour=6),
             "args": (),
         },
-        # "send-notification-emails": {
-        #     "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
-        #     "schedule": 60 * 5,
-        #     "args": (),
-        # },
+        "send-notification-emails": {
+            "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
+            "schedule": 60 * 5,
+            "args": (),
+        },
         "update-search-popularity": {
             "task": "dataworkspace.apps.datasets.search.update_datasets_average_daily_users",
             "schedule": crontab(minute=30),


### PR DESCRIPTION
### Description of change

This reverts commit db276b64b83ac065ed33437db2914f1a81643ef1.

Now manually syncing Quicksight users, and have changed it to not stop syncing all Quicksight users at the first exception, so re-enabling the sending of emails.

### Checklist

* [ ] Have tests been added to cover any changes?
