### PR TITLE
feat: replace user email with ssoid to hide reader accounts when sharing dashboards

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -332,7 +332,7 @@ data "aws_iam_policy_document" "admin_dashboard_embedding" {
   }
   statement {
     actions = ["quicksight:GetAuthCode"]
-    resources = ["arn:aws:quicksight:*:${data.aws_caller_identity.aws_caller_identity.account_id}:user/default/${var.prefix}-quicksight-embedding/*"]
+    resources = ["arn:aws:quicksight:*:${data.aws_caller_identity.aws_caller_identity.account_id}:user/${var.quicksight_namespace}/${var.prefix}-quicksight-embedding/*"]
   }
 }
 


### PR DESCRIPTION
### Description of change
There is often confusion when sharing quicksight dashboards due to the seperate READER and AUTHOR users. While we would like to have a single user for these, in the meantime this PR replaces the {user.email} in the name of READER users with their {sso_id}. This should hopefully hide these fromthe options when sharing a dashboard.

This includes a fix to correct the embed role for non prod environments, an oversight from previous changes to quicksight namespaces

### Checklist

* [ ] Have tests been added to cover any changes?
