### PR TITLE
fix: don't let broken reference datasets break the metadata syncer

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1638,7 +1638,10 @@ class ReferenceDataset(DeletableTimestampedUserModel):
         """
         records = self.get_records()
         if records.exists():
-            return records.latest("updated_date").updated_date
+            try:
+                return records.latest("updated_date").updated_date
+            except ProgrammingError:
+                pass
         return None
 
     @property


### PR DESCRIPTION
### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
