### PR TITLE
feat: Admin only filter on search visible to all users

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -376,7 +376,7 @@ def find_datasets(request):
             "query": filters.query,
             "datasets": datasets,
             "data_type": dict(data_types),
-            "show_admin_filters": has_unpublished_dataset_access(request.user),
+            "show_admin_filters": has_unpublished_dataset_access(request.user) and request.user.is_superuser,
             "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
             "ACCESSIBLE_AUTOCOMPLETE_FLAG": settings.ACCESSIBLE_AUTOCOMPLETE_FLAG,
             "search_type": "searchBar" if filters.query else "noSearch",

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -376,7 +376,8 @@ def find_datasets(request):
             "query": filters.query,
             "datasets": datasets,
             "data_type": dict(data_types),
-            "show_admin_filters": has_unpublished_dataset_access(request.user) and request.user.is_superuser,
+            "show_admin_filters": has_unpublished_dataset_access(request.user)
+            and request.user.is_superuser,
             "DATASET_FINDER_FLAG": settings.DATASET_FINDER_ADMIN_ONLY_FLAG,
             "ACCESSIBLE_AUTOCOMPLETE_FLAG": settings.ACCESSIBLE_AUTOCOMPLETE_FLAG,
             "search_type": "searchBar" if filters.query else "noSearch",


### PR DESCRIPTION
### Description of change
The “Admin only options” appear to all users when they should only show for admin users. Can they be hidden unless the user is an admin?

### Checklist

* [ ] Have tests been added to cover any changes?
