### PR TITLE
feat: DT-1168 - replace none with awaiting classification

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/charts/filter_chart_data.html
+++ b/dataworkspace/dataworkspace/templates/datasets/charts/filter_chart_data.html
@@ -9,18 +9,23 @@
 {% block content %}
   <div class="govuk-grid-row">
     {% flag SECURITY_CLASSIFICATION_FLAG %}
-    <div class="govuk-grid-column-full" style ="margin-bottom: 13px;">
-      {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-        <strong class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
-      {% else %}
-        <strong class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-          {% if object.dataset.sensitivity.all %}
-            {% for sensitivity in object.dataset.sensitivity.all %}
-              {% if not forloop.first  %}and{% endif %}</span> {{ sensitivity }}
-            {% endfor %}
-        {% endif %} </strong>
-      {% endif %}   
-    </div>
+      <div class="govuk-grid-column-full" style="margin-bottom: 13px;">
+        {% if not model.government_security_classification %}
+          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+        {% else %}
+          {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+            <strong
+              class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+          {% else %}
+            <strong class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+              {% if object.dataset.sensitivity.all %}
+                {% for sensitivity in object.dataset.sensitivity.all %}
+                  {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+                {% endfor %}
+              {% endif %} </strong>
+          {% endif %}
+        {% endif %}
+      </div>
     {% endflag %}   
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">{{ source.name }}</h1>

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -24,10 +24,10 @@
       null,
       '{{ object.name }}-custom-export.csv',
       {% flag CHART_BUILDER_BUILD_CHARTS_FLAG %}
-        '{% url 'datasets:create_chart_from_grid' object.dataset.id object.id %}'
+        '{% url 'datasets:create_chart_from_grid' object.dataset.id object.id %}',
       {% else %}
-        null
-      {% endflag %},
+        null,
+      {% endflag %}
       null,
       '{{ object.dataset.id }}',
       '{{ object.dataset.name }}',
@@ -40,16 +40,21 @@
   <div class="govuk-grid-row">
   {% flag SECURITY_CLASSIFICATION_FLAG %}
     <div class="govuk-grid-column-full" style ="margin-bottom: 13px;">
-      {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-        <strong class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+      {% if not model.government_security_classification %}
+        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
       {% else %}
-        <strong class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-          {% if object.dataset.sensitivity.all %}
-            {% for sensitivity in object.dataset.sensitivity.all %}
-              {% if not forloop.first  %}and{% endif %}</span> {{ sensitivity }}
-            {% endfor %}
-        {% endif %} </strong>
-      {% endif %}      
+        {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+          <strong
+            class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+        {% else %}
+          <strong class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+            {% if object.dataset.sensitivity.all %}
+              {% for sensitivity in object.dataset.sensitivity.all %}
+                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+              {% endfor %}
+            {% endif %} </strong>
+        {% endif %}
+      {% endif %}
     </div>
   {% endflag %}
     <div class="govuk-grid-column-full">

--- a/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
@@ -23,20 +23,24 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-    {% flag SECURITY_CLASSIFICATION_FLAG %}
-    {% if source.dataset.government_security_classification %}
-      {% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
-        <strong class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display }}</strong>
-      {% else %}
-        <strong class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display }}
-          {% if source.dataset.sensitivity.all %}
-            {% for sensitivity in source.dataset.sensitivity.all %}
-              {% if not forloop.first %}<span>and{% endif %}</span> {{ sensitivity }}
-            {% endfor %}
+      {% flag SECURITY_CLASSIFICATION_FLAG %}
+        {% if source.dataset.government_security_classification %}
+          {% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
+            <strong
+              class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display }}</strong>
+          {% else %}
+            <strong
+              class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display }}
+              {% if source.dataset.sensitivity.all %}
+                {% for sensitivity in source.dataset.sensitivity.all %}
+                  {% if not forloop.first %}<span>and{% endif %}</span> {{ sensitivity }}
+                {% endfor %}
+              {% endif %}
+            </strong>
           {% endif %}
-        </strong>
-      {% endif %}
-    {% endif %}
+        {% else %}
+          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+        {% endif %}
     {% endflag %}
       <h1 class="govuk-heading-l">"{{ source.schema }}"."{{ source.table }}"</h1>
       <p class="govuk-body govuk-body-m">
@@ -48,10 +52,14 @@
   <div class="govuk-grid-row govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-s">Government Security Classification</h1>
     <p class="govuk-body govuk-body-m">
-      This data is currently classified as {% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
-        <strong class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display }}</strong>
+      This data is currently classified as {% if not model.government_security_classification %}
+      <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+      {% else %}{% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
+        <strong
+          class="govuk-tag govuk-tag--blue">{{ source.dataset.get_government_security_classification_display }}</strong>
       {% else %}
-        <strong class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display }}
+        <strong
+          class="govuk-tag govuk-tag--red govuk-!-margin-bottom-4">{{ source.dataset.get_government_security_classification_display }}
           {% if source.dataset.sensitivity.all %}
             {% for sensitivity in source.dataset.sensitivity.all %}
               {% if not forloop.first %}<span>and {% endif %}</span>{{ sensitivity }}
@@ -59,6 +67,7 @@
           {% endif %}
         </strong>
       {% endif %}
+    {% endif %}
       <br>If this is no longer correct, please update the classification on
       the <a href="{% url 'datasets:edit_dataset' source.dataset.id %}">Manage screen.</a>
     </p>

--- a/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
+++ b/dataworkspace/dataworkspace/templates/datasets/reference_dataset_grid.html
@@ -36,16 +36,20 @@
   <div class="govuk-grid-row">
   {% flag SECURITY_CLASSIFICATION_FLAG %}
     <div class="govuk-grid-column-full" style ="margin-bottom: 13px;">
-      {% if model.get_government_security_classification_display == "OFFICIAL" %}
-        <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
+      {% if not model.government_security_classification %}
+        <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
       {% else %}
-        <strong class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}
-          {% if model.sensitivity.all %}
-            {% for sensitivity in model.sensitivity.all %}
-              {% if not forloop.first  %}and{% endif %}</span> {{ sensitivity }}
-            {% endfor %}
-        {% endif %} </strong>
-      {% endif %}      
+        {% if model.get_government_security_classification_display == "OFFICIAL" %}
+          <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
+        {% else %}
+          <strong class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}
+            {% if model.sensitivity.all %}
+              {% for sensitivity in model.sensitivity.all %}
+                {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+              {% endfor %}
+            {% endif %} </strong>
+        {% endif %}
+      {% endif %}
     </div>
   {% endflag %}
     <div class="govuk-grid-column-two-thirds">

--- a/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/referencedataset_detail.html
@@ -111,16 +111,22 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Government Security Classification</dt>
       <dd class="govuk-summary-list__value">
-        {% if model.get_government_security_classification_display == "OFFICIAL" %}
-          <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
+        {% if not model.government_security_classification %}
+          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
         {% else %}
-          {% if model.sensitivity.all %}
-            {% for sensitivity in model.sensitivity.all %}
-              <strong
-                class="govuk-tag govuk-tag--red govuk-!-margin-bottom-1">{{ model.get_government_security_classification_display }} {{ sensitivity }}</strong>
-            {% endfor %}
+          {% if model.get_government_security_classification_display == "OFFICIAL" %}
+            <strong
+              class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
           {% else %}
-            <strong class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}</strong>
+            {% if model.sensitivity.all %}
+              {% for sensitivity in model.sensitivity.all %}
+                <strong
+                  class="govuk-tag govuk-tag--red govuk-!-margin-bottom-1">{{ model.get_government_security_classification_display }} {{ sensitivity }}</strong>
+              {% endfor %}
+            {% else %}
+              <strong
+                class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}</strong>
+            {% endif %}
           {% endif %}
         {% endif %}
       <br>

--- a/dataworkspace/dataworkspace/templates/partials/dataset_info.html
+++ b/dataworkspace/dataworkspace/templates/partials/dataset_info.html
@@ -9,16 +9,22 @@
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Government Security Classification</dt>
       <dd class="govuk-summary-list__value">
-        {% if model.get_government_security_classification_display == "OFFICIAL" %}
-          <strong class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
+        {% if not model.government_security_classification %}
+          <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
         {% else %}
-          {% if model.sensitivity.all %}
-            {% for sensitivity in model.sensitivity.all %}
-              <strong
-                class="govuk-tag govuk-tag--red govuk-!-margin-bottom-1">{{ model.get_government_security_classification_display }} {{ sensitivity }}</strong>
-            {% endfor %}
+          {% if model.get_government_security_classification_display == "OFFICIAL" %}
+            <strong
+              class="govuk-tag govuk-tag--blue">{{ model.get_government_security_classification_display }}</strong>
           {% else %}
-            <strong class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}</strong>
+            {% if model.sensitivity.all %}
+              {% for sensitivity in model.sensitivity.all %}
+                <strong
+                  class="govuk-tag govuk-tag--red govuk-!-margin-bottom-1">{{ model.get_government_security_classification_display }} {{ sensitivity }}</strong>
+              {% endfor %}
+            {% else %}
+              <strong
+                class="govuk-tag govuk-tag--red">{{ model.get_government_security_classification_display }}</strong>
+            {% endif %}
           {% endif %}
         {% endif %}
       <br>

--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -126,16 +126,22 @@
           {% flag SECURITY_CLASSIFICATION_FLAG %}
           <div class="govuk-grid-column-one-half" style="text-align: right;">
             <div class="govuk-breadcrumbs" style="margin-top: 13px;">
-              {% if catalogue_item.get_government_security_classification_display == "OFFICIAL" %}
-              <strong class="govuk-tag govuk-tag--blue">{{ catalogue_item.get_government_security_classification_display }}</strong>
+              {% if not model.government_security_classification %}
+                <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
+              {% else %}
+                {% if catalogue_item.get_government_security_classification_display == "OFFICIAL" %}
+                  <strong
+                    class="govuk-tag govuk-tag--blue">{{ catalogue_item.get_government_security_classification_display }}</strong>
                 {% else %}
-                  <strong class="govuk-tag govuk-tag--red">{{ catalogue_item.get_government_security_classification_display }}
+                  <strong
+                    class="govuk-tag govuk-tag--red">{{ catalogue_item.get_government_security_classification_display }}
                     {% if catalogue_item.sensitivity.all %}
                       {% for sensitivity in catalogue_item.sensitivity.all %}
-                        {% if not forloop.first  %}and{% endif %}</span> {{ sensitivity }}
+                        {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
                       {% endfor %}
-                  {% endif %} </strong>
-              {% endif %}   
+                    {% endif %} </strong>
+                {% endif %}
+              {% endif %}
             </div>
           </div>
         {% endflag %}


### PR DESCRIPTION
### Description of change
Currently when an item does not have a security classification it says “None”. This is incorrect and misleading.

Can we replace this with “Awaiting classification”


### Checklist

* [ ] Have tests been added to cover any changes?
