### PR TITLE
fix: replace slashes in column names with underscores

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1259,6 +1259,13 @@ def clean_db_identifier(identifier):
     return re.sub(r"[-\s]+", "_", identifier)
 
 
+def clean_db_column_name(column_name):
+    """
+    Replace forward slashes in column names before cleaning for user
+    """
+    return clean_db_identifier(column_name.replace("/", ""))
+
+
 def get_s3_csv_column_types(path):
     client = get_s3_client()
 
@@ -1289,7 +1296,7 @@ def get_s3_csv_column_types(path):
         fields.append(
             {
                 "header_name": field["name"],
-                "column_name": clean_db_identifier(field["name"]),
+                "column_name": clean_db_column_name(field["name"]),
                 "data_type": SCHEMA_POSTGRES_DATA_TYPE_MAP.get(
                     TABLESCHEMA_FIELD_TYPE_MAP.get(field["type"], field["type"]),
                     PostgresDataTypes.TEXT,

--- a/dataworkspace/dataworkspace/apps/your_files/utils.py
+++ b/dataworkspace/dataworkspace/apps/your_files/utils.py
@@ -13,7 +13,7 @@ from dataworkspace.apps.core.constants import (
 )
 from dataworkspace.apps.core.utils import (
     USER_SCHEMA_STEM,
-    clean_db_identifier,
+    clean_db_column_name,
     db_role_schema_suffix_for_user,
 )
 
@@ -78,7 +78,7 @@ def _get_csv_column_types(rows):
         fields.append(
             {
                 "header_name": field["name"],
-                "column_name": clean_db_identifier(field["name"]),
+                "column_name": clean_db_column_name(field["name"]),
                 "data_type": SCHEMA_POSTGRES_DATA_TYPE_MAP.get(
                     TABLESCHEMA_FIELD_TYPE_MAP.get(field["type"], field["type"]),
                     PostgresDataTypes.TEXT,


### PR DESCRIPTION
### Description of change

Fixes an issue where slashes in column names were creating duplicate columns. When an uploaded csv had multiple columns with forward slashes we were only using the last part of the name. 

For example if we had two columns,`business address / line 1` and `home address / line 1`, were were naming both columns `line_1`. This PR removes the forward slash so the columns would be named `business_address_line_1` and `home_address_line_1`.

### Checklist

* [ ] Have tests been added to cover any changes?
