### PR TITLE
feat: catch LockError and LockNotOwnedError exceptions to reduce Sentry exceptions

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -458,6 +458,8 @@ def delete_unused_datasets_users():
     try:
         with cache.lock("delete_unused_datasets_users", blocking_timeout=0, timeout=1800):
             _do_delete_unused_datasets_users()
+    except redis.exceptions.LockNotOwnedError:
+        logger.info("delete_unused_datasets_users: Lock not owned - running on another instance?")
     except redis.exceptions.LockError:
         logger.info(
             "delete_unused_datasets_users: Unable to grab lock - running on another instance?"


### PR DESCRIPTION
### Description of change
As part of the work on removing and auditing non-useful elements from Sentry, this PR will catch LockError and LockNotOwned errors and log them appropriately to reduce the amount of noise on Sentry

### Checklist

* [ ] Have tests been added to cover any changes?
