### PR TITLE
Add contact filter to data catalogue page

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/forms.py
@@ -155,6 +155,7 @@ class DatasetSearchForm(forms.Form):
     SUBSCRIBED = "subscribed"
     BOOKMARKED = "bookmarked"
     OWNED = "owned"
+    CONTACT = "enquiries_contact"
 
     q = forms.CharField(required=False)
 
@@ -183,6 +184,7 @@ class DatasetSearchForm(forms.Form):
             (BOOKMARKED, "My bookmarks"),
             (SUBSCRIBED, "My subscriptions"),
             (OWNED, "Data I own or manage"),
+            (CONTACT, "Data I am a contact for"),
         ],
         required=False,
         widget=AccordionFilterWidget("My datasets"),

--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -142,6 +142,8 @@ def _matches_filters(
         users_datasets.add("subscribed")
     if data["is_owner"]:
         users_datasets.add("owned")
+    if data["is_contact"]:
+        users_datasets.add("enquiries_contact")
 
     return (
         (


### PR DESCRIPTION
### Description of change

This change enables the user to filter datasets that they are a direct contact for.

### Checklist

* [x] Have tests been added to cover any changes?
