### PR TITLE
feat: do not calculate row count unless absolutely necessary

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -78,6 +78,8 @@ from dataworkspace.apps.your_files.models import UploadedTable
 from dataworkspace.datasets_db import (
     get_columns,
     get_earliest_tables_last_updated_date,
+    get_latest_row_count_for_query,
+    get_latest_row_count_for_table,
 )
 
 
@@ -780,6 +782,9 @@ class SourceTable(BaseSource):
             self.database.memorable_name, ((self.schema, self.table),)
         )
 
+    def get_metadata_row_count(self):
+        return get_latest_row_count_for_table(self)
+
     def get_grid_data_url(self):
         return reverse("datasets:source_table_data", args=(self.dataset_id, self.id))
 
@@ -1063,6 +1068,9 @@ class CustomDatasetQuery(ReferenceNumberedDatasetSource):
                 tuple((table.schema, table.table) for table in tables),
             )
         return None
+
+    def get_metadata_row_count(self):
+        return get_latest_row_count_for_query(self)
 
     def user_can_preview(self, user):
         return self.dataset.user_has_access(user) and (self.reviewed or user.is_superuser)

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -1313,10 +1313,11 @@ class DataGridDataView(DetailView):
             )
 
         records = self._get_rows(source, query, params)
-        rowcount = self._get_rows(source, rowcount_query, params)
         return JsonResponse(
             {
-                "rowcount": rowcount[0],
+                "rowcount": self._get_rows(source, rowcount_query, params)[0]
+                if request.GET.get("count")
+                else {"count": None},
                 "download_limit": source.data_grid_download_limit,
                 "records": records,
             }

--- a/dataworkspace/dataworkspace/static/data-grid.js
+++ b/dataworkspace/dataworkspace/static/data-grid.js
@@ -238,7 +238,22 @@ function initDataGrid(
     const initialRowCount = gridContainer.getAttribute(
       "data-initial-row-count"
     );
-    console.log(initialRowCount);
+
+    // When filters are reset, display the initial row count
+    gridOptions.api.eventService.addEventListener("filterChanged", (e) => {
+      if (
+        initialDataLoaded &&
+        initialRowCount !== null &&
+        Object.keys(gridOptions.api.getFilterModel()).length === 0
+      ) {
+        const rowCount = parseInt(initialRowCount);
+        document.getElementById("data-grid-rowcount").innerText =
+          rowCount > 5000
+            ? "Over " + Number("5000").toLocaleString() + " rows"
+            : rowCount.toLocaleString() + " rows";
+      }
+    });
+
     var dataSource = {
       rowCount: initialRowCount,
       getRows: function (params) {

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_source_detail.html
@@ -35,102 +35,113 @@
   </script>
 {% endblock footer_scripts %}
 {% block content %}
-  <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link"
-           href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset }}</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">{{ object.name }}</li>
-      {% flag SECURITY_CLASSIFICATION_FLAG %}
-        <div style="float: right" class="govuk-!-padding-right-3">
-          {% if not object.dataset.government_security_classification %}
-            <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
-          {% else %}
-            {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
-              <strong
-                class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+  {% with object.get_metadata_row_count as row_count %}
+    <div class="govuk-breadcrumbs govuk-!-padding-left-2 govuk-!-padding-bottom-2 govuk-!-margin-bottom-0 app-grid-breadcrumbs">
+      <ol class="govuk-breadcrumbs__list">
+        <li class="govuk-breadcrumbs__list-item">
+          <a class="govuk-breadcrumbs__link" href="">Home</a>
+        </li>
+        <li class="govuk-breadcrumbs__list-item">
+          <a class="govuk-breadcrumbs__link"
+             href="{% url "datasets:dataset_detail" dataset_uuid=object.dataset.id %}#{{ object.dataset.slug }}">{{ object.dataset }}</a>
+        </li>
+        <li class="govuk-breadcrumbs__list-item">{{ object.name }}</li>
+        {% flag SECURITY_CLASSIFICATION_FLAG %}
+          <div style="float: right" class="govuk-!-padding-right-3">
+            {% if not object.dataset.government_security_classification %}
+              <strong class="govuk-tag govuk-tag--yellow">Awaiting classification</strong>
             {% else %}
-              <strong
-                class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
-                {% if object.dataset.sensitivity.all %}
-                  {% for sensitivity in object.dataset.sensitivity.all %}
-                    {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
-                  {% endfor %}
-                {% endif %} </strong>
-            {% endif %}
-          {% endif %}
-        </div>
-      {% endflag %}
-    </ol>
-  </div>
-  <div id="collapsible-header" class="govuk-!-margin-top-4">
-    {% include "datasets/partials/grid-view-saved.html" %}
-    {% if object.dataset.enquiries_contact %}
-      <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3" style="float: right"
-        href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
-        {% include "partials/report_an_issue_icon.html" %}
-      </a>
-    {% endif %}
-    <div class="govuk-!-padding-top-3 govuk-!-padding-left-2">
-      <span class="govuk-caption-xl">
-        Data table{% if object.schema %} ({{ object.schema }}.{{ object.table }}){% endif %}
-      </span>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          <h2 class="govuk-heading-l govuk-!-margin-bottom-0">{{ object.name }} </h2>
-        </div>
-        <div class="govuk-grid-column-full">
-          <p class="govuk-body govuk-!-padding-top-0 govuk-!-padding-right-3 govuk-!-margin-bottom-2 govuk-!-text-align-right">
-          <span class="govuk-!-font-weight-bold">Data last updated:</span>
-            {{ object.get_data_last_updated_date|gmt_date|default_if_none:"N/A" }} {{ object.get_data_last_updated_date|time_with_gmt_offset|default_if_none:"N/A" }}
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-     <div class="app-compressed-grid">
-      <div class="app-grid-header">
-        <div class="grid-header-left">
-          <div class="govuk-button-group">
-            <p class="govuk-body govuk-!-font-weight-bold" id="data-grid-rowcount"> Loading data... </p>
-            {% flag CHART_BUILDER_BUILD_CHARTS_FLAG %}
-              <button class="govuk-button" id="data-grid-create-chart">Create a chart</button>
-            {% endflag %}
-            <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-save-view" data-prevent-double-click="true">
-              Save view
-            </button>
-            <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-reset-view">
-              Reset view
-            </button>
-            {% if object.data_grid_download_enabled %}
-              <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-download">
-                Download this data
-              </button>
-            {% endif %}
-            {# We only support data dictionaries for master and reference datasets currently #}
-            {# reference datagrid uses reference_dataset_grid.html btw   #}
-            {% if object.type == 1 %}
-              {% if object.dataset.dictionary_published or request.user|can_edit_dataset:object.dataset %}
-                <a href="{% url "datasets:data_dictionary" source_uuid=object.id %}?dataset_uuid={{ object.dataset.id }}" target="_blank" class="govuk-link govuk-!-margin-top-1 govuk-!-font-size-16">
-                  Data dictionary
-                </a>
+              {% if object.dataset.get_government_security_classification_display == "OFFICIAL" %}
+                <strong
+                  class="govuk-tag govuk-tag--blue">{{ object.dataset.get_government_security_classification_display }}</strong>
+              {% else %}
+                <strong
+                  class="govuk-tag govuk-tag--red">{{ object.dataset.get_government_security_classification_display }}
+                  {% if object.dataset.sensitivity.all %}
+                    {% for sensitivity in object.dataset.sensitivity.all %}
+                      {% if not forloop.first %}and{% endif %}</span> {{ sensitivity }}
+                    {% endfor %}
+                  {% endif %} </strong>
               {% endif %}
             {% endif %}
           </div>
-        </div>
-        <div class="grid-header-right govuk-!-padding-right-3">
-          <button id="increase-grid-button" class="govuk-button govuk-button--secondary" data-module="govuk-button">Show more rows</button>
+        {% endflag %}
+      </ol>
+    </div>
+    <div id="collapsible-header" class="govuk-!-margin-top-4">
+      {% include "datasets/partials/grid-view-saved.html" %}
+      {% if object.dataset.enquiries_contact %}
+        <a class="govuk-link govuk-link--no-visited-state govuk-!-padding-right-3" style="float: right"
+          href="mailto:{{ object.dataset.enquiries_contact.email }}?subject=Reporting an issue - {{ object.name }}">
+          {% include "partials/report_an_issue_icon.html" %}
+        </a>
+      {% endif %}
+      <div class="govuk-!-padding-top-3 govuk-!-padding-left-2">
+        <span class="govuk-caption-xl">
+          Data table{% if object.schema %} ({{ object.schema }}.{{ object.table }}){% endif %}
+        </span>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-l govuk-!-margin-bottom-0">{{ object.name }} </h2>
+          </div>
+          <div class="govuk-grid-column-full">
+            <p class="govuk-body govuk-!-padding-top-0 govuk-!-padding-right-3 govuk-!-margin-bottom-2 govuk-!-text-align-right">
+            <span class="govuk-!-font-weight-bold">Data last updated:</span>
+              {{ object.get_data_last_updated_date|gmt_date|default_if_none:"N/A" }} {{ object.get_data_last_updated_date|time_with_gmt_offset|default_if_none:"N/A" }}
+            </p>
+          </div>
         </div>
       </div>
-      <div
-        id="data-grid"
-        class="ag-theme-alpine"
-        data-save-view-url="{{ object.get_save_grid_view_url }}"
-      ></div>
     </div>
+       <div class="app-compressed-grid">
+        <div class="app-grid-header">
+          <div class="grid-header-left">
+            <div class="govuk-button-group">
+              <p class="govuk-body govuk-!-font-weight-bold" id="data-grid-rowcount">
+                {% if row_count is not None %}
+                  {% if row_count > 5000 %}Over 5,000{% else %}{{ row_count|intcomma }}{% endif %} rows
+                {% else %}
+                  Loading data...
+                {% endif %}
+              </p>
+              {% flag CHART_BUILDER_BUILD_CHARTS_FLAG %}
+                <button class="govuk-button" id="data-grid-create-chart">Create a chart</button>
+              {% endflag %}
+              <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-save-view" data-prevent-double-click="true">
+                Save view
+              </button>
+              <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-reset-view">
+                Reset view
+              </button>
+              {% if object.data_grid_download_enabled %}
+                <button class="govuk-button govuk-button--secondary" data-module="govuk-button" id="data-grid-download">
+                  Download this data
+                </button>
+              {% endif %}
+              {# We only support data dictionaries for master and reference datasets currently #}
+              {# reference datagrid uses reference_dataset_grid.html btw   #}
+              {% if object.type == 1 %}
+                {% if object.dataset.dictionary_published or request.user|can_edit_dataset:object.dataset %}
+                  <a href="{% url "datasets:data_dictionary" source_uuid=object.id %}?dataset_uuid={{ object.dataset.id }}" target="_blank" class="govuk-link govuk-!-margin-top-1 govuk-!-font-size-16">
+                    Data dictionary
+                  </a>
+                {% endif %}
+              {% endif %}
+            </div>
+          </div>
+          <div class="grid-header-right govuk-!-padding-right-3">
+            <button id="increase-grid-button" class="govuk-button govuk-button--secondary" data-module="govuk-button">Show more rows</button>
+          </div>
+        </div>
+        <div
+          id="data-grid"
+          class="ag-theme-alpine"
+          data-save-view-url="{{ object.get_save_grid_view_url }}"
+          {% if row_count is not None %}
+            data-initial-row-count="{{ row_count }}"
+          {% endif %}
+        ></div>
+      </div>
+  {% endwith %}
   {% csrf_token %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/datasets/test_views.py
+++ b/dataworkspace/dataworkspace/tests/datasets/test_views.py
@@ -3345,10 +3345,57 @@ class TestGridDataView:
             ("custom_query", "custom_dataset_query_data"),
         ),
     )
-    def test_contains_filter(self, client, fixture_name, url_name, request):
+    def test_no_count(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
             reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            {
+                "sort_direction": "ASC",
+                "sort_field": "num",
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json() == {
+            "rowcount": {"count": None},
+            "download_limit": None,
+            "records": [
+                {
+                    "date": "2019-01-01",
+                    "id": "488d06b6-032b-467a-b2c5-2820610b0ca6",
+                    "name": "the second record",
+                    "num": "2",
+                    "an_array": ["ghi", "jkl"],
+                },
+                {
+                    "name": "the first record",
+                    "num": "1",
+                    "date": None,
+                    "id": "896b4dde-f787-41be-a7bf-82be91805f24",
+                    "an_array": ["abc", "def"],
+                },
+                {
+                    "name": "the last record",
+                    "num": None,
+                    "date": "2020-01-01",
+                    "id": "a41da88b-ffa3-4102-928c-b3937fa5b58f",
+                    "an_array": None,
+                },
+            ],
+        }
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        "fixture_name, url_name",
+        (
+            ("source_table", "source_table_data"),
+            ("custom_query", "custom_dataset_query_data"),
+        ),
+    )
+    def test_contains_filter(self, client, fixture_name, url_name, request):
+        source = request.getfixturevalue(fixture_name)
+        response = client.post(
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             {
                 "filters": {
                     "name": {
@@ -3386,7 +3433,7 @@ class TestGridDataView:
     def test_not_contains_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "name": {
@@ -3430,7 +3477,7 @@ class TestGridDataView:
     def test_equals_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "date": {
@@ -3468,7 +3515,7 @@ class TestGridDataView:
     def test_not_equals_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "date": {
@@ -3513,7 +3560,7 @@ class TestGridDataView:
     def test_starts_with_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "name": {
@@ -3550,7 +3597,7 @@ class TestGridDataView:
     def test_ends_with_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "name": {
@@ -3587,7 +3634,7 @@ class TestGridDataView:
     def test_range_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "date": {
@@ -3625,7 +3672,7 @@ class TestGridDataView:
     def test_less_than_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "date": {
@@ -3663,7 +3710,7 @@ class TestGridDataView:
     def test_greater_than_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             data={
                 "filters": {
                     "date": {
@@ -3702,7 +3749,7 @@ class TestGridDataView:
     def test_array_contains_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             {
                 "filters": {
                     "an_array": {
@@ -3740,7 +3787,7 @@ class TestGridDataView:
     def test_array_not_contains_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             {
                 "filters": {
                     "an_array": {
@@ -3785,7 +3832,7 @@ class TestGridDataView:
     def test_array_equals_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             {
                 "filters": {
                     "an_array": {
@@ -3823,7 +3870,7 @@ class TestGridDataView:
     def test_array_not_equals_filter(self, client, fixture_name, url_name, request):
         source = request.getfixturevalue(fixture_name)
         response = client.post(
-            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)),
+            reverse(f"datasets:{url_name}", args=(source.dataset.id, source.id)) + "?count=1",
             {
                 "filters": {
                     "an_array": {


### PR DESCRIPTION
### Description of change

- Make returning the row count optional when fetching grid data
- If no grid filters are applied, display the row count from the metadata table


### Checklist

* [x] Have tests been added to cover any changes?
