### PR TITLE
build: remove /app folder from docker-compose volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,11 +72,11 @@ check: check-flake8 check-black check-pylint
 
 .PHONY: docker-check
 docker-check:
-	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /app && make check"
+	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /dataworkspace && make check"
 
 .PHONY: docker-format
 docker-format: first-use
-	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /app && black ."
+	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /dataworkspace && black ."
 
 
 .PHONY: format
@@ -91,8 +91,8 @@ dev-shell:
 
 .PHONY: save-requirements
 save-requirements:
-	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /app && pip-compile requirements.in"
-	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /app && pip-compile requirements-dev.in"
+	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /dataworkspace && pip-compile requirements.in"
+	docker-compose -f docker-compose-dev.yml run --rm data-workspace bash -c "cd /dataworkspace && pip-compile requirements-dev.in"
 
 .PHONY: docker-test-unit-local
 docker-test-unit-local:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,7 +15,6 @@ services:
       - "data-workspace-redis"
       - "data-workspace-es"
     volumes:
-      - .:/app
       - ./dataworkspace:/dataworkspace
       - ./dataworkspace/dataworkspace/static/js/stats:/dataworkspace/dataworkspace/static/js/stats/
   data-workspace-celery:

--- a/docker-compose-test-local.yml
+++ b/docker-compose-test-local.yml
@@ -34,7 +34,6 @@ services:
       - db-logs-dev:/var/log/postgres
       - ./dataworkspace:/dataworkspace
       - ./test:/test
-      - .:/app
   data-workspace-postgres:
     build:
       context: postgres


### PR DESCRIPTION
### Description of change

It's the same folder as the dataworkspace folder, so shouldn't need to be in two places

### Checklist

* [ ] Have tests been added to cover any changes?
