### PR TITLE
Add recent catalogue items endpoint

### DIFF
--- a/dataworkspace/dataworkspace/apps/api_v2/recent_items/urls.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/recent_items/urls.py
@@ -1,0 +1,7 @@
+from rest_framework.routers import DefaultRouter
+
+from dataworkspace.apps.api_v2.recent_items.views import RecentItemsViewSet
+
+router = DefaultRouter()
+router.register(r"recent_items", RecentItemsViewSet)
+urlpatterns = router.urls

--- a/dataworkspace/dataworkspace/apps/api_v2/recent_items/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/recent_items/views.py
@@ -22,4 +22,8 @@ class RecentItemsViewSet(TimestampFilterMixin, viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return super().get_queryset().filter(event_type=EventLog.TYPE_DATASET_VIEW)
+        return (
+            super()
+            .get_queryset()
+            .filter(user=self.request.user, event_type=EventLog.TYPE_DATASET_VIEW)
+        )

--- a/dataworkspace/dataworkspace/apps/api_v2/recent_items/views.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/recent_items/views.py
@@ -1,0 +1,25 @@
+from rest_framework import viewsets
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import IsAuthenticated
+
+from dataworkspace.apps.api_v1.eventlog.serializers import EventLogSerializer
+from dataworkspace.apps.api_v1.mixins import TimestampFilterMixin
+from dataworkspace.apps.eventlog.models import EventLog
+
+
+class TimestampPageNumberPagination(PageNumberPagination):
+    ordering = ("-timestamp", "id")
+    page_size_query_param = "page_size"
+    max_page_size = 10_000
+
+
+class RecentItemsViewSet(TimestampFilterMixin, viewsets.ModelViewSet):
+    queryset = EventLog.objects.all()
+    serializer_class = EventLogSerializer
+    pagination_class = TimestampPageNumberPagination
+    authentication_classes = [SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        return super().get_queryset().filter(event_type=EventLog.TYPE_DATASET_VIEW)

--- a/dataworkspace/dataworkspace/apps/api_v2/urls.py
+++ b/dataworkspace/dataworkspace/apps/api_v2/urls.py
@@ -8,4 +8,10 @@ urlpatterns = [
             ("dataworkspace.apps.api_v2.data_collections.urls", "api_v2"), namespace="collections"
         ),
     ),
+    path(
+        "",
+        include(
+            ("dataworkspace.apps.api_v2.recent_items.urls", "api_v2"), namespace="recent_items"
+        ),
+    ),
 ]

--- a/dataworkspace/dataworkspace/tests/api_v2/recent_items/test_recent_items.py
+++ b/dataworkspace/dataworkspace/tests/api_v2/recent_items/test_recent_items.py
@@ -15,19 +15,27 @@ def test_unauthenticated_recent_items(unauthenticated_client):
 @pytest.mark.django_db
 def test_ordering_and_filtering_recent_items(client, user):
     client.force_login(user)
-    event1 = factories.EventLogFactory(
+    user_event1 = factories.EventLogFactory(
+        user=user,
         event_type=EventLog.TYPE_DATASET_VIEW,
         related_object=factories.ReferenceDatasetFactory.create(),
     )
-    event2 = factories.EventLogFactory(
+    user_event2 = factories.EventLogFactory(
+        user=user,
         event_type=EventLog.TYPE_DATASET_VIEW,
         related_object=factories.ReferenceDatasetFactory.create(),
     )
-    event3 = factories.EventLogFactory(
+    user_event3 = factories.EventLogFactory(
+        user=user,
         event_type=EventLog.TYPE_DATASET_VIEW,
         related_object=factories.ReferenceDatasetFactory.create(),
     )
     factories.EventLogFactory(
+        event_type=EventLog.TYPE_DATASET_VIEW,
+        related_object=factories.ReferenceDatasetFactory.create(),
+    )
+    factories.EventLogFactory(
+        user=user,
         event_type=EventLog.TYPE_DATASET_FIND_FORM_QUERY,
         related_object=factories.ReferenceDatasetFactory.create(),
     )
@@ -35,7 +43,7 @@ def test_ordering_and_filtering_recent_items(client, user):
     response = client.get(reverse("api-v2:recent_items:eventlog-list"))
     recent_items = response.json()
     assert len(recent_items["results"]) == 3
-    assert recent_items["results"][0]["id"] == event3.id
-    assert recent_items["results"][1]["id"] == event2.id
-    assert recent_items["results"][2]["id"] == event1.id
+    assert recent_items["results"][0]["id"] == user_event3.id
+    assert recent_items["results"][1]["id"] == user_event2.id
+    assert recent_items["results"][2]["id"] == user_event1.id
     assert response.status_code == status.HTTP_200_OK

--- a/dataworkspace/dataworkspace/tests/api_v2/recent_items/test_recent_items.py
+++ b/dataworkspace/dataworkspace/tests/api_v2/recent_items/test_recent_items.py
@@ -1,0 +1,41 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from dataworkspace.tests import factories
+from dataworkspace.apps.eventlog.models import EventLog
+
+
+@pytest.mark.django_db
+def test_unauthenticated_recent_items(unauthenticated_client):
+    response = unauthenticated_client.get(reverse("api-v2:recent_items:eventlog-list"))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_ordering_and_filtering_recent_items(client, user):
+    client.force_login(user)
+    event1 = factories.EventLogFactory(
+        event_type=EventLog.TYPE_DATASET_VIEW,
+        related_object=factories.ReferenceDatasetFactory.create(),
+    )
+    event2 = factories.EventLogFactory(
+        event_type=EventLog.TYPE_DATASET_VIEW,
+        related_object=factories.ReferenceDatasetFactory.create(),
+    )
+    event3 = factories.EventLogFactory(
+        event_type=EventLog.TYPE_DATASET_VIEW,
+        related_object=factories.ReferenceDatasetFactory.create(),
+    )
+    factories.EventLogFactory(
+        event_type=EventLog.TYPE_DATASET_FIND_FORM_QUERY,
+        related_object=factories.ReferenceDatasetFactory.create(),
+    )
+
+    response = client.get(reverse("api-v2:recent_items:eventlog-list"))
+    recent_items = response.json()
+    assert len(recent_items["results"]) == 3
+    assert recent_items["results"][0]["id"] == event3.id
+    assert recent_items["results"][1]["id"] == event2.id
+    assert recent_items["results"][2]["id"] == event1.id
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### Description of changes

Ticket [DT-1749](https://uktrade.atlassian.net/browse/DT-1749)

This change adds a new endpoint for the users recently visited datasets.

### Checklist

* [x] Have tests been added to cover any changes?


[DT-1749]: https://uktrade.atlassian.net/browse/DT-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ