### PR TITLE
fix: log failed stop task calls to sentry

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/spawner.py
+++ b/dataworkspace/dataworkspace/apps/applications/spawner.py
@@ -750,6 +750,7 @@ def _fargate_task_stop(cluster_name, task_arn):
         try:
             client.stop_task(cluster=cluster_name, task=task_arn)
         except Exception:  # pylint: disable=broad-except
+            logger.exception("stop_task failed for %s - Retrying", task_arn)
             gevent.sleep(sleep_time)
             sleep_time = sleep_time * 2
         else:


### PR DESCRIPTION
### Description of change

We are seeing a lot of 400 errors when stopping tasks, hopefully this will shed some light on what they are


### Checklist

* [ ] Have tests been added to cover any changes?
