### PR TITLE
build(deps): use sqlalchemy's database pool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && \
         nginx-extras \
         openssl \
         build-essential \
+        libpq-dev \
         procps \
         python3 \
         python3-dev \

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -498,17 +498,25 @@ GITLAB_URL_FOR_TOOLS = env.get("GITLAB_URL_FOR_TOOLS", "")
 
 DATABASES = {
     "default": {
-        "ENGINE": "django_db_geventpool.backends.postgresql_psycopg2",
+        "ENGINE": "dj_db_conn_pool.backends.postgresql",
         "CONN_MAX_AGE": 0,
         **env["ADMIN_DB"],
-        "OPTIONS": {"sslmode": "require", "MAX_CONNS": int(env.get("DEFAULT_DB_MAX_CONNS", "20"))},
+        "POOL_OPTIONS": {
+            "POOL_SIZE": int(env.get("DEFAULT_DB_MAX_CONNS", "20")),
+            "MAX_OVERFLOW": 0,
+            "RECYCLE": 24 * 60 * 8,
+        },
     },
     **{
         database_name: {
-            "ENGINE": "django_db_geventpool.backends.postgresql_psycopg2",
+            "ENGINE": "dj_db_conn_pool.backends.postgresql",
             "CONN_MAX_AGE": 0,
             **database,
-            "OPTIONS": {"sslmode": "require", "MAX_CONNS": 100},
+            "POOL_OPTIONS": {
+                "POOL_SIZE": int(env.get("DEFAULT_DB_MAX_CONNS", "20")),
+                "MAX_OVERFLOW": 0,
+                "RECYCLE": 24 * 60 * 8,
+            },
             "TEST": {"MIGRATE": False},
         }
         for database_name, database in env["DATA_DB"].items()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -151,7 +151,7 @@ django==3.2.18
     #   django-ckeditor
     #   django-csp
     #   django-csp-helpers
-    #   django-db-geventpool
+    #   django-db-connection-pool
     #   django-debug-toolbar
     #   django-dynamic-models-readonly
     #   django-js-asset
@@ -174,7 +174,7 @@ django-csp==3.6
     # via -r requirements.txt
 django-csp-helpers==0.6.2
     # via -r requirements.txt
-django-db-geventpool @ git+https://github.com/uktrade/django-db-geventpool@a5197b05baa84b4e6d01f17c2dd640d25750ce2b
+django-db-connection-pool[postgresql]==1.2.2
     # via -r requirements.txt
 django-debug-toolbar==3.2.1
     # via -r requirements-dev.in
@@ -381,13 +381,13 @@ prompt-toolkit==3.0.38
 psutil==5.7.2
     # via -r requirements.txt
 psycogreen==1.0.2
+    # via -r requirements.txt
+psycopg2==2.9.6
     # via
     #   -r requirements.txt
-    #   django-db-geventpool
+    #   django-db-connection-pool
 psycopg2-binary==2.9.6
-    # via
-    #   -r requirements.txt
-    #   aiopg
+    # via aiopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -533,9 +533,10 @@ soupsieve==2.3.2.post1
     # via
     #   -r requirements.txt
     #   beautifulsoup4
-sqlalchemy==1.3.19
+sqlalchemy==2.0.12
     # via
     #   -r requirements.txt
+    #   django-db-connection-pool
     #   geoalchemy2
     #   tabulator
 sqlparse==0.4.2
@@ -579,11 +580,13 @@ trio==0.20.0
     #   trio-websocket
 trio-websocket==0.9.2
     # via selenium
-typing-extensions==4.0.0
+typing-extensions==4.5.0
     # via
+    #   -r requirements.txt
     #   astroid
     #   black
     #   pylint
+    #   sqlalchemy
 unicodecsv==0.14.1
     # via
     #   -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -13,12 +13,7 @@ django-ckeditor
 django-compressor
 django-csp
 django-csp-helpers
-# Forked from django-db-geventpool to add Sentry exceptions when the pool is full
-# Ideally the fork will be merged upstream, but in the meantime, this commit is
-# from the develop branch in https://github.com/uktrade/django-db-geventpool
-# This is deliberately a commit ID rather than a branch name - to make sure that
-# old versions aren't cached anywhere if changes are made
-django-db-geventpool @ git+https://github.com/uktrade/django-db-geventpool@a5197b05baa84b4e6d01f17c2dd640d25750ce2b
+django-db-connection-pool[postgresql]
 django-dynamic-models-readonly
 django-environ
 django-extensions
@@ -42,7 +37,6 @@ plotly
 pglast
 psutil
 psycogreen
-psycopg2-binary
 python-dotenv
 redis
 pyjwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ django==3.2.18
     #   django-ckeditor
     #   django-csp
     #   django-csp-helpers
-    #   django-db-geventpool
+    #   django-db-connection-pool
     #   django-dynamic-models-readonly
     #   django-js-asset
     #   django-redis
@@ -108,7 +108,7 @@ django-csp==3.6
     # via -r requirements.in
 django-csp-helpers==0.6.2
     # via -r requirements.in
-django-db-geventpool @ git+https://github.com/uktrade/django-db-geventpool@a5197b05baa84b4e6d01f17c2dd640d25750ce2b
+django-db-connection-pool[postgresql]==1.2.2
     # via -r requirements.in
 django-dynamic-models-readonly==0.1.1
     # via -r requirements.in
@@ -203,11 +203,9 @@ prompt-toolkit==3.0.38
 psutil==5.7.2
     # via -r requirements.in
 psycogreen==1.0.2
-    # via
-    #   -r requirements.in
-    #   django-db-geventpool
-psycopg2-binary==2.9.6
     # via -r requirements.in
+psycopg2==2.9.6
+    # via django-db-connection-pool
 pycparser==2.20
     # via cffi
 pyjwt==2.4.0
@@ -274,9 +272,10 @@ six==1.15.0
     #   zenpy
 soupsieve==2.3.2.post1
     # via beautifulsoup4
-sqlalchemy==1.3.19
+sqlalchemy==2.0.12
     # via
     #   -r requirements.in
+    #   django-db-connection-pool
     #   geoalchemy2
     #   tabulator
 sqlparse==0.4.2
@@ -289,6 +288,8 @@ tenacity==6.2.0
     # via
     #   celery-redbeat
     #   plotly
+typing-extensions==4.5.0
+    # via sqlalchemy
 unicodecsv==0.14.1
     # via
     #   tableschema


### PR DESCRIPTION
### Description of change

Having a look at what was being used before, https://github.com/jneight/django-db-geventpool, suspect there are a few race conditions in the database connection pool code. We could fork (and we did try that), but

- It felt a bit like reinventing the wheel
- It used very little gevent-specific code

So, opting to use https://github.com/altairbow/django-db-connection-pool, a thin layer over SQLAlchemy's database connection pooling code, with the hope that with SQLAlchemy's popularity, it would address these race conditions, and be generally more robust. Note that because of gevent's monkey patching, using gevent with the pool _should_ work fine.

This change includes moving from psycopg2-binary to psycopg2 since https://github.com/altairbow/django-db-connection-pool requires that. It appears that for production use, psycopg2 is recommended. The downside of that is that it needs more dependencies to compile

Another downside is that this no longer has a logger.error when all connections has been allocated. However, I wonder if this is a better longer term bet - more battle tested pooling code without our own fork of pooling code which is what the logger.error came from.

However, the default timeout here that a request will wait before getting a connection is 30 seconds - compared to what I suspect was no timeout before, other than the 60 second timeout before a user gets a 50x from either nginx or the load balancer.  This admittedly may introduce some user-facing pain de-facto 60 second timeout to 30 seconds. But - it will force the situation to be addressed. Users should not be waiting 30 seconds for a database connection.

### Checklist

* [ ] Have tests been added to cover any changes?
