### PR TITLE
fix: iframes must have a closing tag.

### DIFF
--- a/dataworkspace/dataworkspace/templates/running.html
+++ b/dataworkspace/dataworkspace/templates/running.html
@@ -1,4 +1,4 @@
 {% extends 'running_base.html' %}
 {% block visualisation %}
-  <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="visualisation" />
+  <iframe src="{{ visualisation_src }}" sandbox="allow-forms allow-presentation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-downloads" class="visualisation"></iframe>
 {% endblock visualisation %}


### PR DESCRIPTION
### Description of change

This was breaking the html/js further down the page


### Checklist

* [ ] Have tests been added to cover any changes?
