### PR TITLE
docs: integrating nav and toc, unhiding nav

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,18 +10,18 @@ Contributions to Data Workspace are welcome, such as reporting issues, requestin
 - To contribute code, knowledge of [Python](https://www.python.org/) is required.
 
 
-## Contributing an issue
+## Issues
 
 Suspected issues with Data Workspace can be submitted at [Data Workspace issues](https://github.com/uktrade/data-workspace/issues).
 An issue that contains a [minimal, reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) stands the best chance of being resolved. However, it is understood that this is not possible in all circumstances.
 
 
-## Contributing a feature request
+## Feature requests
 
 A feature request can be submitted using the [Ideas category in Data Workspace discussions](https://github.com/uktrade/data-workspace/discussions/categories/ideas).
 
 
-## Contributing documentation
+## Documentation
 
 The source of the documentation is in the [`docs/`](https://github.com/uktrade/data-workspace/tree/master/docs) directory of the source code, and is written using [Material for mkdocs](https://squidfunk.github.io/mkdocs-material/).
 
@@ -60,7 +60,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
 When the PR is merged, the documentation is deployed automatically to [https://data-workspace.docs.trade.gov.uk/](https://data-workspace.docs.trade.gov.uk/).
 
 
-## Contributing code
+## Code
 
 Changes are submitted via a Pull Request (PR). To do this:
 

--- a/docs/architecture/components.md
+++ b/docs/architecture/components.md
@@ -4,9 +4,7 @@ title: Components
 
 The architecture is heavily Docker/Fargate based.
 
-## Architecture diagrams
-
-### High level
+## High level architecture
 
 At the highest level, users access the Data Workspace application, which accesses a PostgreSQL database.
 
@@ -15,7 +13,7 @@ graph
   A[User] --> B[Data Workspace]
   B --> C["PostgreSQL (Aurora)"]
 ```
-### Medium level
+## Medium level architecture
 
 ``` mermaid
 graph
@@ -33,7 +31,7 @@ graph
 
 ```
 
-## User-facing components
+## User-facing
 
 - [Main application](https://quay.io/repository/uktrade/data-workspace):
   A Django application to manage datasets and permissions, launch containers, a proxy to route requests to those containers, and an NGINX instance to route to the proxy and serve static files.
@@ -50,7 +48,7 @@ graph
 - File browser:
   A single-page-application that offers upload and download of files to/from each user's folder in S3. The data is transferred directly between the user's browser and S3.
 
-## Infrastructure components
+## Infrastructure
 
 - [metrics](https://quay.io/repository/uktrade/data-workspace-metrics):
   A sidecar-container for the user-launched containers that exposes metrics from the [ECS task metadata endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html) in Prometheus format.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,4 @@
 ---
 title: Contributing
-hide:
-    - navigation
 ---
 --8<-- "CONTRIBUTING.md"

--- a/docs/data-ingestion.md
+++ b/docs/data-ingestion.md
@@ -1,7 +1,5 @@
 ---
 title: Data Ingestion
-hide:
-    - navigation
 ---
 
 Data Workspace is essentially an interface to a PostgreSQL database, referred to as the datasets database. Technical users can access specific tables in the datasets database directly, but there is a concept of "datasets" on top of this direct access. Each dataset has its own page in the user-facing data catalogue that has features for non-technical users.

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -18,7 +18,7 @@ To deploy Data Workspace to AWS you must have:
 You should also have familiarity with working on the command line, working with Terraform, and with AWS.
 
 
-## Creating environment folder
+## Environment folder
 
 Each deployment, or environment, of Data Workspace requires a folder for its configuration. This folder should be within a sibling folder to `data-workspace`.
 

--- a/docs/development/enhancedtables.md
+++ b/docs/development/enhancedtables.md
@@ -10,9 +10,7 @@ Turn an existing govuk styled table into a govuk styled ag-grid grid.
 - If the user has JavaScript disabled, automatically fall back to the standard govuk table.
 - In the future can be enhanced to add column filtering
 
-## How to
-
-### Create table
+## Create table
 
 1. Create a gov uk style table and give it the class `enhanced-table`.
 2. The table must have one `<thead>` and one `<tbody>`
@@ -24,7 +22,7 @@ Turn an existing govuk styled table into a govuk styled ag-grid grid.
 </table>
 ```
 
-### Configure rows
+## Configure rows
 
 Configuration for the columns is done on the `<th>` elements via data attributes. The options are:
 
@@ -61,7 +59,7 @@ Configuration for the columns is done on the `<th>` elements via data attributes
 </table>
 ```
 
-### Initialise it
+## Initialise it
 
 Add the following to your page
 

--- a/docs/development/running-locally.md
+++ b/docs/development/running-locally.md
@@ -117,7 +117,7 @@ To build this locally requires NodeJS. Ideally installed via `nvm` [https://gith
 ```
 
 
-## Running React apps locally
+## React apps
 
 We're set up to use django-webpack-loader for hotloading the React app while developing. 
 

--- a/docs/development/running-tests.md
+++ b/docs/development/running-tests.md
@@ -31,7 +31,7 @@ make docker-test-integration
 ```
 
 
-## Without rebuilding containers
+## Without rebuilding
 
 To run the tests locally without having to rebuild the containers every time append `-local` to the test make commands
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,54 @@
+/* This removes the borders in the combined nav/toc */
+
+.md-nav--primary > .md-nav__list > .md-nav__item--active > .md-nav > .md-nav__list > .md-nav__item--active {
+    padding-left: 10px;
+    border-left: 4px solid;
+    border-left-color: #1d70b8;
+}
+
+.md-nav--secondary > .md-nav__list > .md-nav__item  > .md-nav__link--active{
+    border-left: none;
+}
+
+.md-nav--secondary {
+    font-weight: normal;
+}
+
+.md-nav--secondary .md-nav__item::before {
+    content: '—';
+    font-size: 20px;
+    display: inline-block;
+    vertical-align: middle;
+    color: #505a5f;
+}
+
+.md-nav__item .md-nav__link--passed {
+    color: var(--md-typeset-a-color);
+}
+
+.md-nav__item .md-nav__link--active {
+    color: var(--md-typeset-a-color);
+}
+
+.md-nav--secondary .md-nav__link--active {
+    padding-left:  0;
+}
+
+.md-nav--secondary .md-nav__link {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0;
+    line-height: 2;
+}
+
+.md-nav--secondary .md-nav__list {
+    margin-top: 5px;
+}
+
+[dir=ltr] .md-nav--secondary .md-nav__item {
+    padding-left: 0;
+}
+
+[dir=ltr] .md-nav--integrated > .md-nav__list > .md-nav__item--active .md-nav--secondary {
+    border-left: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ theme:
     - navigation.tabs.sticky
     - navigation.indexes
     - navigation.tracking
+    - toc.integrate
   font:
     text: Roboto
     code: Roboto Mono
@@ -45,6 +46,7 @@ markdown_extensions:
   - md_in_html
 extra_css:
   - stylesheets/tags-color.css
+  - stylesheets/extra.css
 plugins:
   - material/search
   - material/tags:


### PR DESCRIPTION
### Description of change

It feels less confusing to have have on 2 sides, top and left, rather than 3. Some titles in the toc went onto multiple lines, which looked very messy on the left hand nav, so this change include shortening them.

### Checklist

* [ ] Have tests been added to cover any changes?
