### PR TITLE
Increased the max number of db connections available for quicksight celery tasks

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -496,7 +496,7 @@ DATABASES = {
         "ENGINE": "django_db_geventpool.backends.postgresql_psycopg2",
         "CONN_MAX_AGE": 0,
         **env["ADMIN_DB"],
-        "OPTIONS": {"sslmode": "require", "MAX_CONNS": 20},
+        "OPTIONS": {"sslmode": "require", "MAX_CONNS": int(env.get("DEFAULT_DB_MAX_CONNS", "20"))},
     },
     **{
         database_name: {

--- a/dataworkspace/start-celery.sh
+++ b/dataworkspace/start-celery.sh
@@ -9,5 +9,5 @@ set -e
     parallel --will-cite --line-buffer --jobs 3 --halt now,done=1 ::: \
         "celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150 --hostname spawner@%h -Q applications.spawner.spawn" \
         "celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150 --hostname explorer@%h -Q explorer.tasks" \
-        "celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150 --hostname default@%h -X applications.spawner.spawn,explorer.tasks"
+        "DEFAULT_DB_MAX_CONNS=60 celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 60 --hostname default@%h -X applications.spawner.spawn,explorer.tasks"
 )


### PR DESCRIPTION
### Description of change
After some investigation around permission syncs and other tasks that hinted
that tasks weren't running due to contention for a limited resource. This is a
speculative change that increases the limit for db connections for those tasks.
We are deliberately not increasing limit everywhere to avoid hitting the max
number of connections on the db itself.


### Checklist

* [ ] Have tests been added to cover any changes?
