### PR TITLE
feat: DT-1136 - Reveal manage screen for superusers on data cuts

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -84,7 +84,7 @@
         </a>
       </p>
       {% endif %}
-      {% if request.user == model.information_asset_owner or request.user == model.information_asset_manager %}
+      {% if request.user.is_superuser or request.user == model.information_asset_owner or request.user == model.information_asset_manager %}
           <p class="govuk-body sidebar-section">
             <a href="{% url 'datasets:edit_dataset' model.id %}" class="govuk-link">Manage this dataset</a>
           </p>


### PR DESCRIPTION
### Description of change

The Manage link/screen is visible to users on Source datasets but not on Data cuts. 

Graham has checked with Anthony and there are no concerns about adding it.

Can we reveal the Manage link for superusers so that they can edit data cuts on the front-end?
### Checklist

* [ ] Have tests been added to cover any changes?
