### PR TITLE
feat: display client ip on the 404 page

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -55,7 +55,12 @@ def public_error_404_html_view(request, exception=None):
 def public_error_403_html_view(request, exception=None):
     default_template = "errors/error_403.html"
     if exception is None:
-        return render(request, default_template, status=403)
+        return render(
+            request,
+            default_template,
+            context={"peer_ip": request.META.get("HTTP_X_FORWARDED_FOR")},
+            status=403,
+        )
     return render(
         request,
         getattr(exception, "template_name", default_template),

--- a/dataworkspace/dataworkspace/templates/errors/error_403.html
+++ b/dataworkspace/dataworkspace/templates/errors/error_403.html
@@ -9,4 +9,9 @@
   <p class="govuk-body">
     If you're already signed into ZScaler or another VPN client, <a class="govuk-link" href="{% url 'support' %}">contact the Data Workspace Team</a> for help accessing this page.
   </p>
+  {% if peer_ip %}
+    <p class="govuk-body">
+      Peer IP: <code>{{ peer_ip }}</code>.
+    </p>
+  {% endif %}
 {% endblock error_content %}

--- a/dataworkspace/proxy.py
+++ b/dataworkspace/proxy.py
@@ -1264,7 +1264,9 @@ async def async_main():
                 return await handle_admin(
                     request,
                     "GET",
-                    CIMultiDict(admin_headers_request(request)),
+                    CIMultiDict(
+                        admin_headers_request(request) + tuple([("x-forwarded-for", peer_ip)])
+                    ),
                     "/error_403",
                     {},
                     b"",


### PR DESCRIPTION
### Description of change

Adds the user's current peer IP on the 403 error page. 

When a user is denied access to due to their IP not being in the whitelist we have no way to tell what is going wrong. Adding the IP to the user facing page means we can ask for a screenshot of the error. If the IP is not part of our whitelist we can at least tell that either their zscaler is disabled or incorrectly configured somehow.

![image](https://user-images.githubusercontent.com/594496/226653715-5d619041-f411-487a-aa62-6390294115a4.png)

### Checklist

* [ ] Have tests been added to cover any changes?
