### PR TITLE
Docker-compose to docker compose and -f removal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ prepare-docker-cache: &prepare-docker-cache
         # Saving them is quite slow, so in this case let's not bother.
        echo ''
       else
-        docker-compose -f docker-compose-test.yml build data-workspace-test  | grep "\-\-\->" | grep -v "Using cache" | cut -f 3 -d " " > /tmp/layers.txt
+        docker compose -f docker-compose-test.yml build data-workspace-test  | grep "\-\-\->" | grep -v "Using cache" | cut -f 3 -d " " > /tmp/layers.txt
         docker save $(cat /tmp/layers.txt) | gzip > caches/data-workspace-test-latest.tar.gz
         sha256sum Dockerfile requirements.txt requirements-dev.txt > caches/checksums
       fi

--- a/Makefile
+++ b/Makefile
@@ -22,24 +22,24 @@ first-use:
 
 .PHONY: up
 up: first-use
-	docker-compose -f docker-compose.yml up
+	docker compose up
 
 
 .PHONY: docker-build
 docker-build:
-	docker-compose -f docker-compose-test.yml build
+	docker compose -f docker-compose-test.yml build
 
 
 .PHONY: docker-test-unit
 docker-test-unit: TESTS ?= /dataworkspace/dataworkspace
 docker-test-unit: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest -vv --junitxml=/test-results/junit.xml $(TESTS)
+	docker compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest -vv --junitxml=/test-results/junit.xml $(TESTS)
 
 
 .PHONY: docker-test-integration
 docker-test-integration: TESTS ?= test/
 docker-test-integration: docker-build
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest --junitxml=/test-results/junit.xml $(TESTS)
+	docker compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test pytest --junitxml=/test-results/junit.xml $(TESTS)
 
 
 .PHONY: docker-test
@@ -48,7 +48,7 @@ docker-test: docker-test-integration docker-test-unit
 
 .PHONY: docker-clean
 docker-clean:
-	docker-compose -f docker-compose-test.yml -p data-workspace-test down -v
+	docker compose -f docker-compose-test.yml -p data-workspace-test down -v
 
 .PHONY: check-flake8
 check-flake8:
@@ -56,7 +56,7 @@ check-flake8:
 
 .PHONY: docker-check-migrations
 docker-check-migrations:
-	docker-compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test sh -c "sleep 5 && django-admin makemigrations --check --dry-run --verbosity 3"
+	docker compose -f docker-compose-test.yml -p data-workspace-test run data-workspace-test sh -c "sleep 5 && django-admin makemigrations --check --dry-run --verbosity 3"
 
 .PHONY: check-black
 check-black:
@@ -72,11 +72,11 @@ check: check-flake8 check-black check-pylint
 
 .PHONY: docker-check
 docker-check:
-	docker-compose -f docker-compose.yml run --rm data-workspace bash -c "cd /app && make check"
+	docker compose run --rm data-workspace bash -c "cd /app && make check"
 
 .PHONY: docker-format
 docker-format: first-use
-	docker-compose -f docker-compose.yml run --rm data-workspace bash -c "cd /app && black ."
+	docker compose run --rm data-workspace bash -c "cd /app && black ."
 
 
 .PHONY: format
@@ -86,13 +86,13 @@ format:
 
 .PHONY: dev-shell
 dev-shell:
-	docker-compose -f docker-compose.yml run --rm data-workspace bash
+	docker compose run --rm data-workspace bash
 
 
 .PHONY: save-requirements
 save-requirements:
-	docker-compose -f docker-compose.yml run --rm data-workspace bash -c "cd /app && pip-compile requirements.in"
-	docker-compose -f docker-compose.yml run --rm data-workspace bash -c "cd /app && pip-compile requirements-dev.in"
+	docker compose run --rm data-workspace bash -c "cd /app && pip-compile requirements.in"
+	docker compose run --rm data-workspace bash -c "cd /app && pip-compile requirements-dev.in"
 
 .PHONY: docker-test-unit-local
 docker-test-unit-local:
@@ -100,11 +100,11 @@ docker-test-unit-local:
 	if [ -z "$$TEST_DIR" ]; \
 		then TEST_DIR="/dataworkspace/dataworkspace"; \
  	fi; \
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest $$TEST_DIR -x -v --disable-warnings --reuse-db
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run data-workspace-test pytest $$TEST_DIR -x -v --disable-warnings --reuse-db
 
 .PHONY: docker-test-shell-local
 docker-test-shell-local:
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test bash
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test bash
 
 .PHONY: docker-test-integration-local
 docker-test-integration-local:
@@ -112,41 +112,41 @@ docker-test-integration-local:
 	if [ -z "$$TEST_DIR" ]; \
 		then TEST_DIR="/test"; \
  	fi; \
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test bash -c "DJANGO_SETTINGS_MODULE=dataworkspace.settings.integration_tests pytest -x -v $$TEST_DIR --disable-warnings"
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test bash -c "DJANGO_SETTINGS_MODULE=dataworkspace.settings.integration_tests pytest -x -v $$TEST_DIR --disable-warnings"
 
 .PHONY: docker-test-local
 docker-test-local: docker-test-unit-local docker-test-integration-local
 
 .PHONY: logout
 logout:
-	docker-compose exec data-workspace-redis bash -c "redis-cli --scan --pattern data_workspace* | xargs redis-cli unlink"
+	docker compose exec data-workspace-redis bash -c "redis-cli --scan --pattern data_workspace* | xargs redis-cli unlink"
 
 
 .PHONY: docker-test-sequential
 docker-test-sequential:
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test rm -f
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test rm -f
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application_1.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application_1.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application_2.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_application_2.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_utils.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/test_utils.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/selenium/test_explorer.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/selenium/test_explorer.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop
 
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test up -d
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/selenium/test_request_data.py -x -v
-	docker-compose -f docker-compose-test-local.yml -p data-workspace-test stop
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test up -d
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test run --rm data-workspace-test pytest /test/selenium/test_request_data.py -x -v
+	docker compose -f docker-compose-test-local.yml -p data-workspace-test stop

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cp .envs/sample.env .envs/dev.env
 Start the application by
 
 ```bash
-docker-compose -f docker-compose.yml up --build
+docker compose up --build
 ```
 
 Some parts of the database are managed and populated by [data-flow](https://github.com/uktrade/data-flow/). To ensure there are no issues with some tables being missing, initial setup should include checking out that repo and running the `docker-compose-dw.yml` file, which will perform migrations on the shared Data Workspace/Data Flow DB.
@@ -60,7 +60,7 @@ If intending to run superset locally, the following subdomains will also be requ
 If you have issues building the containers try the following
 
 ```
-DOCKER_DEFAULT_PLATFORM=linux/amd64 docker-compose -f docker-compose.yml up --build
+DOCKER_DEFAULT_PLATFORM=linux/amd64 docker compose up --build
 ```
 <!-- --8<-- [end:runninglocally] -->
 <!-- --8<-- [start:runningsuperset] -->
@@ -74,10 +74,10 @@ cp .envs/superset-sample.env .envs/superset.dev.env
 
 Update the new file with your DIT email address (must match your SSO email, or mock SSO credentials).
 
-Then run docker-compose using the superset profile.
+Then run `docker compose` using the superset profile.
 
 ```bash
-docker-compose --profile superset up
+docker compose --profile superset up
 ```
 
 Initially you will then need to set up the Editor role by running the following script, replacing container-id with the id of the data-workspace-postgres docker container:
@@ -93,8 +93,8 @@ You can then visit http://superset-edit.dataworkspace.test:8000/ or http://super
 ## Creating migrations / running management commands
 
 ```bash
-docker-compose build && \
-docker-compose run \
+docker compose build && \
+docker compose run \
     --user root \
     --volume=$PWD/dataworkspace:/dataworkspace/ \
     data-workspace django-admin makemigrations
@@ -149,10 +149,10 @@ make docker-test-integration-local -e TARGET=test/test_application.py
 <!-- --8<-- [start:selenium] -->
 ### Running selenium tests locally
 
-We have some selenium integration tests that launch a (headless) browser in order to interact with a running instance of Data Workspace to assure some core flows (only Data Explorer at the time of writing). It is sometimes desirable to watch these tests run, e.g. in order to debug where it is failing. To run the selenium tests through docker-compose using a local browser, do the following:
+We have some selenium integration tests that launch a (headless) browser in order to interact with a running instance of Data Workspace to assure some core flows (only Data Explorer at the time of writing). It is sometimes desirable to watch these tests run, e.g. in order to debug where it is failing. To run the selenium tests through docker compose using a local browser, do the following:
 
 1) Download the latest [Selenium Server](https://www.selenium.dev/downloads/) and run it in the background, e.g. `java -jar ~/Downloads/selenium-server-standalone-3.141.59 &`
-2) Run the selenium tests via docker-compose, exposing the Data Workspace port and the mock-SSO port and setting the `REMOTE_SELENIUM_URL` environment variable, e.g. `docker-compose -f docker-compose-test.yml -p data-workspace-test run -e REMOTE_SELENIUM_URL=http://host.docker.internal:4444/wd/hub -p 8000:8000 -p 8005:8005 --rm data-workspace-test pytest -vvvs test/test_selenium.py`
+2) Run the selenium tests via docker-compose, exposing the Data Workspace port and the mock-SSO port and setting the `REMOTE_SELENIUM_URL` environment variable, e.g. `docker compose -f docker-compose-test.yml -p data-workspace-test run -e REMOTE_SELENIUM_URL=http://host.docker.internal:4444/wd/hub -p 8000:8000 -p 8005:8005 --rm data-workspace-test pytest -vvvs test/test_selenium.py`
 <!-- --8<-- [end:selenium] -->
 <!-- --8<-- [start:dependencies] -->
 ## Updating a dependency
@@ -184,7 +184,7 @@ We're set up to use django-webpack-loader for hotloading the react app while dev
 You can get it running by starting the dev server:
 
 ```shell
-docker-compose -f docker-compose.yml up
+docker compose up
 ```
 
 and in a separate terminal changing to the js app directory and running the webpack hotloader:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -60,7 +60,7 @@ services:
     ports:
       - "9200:9200"
   # Have a named volume since mounting a local directory isn't possible in CircleCI's
-  # remote docker system. And docker-compose run kills the container running the tests
+  # remote docker system. And docker compose run kills the container running the tests
   # proper, so to be able to copy out results, run a small container just to be able
   # to access the named volume after the tests finish
   data-workspace-test-results:

--- a/docs/development/remotedebugging.md
+++ b/docs/development/remotedebugging.md
@@ -12,7 +12,7 @@ To set this up locally.
     - `REMOTE_PDB_HOST=0.0.0.0`
     - `REMOTE_PDB_PORT=4444`
 3. Sprinkle some `breakpoint()`s liberally in your code
-4. Bring up the docker containers ` docker-compose -f docker-compose.yml up` 
+4. Bring up the docker containers `docker compose up` 
 5. Listen to remote pdb using `remotepdb_client --host localhost --port 4444`
 6. Go and break things http://dataworkspace.test:8000
 
@@ -28,7 +28,7 @@ is set to the path of your dev environment.
     ![Python debug server](assets/remote-debug-server.png)
 
 3. Bring up the containers  
-    ` docker-compose -f docker-compose.yml up`
+    ` docker compose up`
 
 4. Start the pycharm debugger  
     ![Start the debugger](assets/pycharm-start-debugger.png)
@@ -75,7 +75,7 @@ Below are the basic steps for debugging remotely with vscode. They are confirmed
 4. Set a breakpoint in your code  
     `breakpoint()`
 5. Bring up the containers  
-    ` docker-compose -f docker-compose.yml up`
+    ` docker compose up`
 6. Start the remote python debugger  
     ![Vscode run debug](assets/vscode-run-debug.png)
 7. Load the relevant page http://dataworkspace.test:8000


### PR DESCRIPTION
### Description of change

* Changed `docker-compose` to `docker compose` to match latest syntax [(soon to deprecate)](https://docs.docker.com/compose/gettingstarted/)
* Removed -f references to default file

### Checklist

* [ ] Have tests been added to cover any changes?
