### PR TITLE
feat: DT-1344 - Remove tools access message from catalogue page

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -72,6 +72,9 @@
       <div class="govuk-body">
         {{ model.description | minimal_markup }}
       </div>
+      {% if datacut_links_info and not has_access %}
+        {% include 'partials/request_access.html' with type='datacut' has_data_access=has_access %}
+      {% endif %}
     </div>
     <div class="govuk-grid-column-one-third">
       {% if model.enquiries_contact %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -72,9 +72,6 @@
       <div class="govuk-body">
         {{ model.description | minimal_markup }}
       </div>
-      {% if datacut_links_info and not has_access %}
-        {% include 'partials/request_access.html' with type='datacut' has_data_access=has_access %}
-      {% endif %}
     </div>
     <div class="govuk-grid-column-one-third">
       {% if model.enquiries_contact %}

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -69,14 +69,6 @@
 
     </div>
 
-
-    {% if master_datasets_info %}
-      {% if not has_tools_access or not has_access %}
-        {% include 'partials/request_access.html' with type='master' has_tools_access=has_tools_access has_data_access=has_access %}
-      {% endif %}
-    {% endif %}
-
-
     <div class="govuk-grid-column-one-third">
       {% if model.enquiries_contact %}
         <p class="govuk-body sidebar-section">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -69,6 +69,14 @@
 
     </div>
 
+
+    {% if master_datasets_info %}
+      {% if not has_tools_access or not has_access %}
+        {% include 'partials/request_access.html' with type='master' has_tools_access=has_tools_access has_data_access=has_access %}
+      {% endif %}
+    {% endif %}
+
+
     <div class="govuk-grid-column-one-third">
       {% if model.enquiries_contact %}
         <p class="govuk-body sidebar-section">

--- a/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/master_dataset.html
@@ -67,12 +67,6 @@
         {{ model.description | minimal_markup }}
       </div>
 
-      {% if master_datasets_info %}
-        {% if not has_tools_access or not has_access %}
-          {% include 'partials/request_access.html' with type='master' has_tools_access=has_tools_access has_data_access=has_access %}
-        {% endif %}
-      {% endif %}
-
     </div>
 
     <div class="govuk-grid-column-one-third">

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -61,6 +61,10 @@
           {{ model.description | minimal_markup }}
         </div>
 
+        {% if not has_access %}
+          {% include 'partials/request_access.html' with type=dataset_type has_data_access=has_access %}
+        {% endif %}
+
       {% endwith %}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
+++ b/dataworkspace/dataworkspace/templates/datasets/visualisation_catalogue_item.html
@@ -61,10 +61,6 @@
           {{ model.description | minimal_markup }}
         </div>
 
-        {% if not has_access %}
-          {% include 'partials/request_access.html' with type=dataset_type has_data_access=has_access %}
-        {% endif %}
-
       {% endwith %}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/dataworkspace/dataworkspace/templates/partials/request_access.html
+++ b/dataworkspace/dataworkspace/templates/partials/request_access.html
@@ -9,6 +9,12 @@
         You need to request access to tools to analyse this data.
       {% endif %}
     </strong>
+      {% if type == 'master' and not has_tools_access %}
+          <p class="govuk-body govuk-!-margin-top-4">
+            We will ask you some questions so we can give you access to the tools you need to analyse this data.
+            <br>
+          </p>
+      {% endif %}
 
     <p class="govuk-body govuk-!-margin-top-4">
       We will respond to your access request within 5 working days.

--- a/dataworkspace/dataworkspace/templates/partials/request_access.html
+++ b/dataworkspace/dataworkspace/templates/partials/request_access.html
@@ -9,12 +9,6 @@
         You need to request access to tools to analyse this data.
       {% endif %}
     </strong>
-      {% if type == 'master' and not has_tools_access %}
-          <p class="govuk-body govuk-!-margin-top-4">
-            We will ask you some questions so we can give you access to the tools you need to analyse this data.
-            <br>
-          </p>
-      {% endif %}
 
     <p class="govuk-body govuk-!-margin-top-4">
       We will respond to your access request within 5 working days.

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -1916,10 +1916,6 @@ class TestRequestAccess(DatasetsCommon):
         url = reverse("datasets:dataset_detail", args=(master.id,))
         response = staff_client.get(url)
         assert response.status_code == 200
-        assert (
-            "We will ask you some questions so we can give you access to the tools you need to analyse this data."
-            in response.content.decode(response.charset)
-        )
 
     @pytest.mark.parametrize(
         "access_type", (UserAccessType.REQUIRES_AUTHENTICATION, UserAccessType.OPEN)

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -54,26 +54,6 @@ from dataworkspace.tests.conftest import get_client, get_user_data
 from dataworkspace.apps.applications.models import ApplicationInstance
 
 
-@pytest.mark.parametrize(
-    "eligibility_criteria,view_name",
-    [
-        ([], "request_access:dataset"),
-        (["Criteria 1", "Criteria 2"], "datasets:eligibility_criteria"),
-    ],
-)
-def test_dataset_has_request_access_link(client, eligibility_criteria, view_name, metadata_db):
-    ds = factories.DataSetFactory.create(eligibility_criteria=eligibility_criteria, published=True)
-
-    factories.SourceLinkFactory(dataset=ds)
-
-    response = client.get(ds.get_absolute_url())
-
-    request_access_url = reverse(view_name, args=[ds.id])
-
-    assert response.status_code == 200
-    assert request_access_url in str(response.content)
-
-
 def test_eligibility_criteria_list(client):
     ds = factories.DataSetFactory.create(
         eligibility_criteria=["Criteria 1", "Criteria 2"], published=True
@@ -1937,10 +1917,6 @@ class TestRequestAccess(DatasetsCommon):
         response = staff_client.get(url)
         assert response.status_code == 200
         assert (
-            "You need to request access to view this data. You can only access data with a valid reason."
-            in response.content.decode(response.charset)
-        )
-        assert (
             "We will ask you some questions so we can give you access to the tools you need to analyse this data."
             in response.content.decode(response.charset)
         )
@@ -1955,10 +1931,6 @@ class TestRequestAccess(DatasetsCommon):
         response = client.get(url)
 
         assert response.status_code == 200
-        assert (
-            "You need to request access to tools to analyse this data."
-            in response.content.decode(response.charset)
-        )
 
     def test_when_user_has_tools_access_only(self, db, staff_user, metadata_db):
         master = self._create_master(user_access_type=UserAccessType.REQUIRES_AUTHORIZATION)
@@ -1976,11 +1948,6 @@ class TestRequestAccess(DatasetsCommon):
         response = client.get(url)
         assert response.status_code == 200
 
-        assert (
-            "You need to request access to view this data. You can only access data with a valid reason."
-            in response.content.decode(response.charset)
-        )
-
     @pytest.mark.django_db
     def test_unauthorised_datacut(self, staff_client, metadata_db):
         self._create_master(user_access_type=UserAccessType.REQUIRES_AUTHORIZATION)
@@ -1993,9 +1960,6 @@ class TestRequestAccess(DatasetsCommon):
         url = reverse("datasets:dataset_detail", args=(datacut.id,))
         response = staff_client.get(url)
         assert response.status_code == 200
-        assert "You need to request access to view this data." in response.content.decode(
-            response.charset
-        )
 
     @pytest.mark.django_db
     def test_unauthorised_visualisation(self, staff_client, metadata_db):
@@ -2006,9 +1970,6 @@ class TestRequestAccess(DatasetsCommon):
         url = reverse("datasets:dataset_detail", args=(ds.id,))
         response = staff_client.get(url)
         assert response.status_code == 200
-        assert "You need to request access to view this data." in response.content.decode(
-            response.charset
-        )
 
 
 @pytest.mark.django_db
@@ -2145,10 +2106,6 @@ class TestVisualisationsDetailView:
 
         assert response.status_code == 200
         assert vis.name in response.content.decode(response.charset)
-        assert (
-            "You need to request access to view this data."
-            in response.content.decode(response.charset)
-        ) is not has_access
 
     @pytest.mark.django_db
     def test_shows_links_to_visualisations(self):

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -30,7 +30,6 @@ class TestDatasetAccessOnly:
         resp = client.get(dataset.get_absolute_url())
 
         assert resp.status_code == 200
-        assert "You need to request access to view this data." in resp.content.decode(resp.charset)
         assert (
             "We will ask you some questions so we can give you access to the tools you need to analyse this data."
             not in resp.content.decode(resp.charset)
@@ -169,9 +168,6 @@ class TestToolsAccessOnly:
         resp = client.get(dataset.get_absolute_url())
 
         assert resp.status_code == 200
-        assert "You need to request access to tools to analyse this data." in resp.content.decode(
-            resp.charset
-        )
         assert (
             "We will ask you some questions so we can give you access to the tools you need to analyse this data."
             in resp.content.decode(resp.charset)
@@ -361,7 +357,6 @@ class TestDatasetAndToolsAccess:
         resp = client.get(dataset.get_absolute_url())
 
         assert resp.status_code == 200
-        assert "You need to request access to view this data." in resp.content.decode(resp.charset)
         assert (
             "We will ask you some questions so we can give you access to the tools you need to analyse this data."
             in resp.content.decode(resp.charset)

--- a/dataworkspace/dataworkspace/tests/request_access/test_views.py
+++ b/dataworkspace/dataworkspace/tests/request_access/test_views.py
@@ -168,10 +168,6 @@ class TestToolsAccessOnly:
         resp = client.get(dataset.get_absolute_url())
 
         assert resp.status_code == 200
-        assert (
-            "We will ask you some questions so we can give you access to the tools you need to analyse this data."
-            in resp.content.decode(resp.charset)
-        )
 
     @pytest.mark.parametrize(
         "access_type", (UserAccessType.REQUIRES_AUTHENTICATION, UserAccessType.OPEN)
@@ -357,10 +353,6 @@ class TestDatasetAndToolsAccess:
         resp = client.get(dataset.get_absolute_url())
 
         assert resp.status_code == 200
-        assert (
-            "We will ask you some questions so we can give you access to the tools you need to analyse this data."
-            in resp.content.decode(resp.charset)
-        )
 
     def test_request_access_form_is_multipage_form(self, client, metadata_db):
         dataset = DatasetsCommon()._create_master(

--- a/test/test_application_1.py
+++ b/test/test_application_1.py
@@ -190,8 +190,6 @@ class TestApplication(unittest.IsolatedAsyncioTestCase):
         ) as response:
             content = await response.text()
 
-        self.assertIn("You need to request access to view this data.", content)
-
         async with session.request(
             "GET",
             "http://dataworkspace.test:8000/table_data/my_database/public/test_dataset",


### PR DESCRIPTION
### Description of change
When a user doesn’t have Tools access, the catalogue page tells them they will “need to request access to analyse this data” just above the data tables.

Users think this means they don’t have access to the data itself, but the message is actually just about access to Tools. This is very confusing. We discussed it in the team and agreed that this message can simply be removed.
### Checklist

* [ ] Have tests been added to cover any changes?
