### PR TITLE
feat: add some scripts to automate some common aws tasks

### DIFF
--- a/bin/delete-qucksight-users.py
+++ b/bin/delete-qucksight-users.py
@@ -1,0 +1,70 @@
+# Given a csv with one column of email address:
+#   1. Find the quicksight user id for each user
+#   2. Delete the accounts from quicksight
+#
+# Notes:
+#   - Run using aws-vault
+#   - Use --dry-run to run the script without actually deleting the users.
+#
+import csv
+from argparse import ArgumentParser
+
+import boto3
+
+
+def main():
+    parser = ArgumentParser(
+        description="Given a csv of email addresses, delete the related users from quicksight",
+    )
+    parser.add_argument(
+        "-f", "--file", required=True, help="The path to the csv file containing email addresses"
+    )
+    parser.add_argument("-a", "--account-id", required=True, help="The AWS account ID")
+    parser.add_argument(
+        "-d", "--dry-run", help="Do not actually delete users", action="store_true"
+    )
+    args = parser.parse_args()
+    client = boto3.client("quicksight")
+
+    if args.dry_run:
+        print("** This is a dry run. No users will be deleted **")
+
+    print(f"Reading emails from csv {args.file}")
+
+    emails = set()
+    with open(args.file, "r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, fieldnames=["email"])
+        next(reader)  # skip the header
+        for line in reader:
+            emails.add(line["email"])
+
+    print(f"Got {len(emails)} emails. Finding matching users on Quicksight")
+
+    email_to_username = {}
+    next_token = ""
+    while next_token is not None and len(email_to_username) < len(emails):
+        response = client.list_users(
+            AwsAccountId=args.account_id, NextToken=next_token, Namespace="default"
+        )
+        for user in response["UserList"]:
+            if user["Email"] in emails:
+                email_to_username[user["Email"]] = user["UserName"]
+                print(f"Found a match for {len(email_to_username)} of {len(emails)} emails")
+        next_token = response.get("NextToken")
+
+    print(f"Found {len(email_to_username)} accounts to delete from Quicksight")
+    for email, username in email_to_username.items():
+        if args.dry_run:
+            print(f"Dry run: Would delete user with email {email}")
+        else:
+            print(f"Deleting user with email {email}")
+            client.delete_user(
+                AwsAccountId=args.account_id,
+                Namespace="default",
+                UserName=username,
+            )
+    print("Fin.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/list-notebook-tasks.py
+++ b/bin/list-notebook-tasks.py
@@ -1,0 +1,78 @@
+# List running notebook tasks sorted by age
+# Notes:
+#   - Run using aws-vault
+#
+import csv
+import sys
+from argparse import ArgumentParser
+from datetime import datetime
+
+import boto3
+import pytz
+
+
+def _paginate(records):
+    for i in range(0, len(records), 100):
+        yield records[i : i + 100]
+
+
+def main():
+    parser = ArgumentParser(
+        description="List running tasks on an ECS cluster",
+    )
+    parser.add_argument("-c", "--cluster", required=True, help="The name of the ECS cluster")
+    args = parser.parse_args()
+    client = boto3.client("ecs")
+    task_arns = []
+    next_token = ""
+    while True:
+        tasks_response = client.list_tasks(
+            cluster=args.cluster, desiredStatus="RUNNING", nextToken=next_token
+        )
+        task_arns.extend(tasks_response["taskArns"])
+        next_token = tasks_response.get("nextToken")
+        if not next_token:
+            break
+
+    task_list = []
+    for chunk in _paginate(task_arns):
+        for description in client.describe_tasks(cluster=args.cluster, tasks=chunk)["tasks"]:
+            if "startedAt" not in description:
+                continue
+            task_list.append(
+                {
+                    "started": description["startedAt"],
+                    "duration": datetime.now().astimezone(pytz.utc)
+                    - description["startedAt"].astimezone(pytz.utc),
+                    "arn": description["taskArn"],
+                    "task_def": description["taskDefinitionArn"].split("/")[-1].split(":")[0],
+                    "task_role": description["overrides"]["taskRoleArn"].split("/")[-1],
+                    "email": description["overrides"]["taskRoleArn"]
+                    .split("/")[-1]
+                    .replace("jhub-", ""),
+                    "public_host": description["taskDefinitionArn"]
+                    .split("/")[-1]
+                    .split(":")[0]
+                    .replace("jupyterhub-", ""),
+                }
+            )
+
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "started",
+            "duration",
+            "task_role",
+            "task_def",
+            "public_host",
+            "email",
+            "arn",
+        ],
+        quoting=csv.QUOTE_NONNUMERIC,
+    )
+    writer.writeheader()
+    writer.writerows(sorted(task_list, key=lambda x: x["started"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/list-quicksight-author-assets.py
+++ b/bin/list-quicksight-author-assets.py
@@ -1,0 +1,108 @@
+# Outputs a comma separated list of all author accounts on quicksight including:
+#   1. Username
+#   2. email
+#   3. Number of analyses
+#   4. Number of dashboards
+#   5. Number of datasets
+#   6. Number of data sources
+#
+import csv
+import sys
+from argparse import ArgumentParser
+from functools import partial
+
+import boto3
+
+
+def _fetch_authors(client, account_id):
+    next_token = ""
+    while True:
+        response = client.list_users(
+            AwsAccountId=account_id, NextToken=next_token, Namespace="default"
+        )
+        for user in response["UserList"]:
+            if user["Role"] != "AUTHOR":
+                continue
+            yield {
+                "arn": user["Arn"],
+                "username": user["UserName"],
+                "email": user["Email"],
+                "role": user["Role"],
+            }
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+
+
+def _fetch_assets_for_user(
+    client, account_id, user_name, asset_name, response_key, search_field="QUICKSIGHT_OWNER"
+):
+    assets = []
+    next_token = ""
+    while True:
+        args = {
+            "AwsAccountId": account_id,
+            "Filters": [{"Operator": "StringEquals", "Name": search_field, "Value": user_name}],
+        }
+        if next_token:
+            args["NextToken"] = next_token
+
+        response = getattr(client, f"search_{asset_name}")(**args)
+        for asset in response[response_key]:
+            assets.append(
+                {
+                    "arn": asset["Arn"],
+                    "name": asset["Name"],
+                }
+            )
+        next_token = response.get("NextToken")
+        if not next_token:
+            break
+    return assets
+
+
+def main():
+    parser = ArgumentParser(
+        description="Output a list of quciksight authors with number of objects associated with the account",
+    )
+    parser.add_argument("-a", "--account-id", required=True, help="The AWS account ID")
+    args = parser.parse_args()
+    client = boto3.client("quicksight")
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "username",
+            "email",
+            "num_analyses",
+            "num_dashboards",
+            "num_datasets",
+            "num_data_sources",
+        ],
+        quoting=csv.QUOTE_NONNUMERIC,
+    )
+    writer.writeheader()
+    fetch_assets = partial(_fetch_assets_for_user, client, args.account_id)
+    for author in _fetch_authors(client, args.account_id):
+        analyses = fetch_assets(author["arn"], "analyses", "AnalysisSummaryList")
+        dashboards = fetch_assets(author["arn"], "dashboards", "DashboardSummaryList")
+        datasets = fetch_assets(author["arn"], "data_sets", "DataSetSummaries")
+        data_sources = fetch_assets(
+            author["arn"],
+            "data_sources",
+            "DataSourceSummaries",
+            search_field="DIRECT_QUICKSIGHT_SOLE_OWNER",
+        )
+        writer.writerow(
+            {
+                "username": author["username"],
+                "email": author["email"],
+                "num_analyses": len(analyses),
+                "num_dashboards": len(dashboards),
+                "num_datasets": len(datasets),
+                "num_data_sources": len(data_sources),
+            }
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/list-s3-file-types.py
+++ b/bin/list-s3-file-types.py
@@ -1,0 +1,38 @@
+#
+# Outputs a comma separated list of file extensions with the
+# number of occurrences in an S3 bucket.
+#
+# To use set the BUCKET_NAME variable to the name of the bucket you're interested in
+#
+import csv
+import os
+import sys
+from collections import defaultdict
+
+import boto3
+
+BUCKET_NAME = ""
+
+
+def main():
+    extensions = defaultdict(int)
+    client = boto3.client("s3")
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=BUCKET_NAME):
+        for obj in page["Contents"]:
+            extensions[os.path.splitext(obj["Key"])[-1]] += 1
+    writer = csv.DictWriter(
+        sys.stdout,
+        fieldnames=[
+            "extension",
+            "num_files",
+        ],
+        quoting=csv.QUOTE_NONNUMERIC,
+    )
+    writer.writeheader()
+    for ext, count in extensions.items():
+        writer.writerow({"extension": ext, "num_files": count})
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/stop-duplicate-notebook-tasks.py
+++ b/bin/stop-duplicate-notebook-tasks.py
@@ -59,6 +59,10 @@ def main():
         f"Found {total_task_definitions} unique task definitions (out of {total_running_tasks} running tasks)"
     )
     if args.dry_run or (total_running_tasks - total_task_definitions) == 0:
+        for task_def_arn, task_details in running_tasks.items():
+            if len(task_details) <= 1:
+                continue
+            print(f"Task def {task_def_arn} has {len(task_details)} running tasks.")
         sys.exit()
 
     print("Stopping tasks...")

--- a/bin/stop-duplicate-notebook-tasks.py
+++ b/bin/stop-duplicate-notebook-tasks.py
@@ -1,0 +1,79 @@
+# Find any duplicate running task definitions on ECS and stop all but the latest
+# Notes:
+#   - Run using aws-vault
+#   - Use --dry-run to run the script without actually stopping the tasks.
+#
+import sys
+from argparse import ArgumentParser
+from collections import defaultdict
+
+import boto3
+
+
+def _paginate(records):
+    for i in range(0, len(records), 100):
+        yield records[i : i + 100]
+
+
+def main():
+    parser = ArgumentParser(
+        description="Find and stop duplicate running tasks on an ECS cluster",
+    )
+    parser.add_argument("-c", "--cluster", required=True, help="The name of the ECS cluster")
+    parser.add_argument(
+        "-d", "--dry-run", help="Do not actually delete users", action="store_true"
+    )
+    args = parser.parse_args()
+    client = boto3.client("ecs")
+
+    if args.dry_run:
+        print("** This is a dry run. No duplicate tasks will be stopped **")
+
+    print(f"Fetching running tasks in cluster {args.cluster}")
+
+    task_arns = []
+    next_token = ""
+    while True:
+        tasks_response = client.list_tasks(
+            cluster=args.cluster, desiredStatus="RUNNING", nextToken=next_token
+        )
+        task_arns.extend(tasks_response["taskArns"])
+        next_token = tasks_response.get("nextToken")
+        if not next_token:
+            break
+
+    total_running_tasks = len(task_arns)
+    print(f"Found {total_running_tasks} running tasks on cluster {args.cluster}")
+
+    print("Finding duplicate task definitions")
+    running_tasks = defaultdict(list)
+    for chunk in _paginate(task_arns):
+        for description in client.describe_tasks(cluster=args.cluster, tasks=chunk)["tasks"]:
+            if "startedAt" not in description:
+                continue
+            running_tasks[description["taskDefinitionArn"].split("/")[-1].split(":")[0]].append(
+                {"started": description["startedAt"], "arn": description["taskArn"]}
+            )
+    total_task_definitions = len(running_tasks)
+    print(
+        f"Found {total_task_definitions} unique task definitions (out of {total_running_tasks} running tasks)"
+    )
+    if args.dry_run or (total_running_tasks - total_task_definitions) == 0:
+        sys.exit()
+
+    print("Stopping tasks...")
+    for task_def_arn, task_details in running_tasks.items():
+        if len(task_details) <= 1:
+            continue
+        tasks_to_stop = sorted(task_details, key=lambda x: x["started"])[:-1]
+        print(
+            f"Task def {task_def_arn} has {len(task_details)} running tasks. "
+            f"Will stop {len(tasks_to_stop)} of them"
+        )
+        for task in tasks_to_stop:
+            client.stop_task(cluster=args.cluster, task=task["arn"])
+    print("Done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description of change

Adds some scripts to automate some of the tasks we've been asked to do on aws recently.

1. List all authors on quicksight along with the number of assets associated with their accounts
2. Delete a list of users from quicksight
3. Find and stop any duplicate running task defs on an ecs cluster

### Checklist

* [ ] Have tests been added to cover any changes?
