### PR TITLE
fix: stop using information_schema for perms queries

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -229,14 +229,18 @@ def new_private_database_credentials(
             cur.execute(
                 sql.SQL(
                     """
-                    SELECT table_schema as schema, table_name as name
-                    FROM information_schema.table_privileges
-                    WHERE grantee = {role}
-                    AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast', '_data_explorer_charts')
-                    AND table_schema NOT SIMILAR TO 'pg_temp_%|pg_toast_temp_%|pg_toast_temp_%|_user_%|_team_%'
-                    AND table_name NOT SIMILAR TO '_\\d{{8}}t\\d{{6}}|%_swap|%0000|_tmp%'
+                    SELECT relnamespace::regnamespace::text AS schema, relname AS name
+                    FROM pg_class, aclexplode(relacl) acl
+                    WHERE acl.grantee = {role}::regrole::oid
+                    AND acl.privilege_type in (
+                        'SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER'
+                    )
+                    AND relnamespace::regnamespace::text NOT SIMILAR TO
+                        'pg_toast|pg_temp_%|pg_toast_temp_%|_team_%|_user_%'
+                    AND relname NOT SIMILAR TO
+                        '_\\d{{8}}t\\d{{6}}|%_swap|%_idx|_tmp%|%_pkey|%_seq|_data_explorer_tmp%|%000000|_tmp_%';
                     """
-                ).format(role=sql.Literal(db_role), schema=sql.Literal(db_schema))
+                ).format(role=sql.Literal(db_role))
             )
             tables_with_existing_privs_set = set(cur.fetchall())
             logger.info(


### PR DESCRIPTION
### Description of change

Speed up the user table permission gathering query by not using the `information_schema.table_privileges` view. 

### Checklist

* [ ] Have tests been added to cover any changes?
