### PR TITLE
feat: allow sql editing on visualisation datasets page

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -1101,10 +1101,8 @@ def visualisation_datasets_html_view(request, gitlab_project_id):
     return HttpResponse(status=405)
 
 
-def visualisation_datasets_html_GET(request, gitlab_project):
-    application_template = _application_template(gitlab_project)
-    datasets = _datasets(request.user, application_template)
-    pipeline_objects = Pipeline.objects.filter(
+def _get_pipeline_objects_for_application(application_template):
+    return Pipeline.objects.filter(
         Q(
             table_name__startswith=USER_SCHEMA_STEM
             + db_role_schema_suffix_for_app(application_template)
@@ -1118,6 +1116,12 @@ def visualisation_datasets_html_GET(request, gitlab_project):
             + "."
         )
     )
+
+
+def visualisation_datasets_html_GET(request, gitlab_project):
+    application_template = _application_template(gitlab_project)
+    datasets = _datasets(request.user, application_template)
+    pipeline_objects = _get_pipeline_objects_for_application(application_template)
     tables = [
         extract_queried_tables_from_sql_query(pipeline_object.config["sql"])
         if "sql" in pipeline_object.config

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit, urlencode
 
 import boto3
 import botocore
+import pglast
 import waffle
 from botocore.config import Config
 from csp.decorators import csp_exempt, csp_update
@@ -86,6 +87,7 @@ from dataworkspace.apps.datasets.models import (
     VisualisationUserPermission,
     VisualisationLink,
 )
+from dataworkspace.apps.datasets.pipelines.views import save_pipeline_to_dataflow
 from dataworkspace.apps.eventlog.models import EventLog
 from dataworkspace.apps.eventlog.utils import log_event
 from dataworkspace.notify import decrypt_token, send_email
@@ -1148,6 +1150,59 @@ def visualisation_datasets_html_GET(request, gitlab_project):
 def visualisation_datasets_html_POST(request, gitlab_project):
     application_template = _application_template(gitlab_project)
     datasets = _datasets(request.user, application_template)
+
+    pipeline_ids = request.POST.getlist("pipeline_id")
+    pipeline_sqls = request.POST.getlist("sql")
+
+    # Ensure the user only submits pipelines for this visualisation
+    existing_pipeline_ids = set(
+        str(pipeline.id)
+        for pipeline in _get_pipeline_objects_for_application(application_template)
+    )
+    for pipeline_id in pipeline_ids:
+        if pipeline_id not in existing_pipeline_ids:
+            messages.error(request, "You can only save SQL pipelines for this visualisation")
+            return redirect("visualisations:datasets", gitlab_project_id=gitlab_project["id"])
+
+    # Ensure there is a single, valid SELECT statement in query
+    for sql in pipeline_sqls:
+        query = sql.strip().rstrip(";")
+        try:
+            statements = pglast.parse_sql(query)
+        except pglast.parser.ParseError as e:  # pylint: disable=c-extension-no-member
+            messages.error(request, e)
+            return redirect("visualisations:datasets", gitlab_project_id=gitlab_project["id"])
+        else:
+            if len(statements) > 1:
+                messages.error(request, "Enter a single statement")
+                return redirect("visualisations:datasets", gitlab_project_id=gitlab_project["id"])
+            statement_dict = statements[0].stmt()
+            if statement_dict["@"] != "SelectStmt":
+                messages.error(request, "Only SELECT statements are supported")
+                return redirect("visualisations:datasets", gitlab_project_id=gitlab_project["id"])
+
+    # Ensure that new tables are not added to any pipelines
+    tables_from_input = [set(extract_queried_tables_from_sql_query(sql)) for sql in pipeline_sqls]
+    tables_from_existing_pipelines = [
+        set(
+            extract_queried_tables_from_sql_query(
+                Pipeline.objects.get(id=int(pipeline_id)).config["sql"]
+            )
+        )
+        for pipeline_id in pipeline_ids
+    ]
+    for tables_input, tables_existing in zip(tables_from_input, tables_from_existing_pipelines):
+        if not tables_input.issubset(tables_existing):
+            messages.error(request, "You cannot add new tables to SQL pipelines")
+            return redirect("visualisations:datasets", gitlab_project_id=gitlab_project["id"])
+
+    # Save any changed pipelines
+    for pipeline_id, sql in zip(pipeline_ids, pipeline_sqls):
+        pipeline = Pipeline.objects.get(id=int(pipeline_id))
+        if pipeline.config["sql"] != sql:
+            pipeline.config["sql"] = sql
+            save_pipeline_to_dataflow(pipeline, "PUT")
+            pipeline.save()
 
     # Sets for O(1) lookup, and lists for deterministic looping
 

--- a/dataworkspace/dataworkspace/templates/visualisation_datasets.html
+++ b/dataworkspace/dataworkspace/templates/visualisation_datasets.html
@@ -54,7 +54,8 @@
                         </li>
                         {% endfor %}
                     </ul>
-                    <pre class="govuk-!-margin-top-1">{{ pipeline.config.sql }}</pre>
+                    <input type="hidden" name="pipeline_id" value="{{ pipeline.id }}">
+                    <textarea name="sql" rows="10" class="govuk-textarea">{{ pipeline.config.sql }}</textarea>
                 </span>
             </div>
             {% endfor %}


### PR DESCRIPTION
### Description of change

This allows visualisation developers to edit the SQL of existing, admin-added, pipelines that populate a visualisation schema, as long as it doesn't add to its set of tables.

This is a stepping stone to more functionality - but it is a fairly straightforward way to allow visualisation developers some ability to iterate on SQL pipelines

<img width="1029" alt="Screenshot 2023-06-13 at 16 31 06" src="https://github.com/uktrade/data-workspace/assets/116172079/937cec1c-5e2a-48ce-9d5d-46e251b6d2ae">

<img width="1166" alt="Screenshot 2023-06-13 at 16 25 02" src="https://github.com/uktrade/data-workspace/assets/116172079/8e9610b5-a01d-468c-8a9a-603aac2ec556">

<img width="1146" alt="Screenshot 2023-06-13 at 16 26 36" src="https://github.com/uktrade/data-workspace/assets/116172079/46e695bb-eba7-42b7-aec0-0a54bc1140d6">

<img width="1094" alt="Screenshot 2023-06-13 at 16 33 12" src="https://github.com/uktrade/data-workspace/assets/116172079/09be327e-5c6f-43a4-bdb8-a41b2f9dfcd0">

<img width="1121" alt="Screenshot 2023-06-13 at 16 28 08" src="https://github.com/uktrade/data-workspace/assets/116172079/89249a37-560b-4167-bb32-0b57d1cdaf2f">


### Checklist

* [x] Have tests been added to cover any changes?
