### PR TITLE
feat: avoid running more than one send_notification_emails task at a time

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -1019,13 +1019,14 @@ def send_notification_emails():
             except IntegrityError as e:
                 logger.error("Exception when sending notifications: %s", e)
 
-    try:
-        with transaction.atomic():
-            create_notifications()
-    except IntegrityError as e:
-        logger.error("Exception when creating notifications: %s", e)
-    else:
-        send_notifications()
+    with cache.lock("send_notification_emails", blocking_timeout=0, timeout=3600):
+        try:
+            with transaction.atomic():
+                create_notifications()
+        except IntegrityError as e:
+            logger.error("Exception when creating notifications: %s", e)
+        else:
+            send_notifications()
 
 
 def get_dataset_table(obj):


### PR DESCRIPTION
### Description of change

The job is set to run every 5 minutes, but looks like the job can in some cases take more than 5 minutes. Not really sure how long the "timeout" value should be - this is the maximum time the lock can be held. Maybe this is too short. However, it's still longer than now which is essentially "0" beceause there is no lock

Suspect this could be a contributing factor to various background jobs not running - if many send_notification_emails jobs were running, for various reasons they could have blocked others.

DT-1162

### Checklist

* [ ] Have tests been added to cover any changes?
