### PR TITLE
fix: catch and fix duplicate vis sql links

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/utils.py
+++ b/dataworkspace/dataworkspace/apps/datasets/utils.py
@@ -336,7 +336,10 @@ def store_sql_query(visualisation_link, data_set_id, table_id, sql_query):
             table_id=table_id,
             sql_query=sql_query,
         )
-    except VisualisationLinkSqlQuery.DoesNotExist:
+    except (
+        VisualisationLinkSqlQuery.DoesNotExist,
+        VisualisationLinkSqlQuery.MultipleObjectsReturned,
+    ):
         visualisation_link.sql_queries.filter(
             is_latest=True, data_set_id=data_set_id, table_id=table_id
         ).update(is_latest=False)


### PR DESCRIPTION
### Description of change

If a dataset has multiple "latest" visualisation sql links mark them all as not-latest and create a new link

### Checklist

* [ ] Have tests been added to cover any changes?
