### PR TITLE
fix: correct quicksight_id to have an appropriate name

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/serializers.py
@@ -53,7 +53,7 @@ class CatalogueItemSerializer(serializers.Serializer):
     is_draft = serializers.BooleanField(source="draft")
     dictionary_published = serializers.BooleanField(source="dictionary")
     user_ids = serializers.ListField()
-    visualisation_type = serializers.CharField(allow_null=True)
+    quicksight_id = serializers.CharField(allow_null=True)
 
     def to_representation(self, instance):
         instance = super().to_representation(instance)
@@ -69,7 +69,7 @@ class CatalogueItemSerializer(serializers.Serializer):
         instance["retention_policy"] = instance["retention_policy"] or None
         instance["user_access_type"] = instance["user_access_type"]
         instance["authorized_email_domains"] = instance["authorized_email_domains"]
-        instance["visualisation_type"] = instance["visualisation_type"] or None
+        instance["quicksight_id"] = instance["quicksight_id"] or None
         return instance
 
     def get_source_tables(self, instance):

--- a/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v1/datasets/views.py
@@ -338,7 +338,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
         "user_ids",
         "security_classification_display",
         "sensitivity_name",
-        "visualisation_type",
+        "quicksight_id",
     ]
     queryset = (
         DataSet.objects.live()
@@ -369,7 +369,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             )
         )
         .annotate(sensitivity_name=ArrayAgg("sensitivity__name", distinct=True))
-        .annotate(visualisation_type=_static_char(None))
+        .annotate(quicksight_id=_static_char(None))
         .exclude(type=DataSetType.REFERENCE)
         .values(*fields)
         .union(
@@ -400,7 +400,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
                 )
             )
             .annotate(sensitivity_name=ArrayAgg("sensitivity__name", distinct=True))
-            .annotate(visualisation_type=_static_char(None))
+            .annotate(quicksight_id=_static_char(None))
             .values(*_replace(fields, "id", "uuid"))
         )
         .union(
@@ -433,7 +433,7 @@ class CatalogueItemsInstanceViewSet(viewsets.ModelViewSet):
             )
             .annotate(sensitivity_name=ArrayAgg("sensitivity__name", distinct=True))
             .annotate(
-                visualisation_type=models.Case(
+                quicksight_id=models.Case(
                     models.When(
                         visualisationlink__visualisation_type="QUICKSIGHT",
                         then="visualisationlink__identifier",

--- a/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/api_v1/datasets/test_views.py
@@ -477,7 +477,7 @@ class TestCatalogueItemsAPIView(BaseAPIViewTest):
             if isinstance(dataset, ReferenceDataset)
             else dataset.authorized_email_domains,
             "user_ids": userids,
-            "visualisation_type": None,
+            "quicksight_id": None,
         }
 
     def test_success(self, unauthenticated_client):


### PR DESCRIPTION
### Description of change
In API the quicksight ID has been called "visualisation_type", this renames it to quicksight ID to ensure there is no confusion when working with the endpoint

### Checklist

* [ ] Have tests been added to cover any changes?
