### PR TITLE
fix: bump admin db storage from 60 to 100 GB

### DIFF
--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -1,7 +1,7 @@
 resource "aws_db_instance" "admin" {
   identifier = "${var.prefix}-admin"
 
-  allocated_storage = 60
+  allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
   engine_version = var.admin_db_instance_version


### PR DESCRIPTION
### Description of change

During to last weeks outage, the storage size on the prod admin db was bumped to 100GB. This fix updates the config to match


### Checklist

* [ ] Have tests been added to cover any changes?
