### PR TITLE
fix: ignore inactive sso users to quiet noise in the logs

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -1157,6 +1157,14 @@ def _do_sync_activity_stream_sso_users():
             emails = obj["dit:emailAddress"]
             primary_email = obj["dit:StaffSSO:User:contactEmailAddress"] or emails[0]
 
+            if obj["dit:StaffSSO:User:status"] != "active":
+                logger.info(
+                    "Skipping user %s as their status is %s",
+                    primary_email,
+                    obj["dit:StaffSSO:User:status"],
+                )
+                continue
+
             try:
                 create_user_from_sso(
                     user_id,

--- a/dataworkspace/dataworkspace/tests/applications/test_fixture_activity_stream_sso_john_smith.json
+++ b/dataworkspace/dataworkspace/tests/applications/test_fixture_activity_stream_sso_john_smith.json
@@ -22,6 +22,7 @@
           "_source" : {
             "id" : "dit:StaffSSO:User:00000000-0000-0000-0000-000000000000:Update",
             "object" : {
+              "dit:StaffSSO:User:status": "active",
               "dit:StaffSSO:User:contactEmailAddress" : null,
               "dit:StaffSSO:User:emailUserId" : "john.smith@example.com",
               "dit:StaffSSO:User:joined" : "2020-01-01T12:00:00.000Z",

--- a/dataworkspace/dataworkspace/tests/applications/test_fixture_activity_stream_sso_john_smith_multiple_emails.json
+++ b/dataworkspace/dataworkspace/tests/applications/test_fixture_activity_stream_sso_john_smith_multiple_emails.json
@@ -22,6 +22,7 @@
           "_source" : {
             "id" : "dit:StaffSSO:User:00000000-0000-0000-0000-000000000000:Update",
             "object" : {
+              "dit:StaffSSO:User:status": "active",
               "dit:StaffSSO:User:contactEmailAddress" : null,
               "dit:StaffSSO:User:emailUserId" : "john.smith@example.com",
               "dit:StaffSSO:User:joined" : "2020-01-01T12:00:00.000Z",


### PR DESCRIPTION
### Description of change

Trying to create inactive sso users has generated over 9 million errors in sentry. This fix ignores inactive when syncing

### Checklist

* [ ] Have tests been added to cover any changes?
