### PR TITLE
fix: correct model reference to security classification

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/charts/filter_chart_data.html
+++ b/dataworkspace/dataworkspace/templates/datasets/charts/filter_chart_data.html
@@ -10,7 +10,7 @@
   <div class="govuk-grid-row">
     {% flag SECURITY_CLASSIFICATION_FLAG %}
       <div class="govuk-grid-column-full" style="margin-bottom: 13px;">
-        {% if not model.government_security_classification %}
+        {% if not object.dataset.government_security_classification %}
           <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
         {% else %}
           {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -40,7 +40,7 @@
   <div class="govuk-grid-row">
   {% flag SECURITY_CLASSIFICATION_FLAG %}
     <div class="govuk-grid-column-full" style ="margin-bottom: 13px;">
-      {% if not model.government_security_classification %}
+      {% if not object.dataset.government_security_classification %}
         <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
       {% else %}
         {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}

--- a/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/manage_source_table.html
@@ -52,7 +52,7 @@
   <div class="govuk-grid-row govuk-grid-column-two-thirds">
   <h1 class="govuk-heading-s">Government Security Classification</h1>
     <p class="govuk-body govuk-body-m">
-      This data is currently classified as {% if not model.government_security_classification %}
+      This data is currently classified as {% if not source.dataset.government_security_classification %}
       <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
       {% else %}{% if source.dataset.get_government_security_classification_display == "OFFICIAL" %}
         <strong

--- a/dataworkspace/dataworkspace/templates/running_base.html
+++ b/dataworkspace/dataworkspace/templates/running_base.html
@@ -126,7 +126,7 @@
           {% flag SECURITY_CLASSIFICATION_FLAG %}
           <div class="govuk-grid-column-one-half" style="text-align: right;">
             <div class="govuk-breadcrumbs" style="margin-top: 13px;">
-              {% if not model.government_security_classification %}
+              {% if not catalogue_item.government_security_classification %}
                 <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
               {% else %}
                 {% if catalogue_item.get_government_security_classification_display == "OFFICIAL" %}


### PR DESCRIPTION
### Description of change
Reference for awaiting security classification in some places is incorrect. This is a PR to correct to ensure security classification is displayed appropriately everywhere

### Checklist

* [ ] Have tests been added to cover any changes?
