### PR TITLE
fix: bust tool/schema cache when a ref dataset is (un)published

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -1566,7 +1566,7 @@ class ReferenceDataset(DeletableTimestampedUserModel):
             )
             .filter(profile__sso_status="active")
         ):
-            # clear_schema_info_cache_for_user(user)
+            # repeat of clear_schema_info_cache_for_user, to avoid circular imports
             for conn in connections.values():
                 cache_key = f"_explorer_cache_key_{user.profile.sso_id}_{conn}"
                 cache.delete(cache_key)


### PR DESCRIPTION
### Description of change

When a reference dataset is added to or removed from the datasets db we need to force a permissions change for all users. Do this by removing the cached tool permissions and schemas for all active users.

### Checklist

* [ ] Have tests been added to cover any changes?
