### PR TITLE
Sub feat/combine data tables

### DIFF
--- a/dataworkspace/dataworkspace/static/dialog.js
+++ b/dataworkspace/dataworkspace/static/dialog.js
@@ -1,0 +1,18 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const links = document.querySelectorAll("a[data-modal-id]");
+
+    links.forEach(function (link) {
+      link.addEventListener("click", function (e) {
+        e.preventDefault();
+        const modalId = e.target.getAttribute("data-modal-id");
+        const modal = document.getElementById(`modal${modalId}`);
+
+        modal.showModal();
+
+        button = modal.querySelector("button[data-modal-id]");
+        button.addEventListener("click", function () {
+          modal.close();
+        });
+      });
+    });
+  });

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -84,11 +84,11 @@
     <div class="govuk-grid-column-full">
       <h2 class="govuk-heading-m">
         {% if has_datacut_tables and has_datacut_links %}
-        Data Tables & Links
+        Data tables & links
         {% elif has_datacut_tables and not has_datacut_links %}
         Data tables
         {% elif not has_datacut_tables and has_datacut_links %}
-        Links
+        Data links
         {% endif %}
       </h2> 
       {% if not has_access and has_datacut_tables and not has_datacut_links %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -79,66 +79,61 @@
   </div>
   {% endif %}
 
-  {% if has_datacut_tables %}
+  {% if has_datacut_tables or has_datacut_links %}
   <div class="govuk-grid-row govuk-!-margin-top-4">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m">Data tables</h2> 
+      <h2 class="govuk-heading-m">
+        {% if has_datacut_tables and has_datacut_links %}
+        Data Tables & Links
+        {% elif has_datacut_tables and not has_datacut_links %}
+        Data tables
+        {% elif not has_datacut_tables and has_datacut_links %}
+        Links
+        {% endif %}
+      </h2> 
       {% if not has_access and has_datacut_tables and not has_datacut_links %}
           {% include 'partials/request_access.html' with type='datacut' has_data_access=has_access %}
       {% endif %}
       <table class="govuk-table">
         <thead>
         <tr class="govuk-table__row">
-          <th class="govuk-table__header govuk-!-width-two-thirds">Name</th>
-          <th class="govuk-table__header govuk-!-width-one-third">Last updated</th>
+          <th class="govuk-table__header govuk-!-width-two-quarters">Name</th>
+          {% if has_datacut_links %}
+          <th class="govuk-table__header govuk-!-width-one-thirds">Format</th>
+          <th class="govuk-table__header govuk-!-width-one-thirds">Last updated</th>
+          {% elif not has_datacut_links %}
+          <th class="govuk-table__header govuk-!-width-two-quarters">Last updated</th>
+          {% endif %}
         </tr>
         </thead>
         <tbody>
-        {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
-          {% if can_show_link and datacut_link.type == custom_dataset_query_type %}
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                {% if has_access and datacut_link.data_grid_enabled %}
-                    <a class="govuk-link govuk-link--no-visited-state govuk-body"
-                    href="{% url "datasets:custom_dataset_query_detail" dataset_uuid=dataset.id object_id=datacut_link.id %}">
-                    {{ datacut_link.name }}</a>
-                  {% else %}
-                    {{ datacut_link.name }}
+        {% if has_datacut_tables %}
+          {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
+            {% if can_show_link and datacut_link.type == custom_dataset_query_type %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">
+                  {% if has_access and datacut_link.data_grid_enabled %}
+                      <a class="govuk-link govuk-link--no-visited-state govuk-body"
+                      href="{% url "datasets:custom_dataset_query_detail" dataset_uuid=dataset.id object_id=datacut_link.id %}">
+                      {{ datacut_link.name }}</a>
+                    {% else %}
+                      {{ datacut_link.name }}
+                  {% endif %}
+                </td>
+                {% if has_datacut_links %}
+                <td class="govuk-table__cell">
+                  -
+                </td>
                 {% endif %}
-              </td>
-              <td class="govuk-table__cell">
-                {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
-              </td>
-            </tr>
-          {% endif %}
-        {% endfor %}
-        </tbody>
-      </table>
-    </div>
-  </div>
-  {% endif %}
-
-  {% if has_datacut_links %}
-    {% if has_datacut_tables and has_datacut_links %}
-    <div class="govuk-grid-row govuk-!-margin-top-8">
-    {% else %}
-    <div class="govuk-grid-row govuk-!-margin-top-4">
-    {% endif %}
-      <div class="govuk-grid-column-full">
-        <h2 class="govuk-heading-m">Links</h2> 
-        {% if not has_access and has_datacut_links and not has_datacut_tables %}
-          {% include 'partials/request_access.html' with type='datacut' has_data_access=has_access %}
-       {% endif %}
-        <table class="govuk-table">
-          <thead>
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header govuk-!-width-one-half">Name</th>
-            <th class="govuk-table__header govuk-!-width-one-quarter">Format</th>
-            <th class="govuk-table__header govuk-!-width-one-quarter">Last updated</th>
-          </tr>
-          </thead>
-          <tbody>
-            {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
+                <td class="govuk-table__cell">
+                  {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
+                </td>
+              </tr>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+        {% if has_datacut_links %}
+          {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
               {% if can_show_link and datacut_link.type != custom_dataset_query_type %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
@@ -159,12 +154,12 @@
               </tr>
               {% endif %}
             {% endfor %}
-          </tbody>
-        </table>
-      </div>
+          {% endif %}
+        </tbody>
+      </table>
     </div>
-
-    {% endif %}
+  </div>
+  {% endif %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -79,18 +79,11 @@
   </div>
   {% endif %}
 
+  <!-- Data section -->
   {% if has_datacut_tables or has_datacut_links %}
   <div class="govuk-grid-row govuk-!-margin-top-4">
     <div class="govuk-grid-column-full">
-      <h2 class="govuk-heading-m">
-        {% if has_datacut_tables and has_datacut_links %}
-        Data tables & links
-        {% elif has_datacut_tables and not has_datacut_links %}
-        Data tables
-        {% elif not has_datacut_tables and has_datacut_links %}
-        Data links
-        {% endif %}
-      </h2> 
+      <h2 class="govuk-heading-m">Data</h2> 
       {% if not has_access and has_datacut_tables and not has_datacut_links %}
           {% include 'partials/request_access.html' with type='datacut' has_data_access=has_access %}
       {% endif %}
@@ -113,20 +106,22 @@
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell">
                   {% if has_access and datacut_link.data_grid_enabled %}
-                      <a class="govuk-link govuk-link--no-visited-state govuk-body"
-                      href="{% url "datasets:custom_dataset_query_detail" dataset_uuid=dataset.id object_id=datacut_link.id %}">
+                    <a 
+                      class="govuk-link govuk-link--no-visited-state govuk-body"
+                      href="{% url "datasets:custom_dataset_query_detail" dataset_uuid=dataset.id object_id=datacut_link.id %}"
+                    >
                       {{ datacut_link.name }}</a>
-                    {% else %}
+                  {% else %}
                       {{ datacut_link.name }}
                   {% endif %}
                 </td>
                 {% if has_datacut_links %}
                 <td class="govuk-table__cell">
-                  -
+                  Data table
                 </td>
                 {% endif %}
                 <td class="govuk-table__cell">
-                  {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
+                  {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }} 
                 </td>
               </tr>
             {% endif %}
@@ -134,27 +129,49 @@
         {% endif %}
         {% if has_datacut_links %}
           {% for datacut_link, can_show_link, code_snippets, columns, tools_links in datacut_links_info %}
-              {% if can_show_link and datacut_link.type != custom_dataset_query_type %}
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
-                  {% if has_access %}
-                  <a href="{{ datacut_link.get_absolute_url }}" class="govuk-link govuk-link--no-visited-state govuk-body">
-                    {{ datacut_link.name}}
-                  </a>&nbsp;{% include "partials/icons/open_externally_icon.html" %}
-                  {% else %}
-                    {{ datacut_link.name}}
-                  {% endif %}
-                </td>
-                <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
-                  {{ datacut_link.format}}
-                </td>
-                <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
-                  {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
-                </td>
-              </tr>
-              {% endif %}
-            {% endfor %}
-          {% endif %}
+            {% if can_show_link and datacut_link.type != custom_dataset_query_type %}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                {% if has_access %}
+                <a  
+                  href=""
+                  class="govuk-link govuk-link--no-visited-state govuk-body openModalLink"
+                  data-modal-id="{{ datacut_link.id }}"
+                  >
+                  {{ datacut_link.name}}
+                </a>
+                <dialog id="modal{{ datacut_link.id }}">
+                  {% include "datasets/partials/dialog-download-message.html" %}
+                    <div class="govuk-button-group">
+                      <a 
+                        class="govuk-button govuk-button--primary" 
+                        data-module="govuk-button" 
+                        href="{{ datacut_link.get_absolute_url }}"
+                        >
+                          Download data as {{ datacut_link.format }}
+                      </a>
+                      <button 
+                        class="govuk-button govuk-button--secondary closePopUp"  
+                        data-modal-id="{{ datacut_link.id }}"
+                        >
+                          Close
+                        </button>
+                    </div>
+                </dialog>
+                {% else %}
+                  {{ datacut_link.name}}
+                {% endif %}
+              </td>
+              <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                {{ datacut_link.format}} download
+              </td>
+              <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
+                {{ datacut_link.get_data_last_updated_date|date_with_gmt_offset|default_if_none:"N/A" }}
+              </td>
+            </tr>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
         </tbody>
       </table>
     </div>
@@ -243,6 +260,30 @@
     });
   </script>
 
-  
+  <script nonce="{{ request.csp_nonce }}">
+    document.addEventListener("DOMContentLoaded", function () {
+        // Use event delegation for opening modals
+        document.addEventListener("click", function (e) {
+            if (e.target.classList.contains("openModalLink")) {
+                e.stopPropagation();
+                e.preventDefault();
+                const modalId = e.target.getAttribute("data-modal-id");
+                const modal = document.getElementById(`modal${modalId}`);
+                modal.showModal();
+            }
+        });
+
+        // Use event delegation for closing modals
+        document.addEventListener("click", function (e) {
+            if (e.target.classList.contains("closePopUp")) {
+                e.stopPropagation();
+                e.preventDefault();
+                const modalId = e.target.getAttribute("data-modal-id");
+                const modal = document.getElementById(`modal${modalId}`);
+                modal.close();
+            }
+        });
+    });
+  </script>     
   {% render_bundle "data-cut" "js" %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -269,7 +269,7 @@
                 e.preventDefault(); // negate <a> tag href attribute
                 const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
                 const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
-                modal.showModal();
+                modal.showModal(); // show the modal
             }
         });
 
@@ -280,7 +280,7 @@
                 e.preventDefault(); // negate <a> tag href attribute
                 const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
                 const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
-                modal.close();
+                modal.close(); // hide/close the modal
             }
         });
     });

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -134,7 +134,7 @@
               <td class="govuk-table__cell {% if code_snippets %}app-table_cell--no-border{% endif %}">
                 {% if has_access %}
                 <a  
-                  href=""
+                  href="#"
                   class="govuk-link govuk-link--no-visited-state govuk-body openModalLink"
                   data-modal-id="{{ datacut_link.id }}"
                   >

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -135,7 +135,7 @@
                 {% if has_access %}
                 <a  
                   href="#"
-                  class="govuk-link govuk-link--no-visited-state govuk-body openModalLink"
+                  class="govuk-link govuk-link--no-visited-state govuk-body"
                   data-modal-id="{{ datacut_link.id }}"
                   >
                   {{ datacut_link.name}}
@@ -151,7 +151,7 @@
                           Download data as {{ datacut_link.format }}
                       </a>
                       <button 
-                        class="govuk-button govuk-button--secondary closePopUp"  
+                        class="govuk-button govuk-button--secondary"  
                         data-modal-id="{{ datacut_link.id }}"
                         >
                         Close
@@ -260,30 +260,6 @@
     });
   </script>
 
-  <script nonce="{{ request.csp_nonce }}">
-    document.addEventListener("DOMContentLoaded", function () {
-        // use event delegation for opening modals
-        document.addEventListener("click", function (e) {
-            if (e.target.classList.contains("openModalLink")) { // find target element containing class name
-                e.stopPropagation(); 
-                e.preventDefault(); // negate <a> tag href attribute
-                const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
-                const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
-                modal.showModal(); // show the modal
-            }
-        });
-
-        // use event delegation for closing modals
-        document.addEventListener("click", function (e) {
-            if (e.target.classList.contains("closePopUp")) { // find target element containing class name
-                e.stopPropagation();
-                e.preventDefault(); // negate <a> tag href attribute
-                const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
-                const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
-                modal.close(); // hide/close the modal
-            }
-        });
-    });
-  </script>     
+  <script src="{% static 'dialog.js' %}" nonce="{{ request.csp_nonce }}"></script>
   {% render_bundle "data-cut" "js" %}
 {% endblock %}

--- a/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_cut_dataset.html
@@ -154,8 +154,8 @@
                         class="govuk-button govuk-button--secondary closePopUp"  
                         data-modal-id="{{ datacut_link.id }}"
                         >
-                          Close
-                        </button>
+                        Close
+                      </button>
                     </div>
                 </dialog>
                 {% else %}
@@ -262,24 +262,24 @@
 
   <script nonce="{{ request.csp_nonce }}">
     document.addEventListener("DOMContentLoaded", function () {
-        // Use event delegation for opening modals
+        // use event delegation for opening modals
         document.addEventListener("click", function (e) {
-            if (e.target.classList.contains("openModalLink")) {
-                e.stopPropagation();
-                e.preventDefault();
-                const modalId = e.target.getAttribute("data-modal-id");
-                const modal = document.getElementById(`modal${modalId}`);
+            if (e.target.classList.contains("openModalLink")) { // find target element containing class name
+                e.stopPropagation(); 
+                e.preventDefault(); // negate <a> tag href attribute
+                const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
+                const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
                 modal.showModal();
             }
         });
 
-        // Use event delegation for closing modals
+        // use event delegation for closing modals
         document.addEventListener("click", function (e) {
-            if (e.target.classList.contains("closePopUp")) {
+            if (e.target.classList.contains("closePopUp")) { // find target element containing class name
                 e.stopPropagation();
-                e.preventDefault();
-                const modalId = e.target.getAttribute("data-modal-id");
-                const modal = document.getElementById(`modal${modalId}`);
+                e.preventDefault(); // negate <a> tag href attribute
+                const modalId = e.target.getAttribute("data-modal-id"); // datacut link id hand over
+                const modal = document.getElementById(`modal${modalId}`); // get modal by associated datacut link id 
                 modal.close();
             }
         });


### PR DESCRIPTION
### Description of change
The data tables and data links for a datacut have been merged into one list known as "Data", and the corresponding links have been updated to display download modals when clicked.

### Checklist

* [ ] Have tests been added to cover any changes?
