### PR TITLE
fix: Table name not showing when updating table

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/manager/upload_success.html
+++ b/dataworkspace/dataworkspace/templates/datasets/manager/upload_success.html
@@ -16,9 +16,9 @@
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">What next?</h2>
       <p class="govuk-body">
-        You can immediately access your data in tools at <strong>"{{ schema }}"."{{ table_name }}"</strong>.
+        You can immediately access your data in tools at <strong>"{{ source.schema }}"."{{ source.table }}"</strong>.
       </p>
-      <a class="govuk-button govuk-button--primary" target="_blank" href="{% query_table_in_explorer_link schema table_name %}">
+      <a class="govuk-button govuk-button--primary" target="_blank" href="{% query_table_in_explorer_link source.schema source.table %}">
         Open in Data Explorer
       </a>
       <p class="govuk-body">


### PR DESCRIPTION
### Description of change
When attempting to update a table using the 'update table' feature on the table catalogue page, the displayed screen does not show the actual table name. This PR fixes this issue.

### Checklist

* [ ] Have tests been added to cover any changes?
