### PR TITLE
fix: revoking team role from a user's role

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -260,7 +260,7 @@ def new_private_database_credentials(
                     pg_roles
                 WHERE
                     (
-                        rolname LIKE '\\_team\\_'
+                        rolname LIKE '\\_team\\_%'
                     )
                     AND pg_has_role({db_role}, rolname, 'member');
             """


### PR DESCRIPTION
### Description of change

PostgreSQL's LIKE must match the entire pattern, and without the % it would have looked for roles that are exactly `_team_`, rather than just starting with `_team_`

### Checklist

* [ ] Have tests been added to cover any changes?
