### PR TITLE
feat: DT-1085 - add security classification to visualisation pages

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -546,6 +546,8 @@ class VisualisationCatalogueItemEditForm(GOVUKDesignSystemModelForm):
             "short_description",
             "description",
             "enquiries_contact",
+            "government_security_classification",
+            "sensitivity",
             "secondary_enquiries_contact",
             "licence",
             "licence_url",
@@ -622,6 +624,12 @@ class VisualisationCatalogueItemEditForm(GOVUKDesignSystemModelForm):
         ),
         required=False,
     )
+
+    def __init__(self, request, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request = request
+        if waffle.flag_is_active(self.request, settings.SECURITY_CLASSIFICATION_FLAG):
+            self.fields["government_security_classification"].required = True
 
     def clean_enquiries_contact(self):
         if self.cleaned_data["enquiries_contact"]:

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1477,6 +1477,11 @@ class VisualisationCatalogueItemEditView(EditBaseView, UpdateView):
     form_class = VisualisationCatalogueItemEditForm
     template_name = "datasets/edit_visualisation_catalogue_item.html"
 
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
     def get_success_url(self):
         return self.object.get_absolute_url()
 

--- a/dataworkspace/dataworkspace/templates/datasets/edit_visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/edit_visualisation_catalogue_item.html
@@ -73,6 +73,78 @@
                       <input class="govuk-input" type="text" disabled value="{% if request.GET.secondary_enquiries_contact %}{{ request.GET.secondary_enquiries_contact }}{% else %}{{ form.secondary_enquiries_contact.value }}{% endif %}">
                       <a class="govuk-link" href="{% url 'datasets:search_secondary_enquiries_contact' object.id %}?enquiries_contact={{ request.GET.enquiries_contact }}">Add or change contact person</a>
                   </div>
+                  {% flag SECURITY_CLASSIFICATION_FLAG %}
+                    <div
+                      class="govuk-form-group {% if form.government_security_classification.errors %}govuk-form-group--error{% endif %}">
+                      <label class="govuk-label  govuk-!-font-weight-bold" for="id_government_security_classification">
+                        {{ form.government_security_classification.label }} *
+                      </label>
+                      <span class="govuk-hint">Choose the appropriate classification for this item. <a
+                        href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/guidance/information-classification-and-handling/">About Security Classifications</a> </span>
+                      {% if form.government_security_classification.errors %}
+                        <span id="id_government_security_classification-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error: </span> Please choose the appropriate Government Security Classification
+                          </span>
+                      {% endif %}
+                      <div class="govuk-radios">
+                        {% for value, text in form.government_security_classification.field.choices|slice:"1:" %}
+                          <div class="govuk-radios__item">
+                            <input class="govuk-radios__input" id="{{ value }}_id"
+                                   name="{{ form.government_security_classification.html_name }}" type="radio"
+                                   value="{{ value }}"
+                                   {% if value == form.government_security_classification.value %}checked{% endif %}
+                            >
+                            <label class="govuk-label govuk-radios__label"
+                                   for="{{ value }}_id">{{ text }}
+                            </label>
+                          </div>
+                        {% endfor %}
+                      </div>
+                    </div>
+                    <div class="govuk-inset-text" id="sensitivitySection"
+                         style="display: {% if form.government_security_classification.value == 2 %}block{% else %}none{% endif %}">
+                      <div
+                        class="govuk-form-group {% if form.sensitivity.errors %}govuk-form-group--error{% endif %}">
+                        {% if form.sensitivity.errors %}
+                          {% for error in form.sensitivity.errors %}
+                            <span class="govuk-error-message">
+                          <span class="govuk-visually-hidden">Error:</span>
+                          {{ error }}
+                        </span>
+                          {% endfor %}
+                        {% endif %}
+                        <label class="govuk-label  govuk-!-font-weight-bold" for="{{ form.sensitivity.id_for_label }}">
+                          {{ form.sensitivity.label }}
+                        </label>
+                        <span class="govuk-hint">If the data is of a particularly sensitive nature, please choose the relevant options below so that it can be protected and handled the right way.</span>
+                        <div class="govuk-checkboxes--small">
+                          {% for value, text in form.sensitivity.field.choices %}
+                            <div class="govuk-checkboxes__item">
+                              <input
+                                {% if value in form.sensitivity.value %}checked{% endif %}
+                                class="govuk-checkboxes__input"
+                                id="id_{{ value }}"
+                                name="{{ form.sensitivity.html_name }}"
+                                type="checkbox"
+                                value="{{ value }}"
+                              >
+                              <label class="govuk-label govuk-checkboxes__label"
+                                     for="id_{{ value }}">
+                                {{ text|sensitivity_with_descriptor }}
+                              </label>
+                            </div>
+                          {% endfor %}
+                        </div>
+                      </div>
+                    </div>
+                    <div class="govuk-warning-text">
+                      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                      <strong class="govuk-warning-text__text">
+                        <span class="govuk-warning-text__assistive">Warning</span>
+                        Data Workspace is not accredited for SECRET or TOP SECRET information.
+                      </strong>
+                    </div>
+                  {% endflag %}
                     {{ form.licence }}
                     {{ form.licence_url }}
                     {{ form.retention_policy }}
@@ -113,4 +185,12 @@
 
 {% block footer_scripts %}
   {{ form.media }}
+  <script nonce="{{ request.csp_nonce }}">
+    const sensitivity = document.getElementById('sensitivitySection')
+    document.getElementsByName("government_security_classification").forEach(item => {
+      item.addEventListener("change", event => {
+        (event.target.value === "2" ? sensitivity.style.display = "block" : sensitivity.style.display = "none")
+      })
+    })
+  </script>
 {% endblock footer_scripts %}


### PR DESCRIPTION
### Description of change
The Security Classification options are there on the Manage screen for datasets but are missing for visualisation catalogue items.

https://data.trade.gov.uk/datasets/f12f5bb0-a000-4024-b5bf-bac9e5b2a06b/edit-visualisation-catalogue-item

The options are there in Django Admin but not on the frontend for users.

### Checklist

* [ ] Have tests been added to cover any changes?
