### PR TITLE
feat: more robust Editor role setup for Superset

### DIFF
--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -89,12 +89,6 @@ Then run `docker compose` using the superset profile.
 docker compose --profile superset up
 ```
 
-Initially you will then need to set up the Editor role by running the following script, replacing container-id with the id of the data-workspace-postgres docker container:
-
-```bash
-docker exec -i <container-id> psql -U postgres -d superset < superset/create-editor-role.sql
-```
-
 You can then visit http://superset-edit.dataworkspace.test:8000/ or http://superset-admin.dataworkspace.test:8000/
 
 

--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -22,6 +22,7 @@ RUN \
         libldap2-dev \
         libsasl2-dev \
         libssl-dev \
+        postgresql-client \
         python3 \
         python3-dev \
         python3-pip
@@ -39,6 +40,7 @@ ENV \
     FLASK_APP=superset
 
 COPY superset_config.py /etc/superset/
+COPY create-editor-role.sql /
 
 COPY data-workspace-patches.js /usr/local/lib/python3.9/dist-packages/superset/static/assets/
 

--- a/superset/create-editor-role.sql
+++ b/superset/create-editor-role.sql
@@ -1,116 +1,156 @@
-INSERT INTO ab_role VALUES (7, 'Editor');
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),1, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),2, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),3, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),4, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),5, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),6, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),7, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),8, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),9, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),10, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),11, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),12, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),13, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),15, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),16, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),17, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),19, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),22, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),23, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),24, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),25, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),30, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),31, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),39, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),40, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),41, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),42, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),43, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),44, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),45, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),46, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),47, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),48, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),49, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),50, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),51, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),52, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),53, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),54, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),55, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),57, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),58, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),59, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),60, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),61, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),62, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),64, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),65, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),66, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),67, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),68, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),70, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),71, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),72, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),73, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),74, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),75, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),76, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),77, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),78, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),79, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),80, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),81, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),82, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),83, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),84, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),85, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),86, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),87, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),88, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),89, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),90, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),91, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),92, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),93, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),94, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),95, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),96, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),97, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),98, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),99, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),100, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),101, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),102, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),103, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),104, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),105, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),106, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),107, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),108, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),109, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),110, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),111, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),112, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),113, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),114, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),116, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),117, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),118, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),120, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),122, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),123, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),124, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),125, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),127, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),128, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),129, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),130, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),131, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),132, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),135, 7;
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),155, 7;  # can post on TabStateView
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),157, 7;  # can put on TabStateView
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),156, 7;  # can delete on TabStateView
-insert into ab_permission_view_role select nextval('ab_permission_view_role_id_seq'),199, 7;  # all_database_access on all_database_access
+BEGIN;
+
+-- Ensure Editor role exists
+INSERT INTO ab_role(id, name) VALUES (nextval('ab_role_id_seq'), 'Editor') ON CONFLICT DO NOTHING;
+
+-- Delete any existing editor permissions
+DELETE FROM ab_permission_view_role WHERE role_id = (
+	SELECT id FROM ab_role WHERE name = 'Editor'
+);
+
+-- Create set of editor permissions
+-- Since the id column is not serial/autoincrement, we call nextval on a sequence explicitly
+WITH required_permissions(new_permission_view_role_id, permission_name, view_menu_name) AS (
+	VALUES
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'AdvancedDataType'),
+		(nextval('ab_permission_view_role_id_seq'), 'all_database_access', 'all_database_access'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Annotation'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'Annotation'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_query', 'Api'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_query_form_data', 'Api'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_time_range', 'Api'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_list', 'AsyncEventsRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'AvailableDomains'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_invalidate', 'CacheRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'Chart'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Chart'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'Chart'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_get', 'ColumnarToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_post', 'ColumnarToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'CssTemplate'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'CssTemplate'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_get', 'CsvToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_post', 'CsvToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_delete_embedded', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get_embedded', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_set_embedded', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'Dashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'DashboardFilterStateRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'DashboardFilterStateRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'DashboardPermalinkRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'DashboardPermalinkRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'Database'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Database'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_duplicate', 'Dataset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'Dataset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Dataset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'Dataset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_external_metadata', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_external_metadata_by_name', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get_column_values', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_samples', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_save', 'Datasource'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_add', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_delete', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_download', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_edit', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_list', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_show', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'DynamicPlugin'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'EmbeddedDashboard'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_get', 'ExcelToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_post', 'ExcelToDatabaseView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Explore'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'ExploreFormDataRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'ExploreFormDataRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'ExplorePermalinkRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'ExplorePermalinkRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_add', 'FilterSets'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_edit', 'FilterSets'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_list', 'FilterSets'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'ImportExportRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_import_', 'ImportExportRestApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get_value', 'KV'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_store', 'KV'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Log'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get', 'MenuApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get', 'OpenApi'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'Query'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'ReportSchedule'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'ReportSchedule'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_get', 'ResetMyPasswordView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_post', 'ResetMyPasswordView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_add', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_delete', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_download', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_edit', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_list', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_show', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'muldelete', 'RowLevelSecurityFiltersModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export', 'SavedQuery'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_read', 'SavedQuery'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_write', 'SavedQuery'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_my_queries', 'SqlLab'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_execute_sql_query', 'SQLLab'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_export_csv', 'SQLLab'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get_results', 'SQLLab'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_add_slices', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_available_domains', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_copy_dash', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_created_dashboards', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_created_slices', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_dashboard', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_estimate_query_cost', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_explore_json', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_fave_dashboards_by_username', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_favstar', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_fetch_datasource_metadata', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_override_role_permissions', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_profile', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_request_access', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_results', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_schemas_access_for_file_upload', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_slice', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_sql_json', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_sqllab', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_sqllab_history', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_sqllab_viz', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_stop_query', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_validate_sql_json', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_show', 'SwaggerView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_delete', 'TabStateView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_post', 'TabStateView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_put', 'TabStateView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_get', 'TagView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_get', 'UserInfoEditView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_this_form_post', 'UserInfoEditView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_add', 'UserRemoteUserModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_show', 'UserRemoteUserModelView'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_recent_activity', 'Superset'),
+		(nextval('ab_permission_view_role_id_seq'), 'can_recent_activity', 'Log'),
+)
+
+INSERT INTO ab_permission_view_role(id, permission_view_id, role_id)
+	SELECT
+		required_permissions.new_permission_view_role_id,
+		ab_permission_view.id,
+		ab_role.id
+	FROM
+		ab_permission_view
+	INNER JOIN
+		ab_permission ON
+			ab_permission.id = ab_permission_view.permission_id
+	INNER JOIN
+		ab_view_menu ON
+			ab_view_menu.id = ab_permission_view.view_menu_id
+	INNER JOIN
+		required_permissions ON
+			required_permissions.permission_name = ab_permission.name
+			AND required_permissions.view_menu_name = ab_view_menu.name
+	INNER JOIN
+		ab_role ON ab_role.name = 'Editor';
+
+COMMIT;

--- a/superset/start-dev.sh
+++ b/superset/start-dev.sh
@@ -6,6 +6,11 @@ superset db upgrade
 
 # Creates or updates roles
 superset init
+PGUSER=$DB_USER \
+PGPASSWORD=$DB_PASSWORD \
+PGDATABASE=$DB_NAME \
+PGHOST=$DB_HOST \
+    psql -f create-editor-role.sql
 
 gunicorn \
     -w 10 \

--- a/superset/start.sh
+++ b/superset/start.sh
@@ -6,6 +6,11 @@ superset db upgrade
 
 # Creates or updates roles
 superset init
+PGUSER=$DB_USER \
+PGPASSWORD=$DB_PASSWORD \
+PGDATABASE=$DB_NAME \
+PGHOST=$DB_HOST \
+    psql -f create-editor-role.sql
 
 gunicorn \
     -w 10 \


### PR DESCRIPTION
### Description of change

This change does a number of things

- Makes the Editor role setup no longer brittle with respect to database ID values
- And specifically, allows permissions to be configured by name
- Removes the manual step required both locally and in production
- Adds the following Editor permissions found to be required by recent Supeset:

    can post on TabStateView
    can put on TabStateView
    can delete on TabStateView
    can recent activity on Superset
    all_database_access on all_database_access
    can write on ExploreFormDataRestApi
    can read on ExploreFormDataRestApi
    can execute sql query on SQLLab
    can recent activity on Log

### Checklist

* [ ] Have tests been added to cover any changes?
