### PR TITLE
fix: allow for setting default num of celery db connections

### DIFF
--- a/dataworkspace/start-celery.sh
+++ b/dataworkspace/start-celery.sh
@@ -9,5 +9,5 @@ set -e
     parallel --will-cite --line-buffer --jobs 3 --halt now,done=1 ::: \
         "celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150 --hostname spawner@%h -Q applications.spawner.spawn" \
         "celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 150 --hostname explorer@%h -Q explorer.tasks" \
-        "DEFAULT_DB_MAX_CONNS=60 celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 60 --hostname default@%h -X applications.spawner.spawn,explorer.tasks"
+        "DEFAULT_DB_MAX_CONNS=${CELERY_DEFAULT_DB_MAX_CONNS:=60} celery --app dataworkspace.cel.celery_app worker --pool gevent --prefetch-multiplier=1 --concurrency 60 --hostname default@%h -X applications.spawner.spawn,explorer.tasks"
 )


### PR DESCRIPTION
### Description of change

Allow us to configure the max db connections from celery. This is needed to workaround the issue we are having with connections getting exhausted on dev

### Checklist

* [ ] Have tests been added to cover any changes?
