### PR TITLE
feat: add quicksight identifier to API endpoint

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -53,7 +53,7 @@ class CatalogueItemSerializer(serializers.Serializer):
     is_draft = serializers.BooleanField(source="draft")
     dictionary_published = serializers.BooleanField(source="dictionary")
     user_ids = serializers.ListField()
-    visualisation_type = serializers.SerializerMethodField()
+    visualisation_type = serializers.CharField()
 
     def to_representation(self, instance):
         instance = super().to_representation(instance)

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -53,6 +53,7 @@ class CatalogueItemSerializer(serializers.Serializer):
     is_draft = serializers.BooleanField(source="draft")
     dictionary_published = serializers.BooleanField(source="dictionary")
     user_ids = serializers.ListField()
+    visualisation_type = serializers.SerializerMethodField()
 
     def to_representation(self, instance):
         instance = super().to_representation(instance)
@@ -68,6 +69,7 @@ class CatalogueItemSerializer(serializers.Serializer):
         instance["retention_policy"] = instance["retention_policy"] or None
         instance["user_access_type"] = instance["user_access_type"]
         instance["authorized_email_domains"] = instance["authorized_email_domains"]
+        instance["visualisation_type"] = instance["visualisation_type"] or None
         return instance
 
     def get_source_tables(self, instance):

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -53,7 +53,7 @@ class CatalogueItemSerializer(serializers.Serializer):
     is_draft = serializers.BooleanField(source="draft")
     dictionary_published = serializers.BooleanField(source="dictionary")
     user_ids = serializers.ListField()
-    visualisation_type = serializers.CharField()
+    visualisation_type = serializers.CharField(allow_null=True)
 
     def to_representation(self, instance):
         instance = super().to_representation(instance)

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -332,7 +332,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "user_access_type",
         "authorized_email_domains",
         "user_ids",
-        "visualisation_link",
+        "visualisation_type",
     ]
     queryset = (
         DataSet.objects.live()

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -332,7 +332,6 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "user_access_type",
         "authorized_email_domains",
         "user_ids",
-        "identifier",
     ]
     queryset = (
         DataSet.objects.live()

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -332,6 +332,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "user_access_type",
         "authorized_email_domains",
         "user_ids",
+        "visualisation_link",
     ]
     queryset = (
         DataSet.objects.live()

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -353,6 +353,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         )
         .annotate(draft=_static_bool(None))
         .annotate(dictionary=F("dictionary_published"))
+        .annotate(visualisation_type=_static_char(None))
         .exclude(type=DataSetType.REFERENCE)
         .values(*fields)
         .union(
@@ -373,6 +374,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             .annotate(user_ids=Value([], output_field=ArrayField(models.IntegerField())))
             .annotate(draft=F("is_draft"))
             .annotate(dictionary=F("published"))
+            .annotate(visualisation_type=_static_char(None))
             .values(*_replace(fields, "id", "uuid"))
         )
         .union(
@@ -398,22 +400,14 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                 visualisation_type=models.Case(
                     models.When(
                         visualisationlink__visualisation_type="QUICKSIGHT",
-                        then=Value("QUICKSIGHT"),
-                    ),
-                    default=Value(""),
-                    output_field=models.CharField(),
-                )
-            )
-            .values(
-                *fields,
-                visualisation_type=models.Case(
-                    models.When(
-                        visualisationlink__visualisation_type="QUICKSIGHT",
                         then="visualisationlink__identifier",
                     ),
                     default=None,
                     output_field=models.CharField(),
                 ),
+            )
+            .values(
+                *fields,
             )
         )
     ).order_by("created_date")

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -477,6 +477,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             if isinstance(dataset, ReferenceDataset)
             else dataset.authorized_email_domains,
             "user_ids": userids,
+            "visualisation_type": None,
         }
 
     def test_success(self, unauthenticated_client):


### PR DESCRIPTION
### Description of change
As part of work done to assist D&A ingesting DW catalogue pages into data flow, creating this ticket to expose quicksight identifier. To note - supersets are excluded

### Checklist

* [ ] Have tests been added to cover any changes?
