### PR TITLE
Simplify error message where pipelines have failed to update

### DIFF
--- a/dataworkspace/dataworkspace/templates/datasets/details/sourceset_dataset.html
+++ b/dataworkspace/dataworkspace/templates/datasets/details/sourceset_dataset.html
@@ -139,7 +139,7 @@
                 {% endif %}
               {% endif %}
               {% if not pipeline_last_run_succeeded %}
-              <p class="govuk-body-s govuk-error-colour govuk-!-margin-top-2">Update failed: Data is not up to date. The issue is currently in the process of being resolved.</p>
+              <p class="govuk-body-s govuk-error-colour govuk-!-margin-top-2">Update failed: Data is not up to date.</p>
               {% endif %}
             </td>
           </tr>


### PR DESCRIPTION
### Description of change

This simplifies the error message displayed to a user when a pipeline to a database table fails, so that we're no longer implying it is being resolved when this may not necessarily be the case

### Checklist

* [] Have tests been added to cover any changes?
