### PR TITLE
Remove homepage feature flag

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/views.py
+++ b/dataworkspace/dataworkspace/apps/datasets/views.py
@@ -189,10 +189,7 @@ def _get_tags_as_dict():
 
 @csp_update(SCRIPT_SRC=settings.REACT_SCRIPT_SRC)
 def home_view(request):
-    if not waffle.flag_is_active(request, "HOME_PAGE_FLAG"):
-        return find_datasets(request)
-    else:
-        return render(request, "datasets/index.html")
+    return render(request, "datasets/index.html")
 
 
 @csp_update(SCRIPT_SRC=settings.REACT_SCRIPT_SRC)

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -75,14 +75,12 @@
               Home
             </a>
           </li>
-          {% flag 'HOME_PAGE_FLAG' %}
             {% url 'datasets:find_datasets' as data_catalogue_url %}
             <li class="govuk-header__navigation-item{% if request.path == data_catalogue_url %} govuk-header__navigation-item--active{% endif %}">
               <a class="govuk-header__link" href="{{ data_catalogue_url }}">
                 Data catalogue
               </a>
             </li>
-          {% endflag %}
           {% url 'data_collections:collections-list' as collections_homepage_url %}
           <li class="govuk-header__navigation-item{% if request.get_full_path|startswith:collections_homepage_url %} govuk-header__navigation-item--active{% endif %}">
             <a class="govuk-header__link" href="{{ collections_homepage_url }}">

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -231,6 +231,7 @@ def test_header_links(request_client):
             "&utm_medium=referral&utm_campaign=dataflow&utm_content=Switch%20to%20Data%20Hub",
         ),
         ("Home", "http://dataworkspace.test:8000/"),
+        ("Data catalogue", "/datasets/"),
         ("Collections", "/collections/"),
         ("Tools", "/tools/"),
         (

--- a/test/pages.py
+++ b/test/pages.py
@@ -34,8 +34,8 @@ class _BasePage:
         return await self._page.content()
 
 
-class HomePage(_BasePage):
-    _url_path = "/"
+class DataCataloguePage(_BasePage):
+    _url_path = "/datasets/"
 
     async def toggle_filter(self, label) -> "_BasePage":
         if not self._page:

--- a/test/test_application_1.py
+++ b/test/test_application_1.py
@@ -34,7 +34,7 @@ import aiopg
 import mohawk
 
 from test.pages import (  # pylint: disable=wrong-import-order
-    HomePage,
+    DataCataloguePage,
     get_browser,
 )
 
@@ -643,7 +643,7 @@ class TestApplication(unittest.IsolatedAsyncioTestCase):
 
         browser = await get_browser()
         self.addAsyncCleanup(browser.close)
-        home_page = await HomePage(browser=browser).open()
+        home_page = await DataCataloguePage(browser=browser).open()
 
         with_no_filters = find_search_filter_labels(await home_page.get_html())
 


### PR DESCRIPTION
### Description of change

This change just removes a feature flag that was used to toggle the new homepage. Now post release we don't need this anymore.

### Checklist

* [ ] Have tests been added to cover any changes?
