### PR TITLE
fix: show empty headers/data in case where query cannot be found

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/views.py
+++ b/dataworkspace/dataworkspace/apps/explorer/views.py
@@ -530,6 +530,8 @@ class QueryLogResultView(View):
             elif query_log.state == QueryLogState.COMPLETE:
                 template = loader.get_template("explorer/partials/query_results.html")
                 retries = 5
+                headers = []
+                data = []
                 for _ in range(retries):
                     try:
                         headers, data, _ = fetch_query_results(querylog_id)


### PR DESCRIPTION
### Description of change

Fixes issue where an `UnboundLocalError` was thrown when the query was not found. 

### Checklist

* [ ] Have tests been added to cover any changes?
