### PR TITLE
fix: get quicksight user by SSO id instead of email

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -804,7 +804,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
         user_email = quicksight_user["Email"].lower()
         user_role = quicksight_user["Role"]
         user_username = quicksight_user["UserName"]
-        sso_id = quicksight_user["UserName"].split('/')[-1]
+        sso_id = quicksight_user["UserName"].split("/")[-1]
 
         if user_role not in {"AUTHOR", "ADMIN"}:
             logger.info("Skipping %s with role %s.", user_email, user_role)
@@ -856,9 +856,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
                 logger.info("Syncing QuickSight resources for %s", dw_user)
 
                 source_tables = source_tables_for_user(dw_user)
-                db_role_schema_suffix = stable_identification_suffix(
-                    str(sso_id), short=True
-                )
+                db_role_schema_suffix = stable_identification_suffix(str(sso_id), short=True)
 
                 # This creates a DB user for each of our datasets DBs. These users are intended to be long-lived,
                 # so they might already exist. If this is the case, we still generate a new password, as at the moment

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -843,7 +843,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
 
                     raise e
 
-                dw_user = get_user_model().objects.get(id=sso_id)
+                dw_user = get_user_model().objects.get(profile__sso_id=sso_id)
                 if not dw_user:
                     logger.error(
                         "Skipping %s - cannot match with Data Workspace user.",

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -804,6 +804,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
         user_email = quicksight_user["Email"].lower()
         user_role = quicksight_user["Role"]
         user_username = quicksight_user["UserName"]
+        sso_id = quicksight_user["UserName"].split('/')[-1]
 
         if user_role not in {"AUTHOR", "ADMIN"}:
             logger.info("Skipping %s with role %s.", user_email, user_role)
@@ -842,7 +843,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
 
                     raise e
 
-                dw_user = get_user_model().objects.filter(email=user_email).first()
+                dw_user = get_user_model().objects.get(id=sso_id)
                 if not dw_user:
                     logger.error(
                         "Skipping %s - cannot match with Data Workspace user.",
@@ -856,7 +857,7 @@ def sync_quicksight_users(data_client, user_client, account_id, quicksight_user_
 
                 source_tables = source_tables_for_user(dw_user)
                 db_role_schema_suffix = stable_identification_suffix(
-                    str(dw_user.profile.sso_id), short=True
+                    str(sso_id), short=True
                 )
 
                 # This creates a DB user for each of our datasets DBs. These users are intended to be long-lived,

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -73,7 +73,7 @@ class TestSyncQuickSightPermissions:
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_create_new_data_source(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
-        UserFactory.create(username="fake@email.com")
+        user = UserFactory.create(username="fake@email.com")
         SourceTableFactory(
             dataset=MasterDataSetFactory.create(
                 user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
@@ -87,7 +87,7 @@ class TestSyncQuickSightPermissions:
                     "Arn": "Arn",
                     "Email": "fake@email.com",
                     "Role": "AUTHOR",
-                    "UserName": "user/fake@email.com",
+                    "UserName": f"user/fake@email.com/{user.profile.sso_id}",
                 }
             ]
         }
@@ -110,10 +110,11 @@ class TestSyncQuickSightPermissions:
                 Namespace=settings.QUICKSIGHT_NAMESPACE,
                 Role="AUTHOR",
                 CustomPermissionsName="author-custom-permissions-test",
-                UserName="user/fake@email.com",
+                UserName=f"user/fake@email.com/{user.profile.sso_id}",
                 Email="fake@email.com",
             )
         ]
+
         assert mock_data_client.create_data_source.call_args_list == [
             mock.call(
                 AwsAccountId=mock.ANY,

--- a/dataworkspace/dataworkspace/tests/applications/test_utils.py
+++ b/dataworkspace/dataworkspace/tests/applications/test_utils.py
@@ -233,7 +233,7 @@ class TestSyncQuickSightPermissions:
     @mock.patch("dataworkspace.apps.applications.utils.cache")
     def test_update_existing_data_source(self, mock_cache, mock_boto3_client, mock_creds):
         # Arrange
-        UserFactory.create(username="fake@email.com")
+        user = UserFactory.create(username="fake@email.com")
         SourceTableFactory(
             dataset=MasterDataSetFactory.create(
                 user_access_type=UserAccessType.REQUIRES_AUTHENTICATION
@@ -247,7 +247,7 @@ class TestSyncQuickSightPermissions:
                     "Arn": "Arn",
                     "Email": "fake@email.com",
                     "Role": "AUTHOR",
-                    "UserName": "user/fake@email.com",
+                    "UserName": f"user/fake@email.com/{user.profile.sso_id}",
                 }
             ]
         }
@@ -280,7 +280,7 @@ class TestSyncQuickSightPermissions:
                 Namespace=settings.QUICKSIGHT_NAMESPACE,
                 Role="AUTHOR",
                 CustomPermissionsName="author-custom-permissions-test",
-                UserName="user/fake@email.com",
+                UserName=f"user/fake@email.com/{user.profile.sso_id}",
                 Email="fake@email.com",
             )
         ]
@@ -371,7 +371,7 @@ class TestSyncQuickSightPermissions:
                     "Arn": "Arn",
                     "Email": "fake2@email.com",
                     "Role": "ADMIN",
-                    "UserName": "user/fake2@email.com",
+                    "UserName": f"user/fake2@email.com/{user2.profile.sso_id}",
                 }
             },
             botocore.exceptions.ClientError(
@@ -404,7 +404,7 @@ class TestSyncQuickSightPermissions:
                 Namespace=settings.QUICKSIGHT_NAMESPACE,
                 Role="ADMIN",
                 UnapplyCustomPermissions=True,
-                UserName="user/fake2@email.com",
+                UserName=f"user/fake2@email.com/{user2.profile.sso_id}",
                 Email="fake2@email.com",
             )
         ]


### PR DESCRIPTION
### Description of change
The sync of permissions currently uses email address to match users, but users sometimes have more than one email address. This is causing problems where users cannot access QuickSight because the "wrong" email address has been synced.

Can we change the sync to match users on SSO ID instead, since this is unique and there is only one for each user?

(FYI this also seems to be affecting Your Files uploads for this user)

### Checklist

* [ ] Have tests been added to cover any changes?
