### PR TITLE
less frequent user notifications to help ease db load

### DIFF
--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -415,7 +415,7 @@ if not strtobool(env.get("DISABLE_CELERY_BEAT_SCHEDULE", "0")):
         },
         "send-notification-emails": {
             "task": "dataworkspace.apps.datasets.utils.send_notification_emails",
-            "schedule": 60 * 5,
+            "schedule": 60 * 60,
             "args": (),
         },
         "update-search-popularity": {


### PR DESCRIPTION
### Description of change
User notifications were being sent every 5 mins, this is now setup to run hourly temporarily. This is to ease db load, while tools are having tough time.

### Checklist

* [ ] Have tests been added to cover any changes?
