### PR TITLE
feat: DT-1089 - update dataset summary

### DIFF
--- a/dataworkspace/dataworkspace/templates/partials/dataset_info.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info.html
@@ -1,6 +1,10 @@
 {% load humanize datasets_tags waffle_tags %}
 
 <dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Summary</dt>
+    <dd class="govuk-summary-list__value">{{ model.short_description }}</dd>
+  </div>
   {% flag SECURITY_CLASSIFICATION_FLAG %}
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Government Security Classification</dt>
@@ -24,6 +28,15 @@
       </dd>
     </div>
   {% endflag %}
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Personal data</dt>
+    <dd class="govuk-summary-list__value">{{ model.personal_data|default:'' }}</dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Usage restrictions</dt>
+    <dd class="govuk-summary-list__value">{{ model.restrictions_on_usage | linebreaksbr }}</dd>
+  </div>
 
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Date added</dt>
@@ -38,16 +51,6 @@
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Source</dt>
     <dd class="govuk-summary-list__value">{{ source_text }}</dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Restrictions on usage</dt>
-    <dd class="govuk-summary-list__value">{{ model.restrictions_on_usage | linebreaksbr }}</dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Summary</dt>
-    <dd class="govuk-summary-list__value">{{ model.short_description }}</dd>
   </div>
 
   <div class="govuk-summary-list__row">

--- a/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info_additional.html
@@ -22,11 +22,6 @@
       </div>
 
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Personal Data</dt>
-        <dd class="govuk-summary-list__value">{{ model.personal_data|default:'' }}</dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Retention period details</dt>
         <dd class="govuk-summary-list__value">{{ model.retention_policy | linebreaksbr }}</dd>
       </div>


### PR DESCRIPTION
### Description of change
To accompany the new Government Security Classification, can we move Personal data immediately after it in the metadata table, and “Restrictions on usage” after that.

Can we also change the names to:

Personal data (small d)

Usage restrictions (shorter)

Could we also move the Summary to the top (above Government Security Classification).

### Checklist

* [ ] Have tests been added to cover any changes?
