### PR TITLE
feat: allow users to list the mirror bucket

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -183,6 +183,16 @@ data "aws_iam_policy_document" "notebook_s3_access_template" {
 
   statement {
     actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.mirrors_data_bucket_name != "" ? var.mirrors_data_bucket_name : var.mirrors_bucket_name}",
+    ]
+  }
+
+  statement {
+    actions = [
       "elasticfilesystem:ClientMount",
       "elasticfilesystem:ClientWrite",
     ]
@@ -277,6 +287,21 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
 
   statement {
     principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.mirrors_data_bucket_name != "" ? var.mirrors_data_bucket_name : var.mirrors_bucket_name}",
+    ]
+  }
+
+  statement {
+    principals {
       type = "AWS"
       identifiers = ["*"]
     }
@@ -319,6 +344,16 @@ data "aws_iam_policy_document" "jupyterhub_notebook_task_boundary" {
 
     resources = [
       "${aws_s3_bucket.notebooks.arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${var.mirrors_data_bucket_name != "" ? var.mirrors_data_bucket_name : var.mirrors_bucket_name}",
     ]
   }
 


### PR DESCRIPTION
### Description of change

This gives users in Data Workspace the ability to list the contents of the mirror bucket so they can see what's been mirrored, .e.g. from Python scripts inside tools.

At the moment however, I suspect for a user to be able to use this, they would have to have the Tools access IAM role arn manually cleared in their user record, which would force their IAM role to be reconstructed with the new permission. I'm not sure of a way to do this in bulk right now.

### Checklist

* [ ] Have tests been added to cover any changes?
