### PR TITLE
feature/DT-1798-contact-us-journey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ dataworkspace/dataworkspace/static/*.css.map
 test-results/
 cypress/screenshots/
 cypress/videos/
+.vscode/settings.json

--- a/dataworkspace/dataworkspace/apps/core/forms.py
+++ b/dataworkspace/dataworkspace/apps/core/forms.py
@@ -133,8 +133,14 @@ class ContactUsForm(GOVUKDesignSystemForm):
         GIVE_FEEDBACK = "feedback", "Give feedback"
 
     contact_type = GOVUKDesignSystemRadioField(
+        required=False,
         label="What would you like to do?",
         choices=ContactTypes.choices,
         widget=ConditionalSupportTypeRadioWidget(heading="h2"),
-        error_messages={"required": "Please select what you would like to do."},
     )
+    
+    def clean_contact_type(self):
+        contact_type = self.cleaned_data.get("contact_type")
+        if not contact_type:
+            raise forms.ValidationError("Please select what you would like to do.")
+        return contact_type

--- a/dataworkspace/dataworkspace/apps/core/forms.py
+++ b/dataworkspace/dataworkspace/apps/core/forms.py
@@ -125,3 +125,16 @@ class TechnicalSupportForm(GOVUKDesignSystemForm):
             and not cleaned["what_should_have_happened"]
         ):
             raise forms.ValidationError("Please add some detail to the support request")
+
+
+class ContactUsForm(GOVUKDesignSystemForm):
+    class ContactTypes(models.TextChoices):
+        GET_HELP = "help", "Get help"
+        GIVE_FEEDBACK = "feedback", "Give feedback"
+
+    contact_type = GOVUKDesignSystemRadioField(
+        label="What would you like to do?",
+        choices=ContactTypes.choices,
+        widget=ConditionalSupportTypeRadioWidget(heading="h2"),
+        error_messages={"required": "Please select what you would like to do."},
+    )

--- a/dataworkspace/dataworkspace/apps/core/forms.py
+++ b/dataworkspace/dataworkspace/apps/core/forms.py
@@ -142,5 +142,5 @@ class ContactUsForm(GOVUKDesignSystemForm):
     def clean_contact_type(self):
         contact_type = self.cleaned_data.get("contact_type")
         if not contact_type:
-            raise forms.ValidationError("Please select what you would like to do.")
+            raise forms.ValidationError("Select an option for what you would like to do")
         return contact_type

--- a/dataworkspace/dataworkspace/apps/core/forms.py
+++ b/dataworkspace/dataworkspace/apps/core/forms.py
@@ -138,7 +138,7 @@ class ContactUsForm(GOVUKDesignSystemForm):
         choices=ContactTypes.choices,
         widget=ConditionalSupportTypeRadioWidget(heading="h2"),
     )
-    
+
     def clean_contact_type(self):
         contact_type = self.cleaned_data.get("contact_type")
         if not contact_type:

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -412,9 +412,9 @@ class RestoreTableDAGTaskStatusView(View):
 class ContactUsView(FormView):
     form_class = ContactUsForm
     template_name = "core/contact-us.html"
-    
+
     def form_valid(self, form):
         cleaned = form.cleaned_data
         if cleaned["contact_type"] == form.ContactTypes.GET_HELP:
-            return HttpResponseRedirect(reverse("support"))   
+            return HttpResponseRedirect(reverse("support"))
         return HttpResponseRedirect(reverse("feedback"))

--- a/dataworkspace/dataworkspace/apps/core/views.py
+++ b/dataworkspace/dataworkspace/apps/core/views.py
@@ -22,6 +22,7 @@ from requests import HTTPError
 from dataworkspace.apps.applications.models import ApplicationInstance, VisualisationTemplate
 from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.forms import (
+    ContactUsForm,
     NewsletterSubscriptionForm,
     SupportForm,
     TechnicalSupportForm,
@@ -406,3 +407,14 @@ class RestoreTableDAGTaskStatusView(View):
             )
         except HTTPError as e:
             return JsonResponse({}, status=e.response.status_code)
+
+
+class ContactUsView(FormView):
+    form_class = ContactUsForm
+    template_name = "core/contact-us.html"
+    
+    def form_valid(self, form):
+        cleaned = form.cleaned_data
+        if cleaned["contact_type"] == form.ContactTypes.GET_HELP:
+            return HttpResponseRedirect(reverse("support"))   
+        return HttpResponseRedirect(reverse("feedback"))

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -110,7 +110,7 @@
             </a>
           </li>
           <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="{% url 'support' %}">
+            <a class="govuk-header__link" href="{% url 'contact-us' %}">
               Contact us
             </a>
           </li>
@@ -165,7 +165,7 @@
                 </a>
               </li>
             <li class="govuk-footer__list-item">
-              <a class="govuk-footer__link"  href="{% url 'support' %}">
+              <a class="govuk-footer__link"  href="{% url 'contact-us' %}">
                 Contact us
               </a>
             </li>

--- a/dataworkspace/dataworkspace/templates/core/contact-us.html
+++ b/dataworkspace/dataworkspace/templates/core/contact-us.html
@@ -1,0 +1,30 @@
+{% extends '_main.html' %} 
+{% load waffle_tags %} 
+{% block page_title %}Contact
+us - {{ block.super }}
+{% endblock page_title %} 
+{% block breadcrumbs %}
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{% url 'root' %}">Home</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">Contact Us</li>
+    </ol>
+  </div>
+{% endblock %} 
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div id="contact-us"></div>
+      {% include 'design_system/error_summary.html' with form=form %}
+        <form method="post">
+          {% csrf_token %}
+          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+            {{ form.contact_type }}            
+          </div>
+          <button type="submit" class="govuk-button">Continue</button>
+        </form>
+    </div>
+  </div>
+{% endblock %}

--- a/dataworkspace/dataworkspace/templates/core/contact-us.html
+++ b/dataworkspace/dataworkspace/templates/core/contact-us.html
@@ -1,30 +1,27 @@
-{% extends '_main.html' %} 
-{% load waffle_tags %} 
-{% block page_title %}Contact
-us - {{ block.super }}
-{% endblock page_title %} 
-{% block breadcrumbs %}
-  <div class="govuk-breadcrumbs">
-    <ol class="govuk-breadcrumbs__list">
-      <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="{% url 'root' %}">Home</a>
-      </li>
-      <li class="govuk-breadcrumbs__list-item">Contact Us</li>
-    </ol>
+{% extends '_main.html' %} {% load waffle_tags %} {% block page_title %}Contact
+us - {{ block.super }} {% endblock page_title %} {% block breadcrumbs %}
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{% url 'root' %}">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">Contact Us</li>
+  </ol>
+</div>
+{% endblock %} {% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {% include 'design_system/error_summary.html' with form=form %}
+    <form method="post">
+      {% csrf_token %}
+      <div
+        class="govuk-radios govuk-radios--conditional"
+        data-module="govuk-radios"
+      >
+        {{ form.contact_type }}
+      </div>
+      <button type="submit" class="govuk-button">Continue</button>
+    </form>
   </div>
-{% endblock %} 
-{% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div id="contact-us"></div>
-      {% include 'design_system/error_summary.html' with form=form %}
-        <form method="post">
-          {% csrf_token %}
-          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-            {{ form.contact_type }}            
-          </div>
-          <button type="submit" class="govuk-button">Continue</button>
-        </form>
-    </div>
-  </div>
+</div>
 {% endblock %}

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -521,30 +521,24 @@ class TestContactUsViews(BaseTestCase):
         self.assertContains(response, "Give feedback")
 
     def test_missing_contact_type_returns_expected_error(self):
-        response = self._authenticated_post(
-            reverse("contact-us"), {'contact_type': ''}
-        )
+        response = self._authenticated_post(reverse("contact-us"), {"contact_type": ""})
         assert response.status_code == 200
         self.assertContains(response, "Please select what you would like to do.")
 
     def test_invalid_contact_type_returns_expected_error(self):
-        response = self._authenticated_post(
-            reverse("contact-us"), {'contact_type': 'NOT_REAL'}
-        )
+        response = self._authenticated_post(reverse("contact-us"), {"contact_type": "NOT_REAL"})
         assert response.status_code == 200
         print(response.content)
-        self.assertContains(response, "Select a valid choice. NOT_REAL is not one of the available choices.")
+        self.assertContains(
+            response, "Select a valid choice. NOT_REAL is not one of the available choices."
+        )
 
     def test_get_help_redirects_to_support_page(self):
-        response = self._authenticated_post(
-            reverse("contact-us"), {'contact_type': 'help'}
-        )
+        response = self._authenticated_post(reverse("contact-us"), {"contact_type": "help"})
         assert response.status_code == 200
         self.assertRedirects(response, reverse("support"))
 
     def test_get_help_redirects_to_feedback_page(self):
-        response = self._authenticated_post(
-            reverse("contact-us"), {'contact_type': 'feedback'}
-        )
+        response = self._authenticated_post(reverse("contact-us"), {"contact_type": "feedback"})
         assert response.status_code == 200
         self.assertRedirects(response, reverse("feedback"))

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -238,7 +238,7 @@ def test_header_links(request_client):
             "Help centre (opens in a new tab)",
             "https://data-services-help.trade.gov.uk/data-workspace",
         ),
-        ("Contact us", "/support-and-feedback/"),
+        ("Contact us", "/contact-us/"),
     ]
 
     assert link_labels == expected_links
@@ -258,7 +258,7 @@ def test_footer_links(request_client):
         ("Tools", "/tools/"),
         ("About", "/about/"),
         ("Our Work", "/case-studies/"),
-        ("Contact us", "/support-and-feedback/"),
+        ("Contact us", "/contact-us/"),
         (
             "Help centre (opens in a new tab)",
             "https://data-services-help.trade.gov.uk/data-workspace",
@@ -510,3 +510,41 @@ class TestNewsletterViews(BaseTestCase):
         subscription = NewsletterSubscription.objects.filter(user=self.user)
         assert subscription.exists()
         assert not subscription.first().is_active
+
+
+class TestContactUsViews(BaseTestCase):
+    def test_contact_us_page_displays_expected_options(self):
+        response = self._authenticated_get(reverse("contact-us"))
+        # pylint: disable=no-member
+        assert response.status_code == 200
+        self.assertContains(response, "Get help")
+        self.assertContains(response, "Give feedback")
+
+    def test_missing_contact_type_returns_expected_error(self):
+        response = self._authenticated_post(
+            reverse("contact-us"), {'contact_type': ''}
+        )
+        assert response.status_code == 200
+        self.assertContains(response, "Please select what you would like to do.")
+
+    def test_invalid_contact_type_returns_expected_error(self):
+        response = self._authenticated_post(
+            reverse("contact-us"), {'contact_type': 'NOT_REAL'}
+        )
+        assert response.status_code == 200
+        print(response.content)
+        self.assertContains(response, "Select a valid choice. NOT_REAL is not one of the available choices.")
+
+    def test_get_help_redirects_to_support_page(self):
+        response = self._authenticated_post(
+            reverse("contact-us"), {'contact_type': 'help'}
+        )
+        assert response.status_code == 200
+        self.assertRedirects(response, reverse("support"))
+
+    def test_get_help_redirects_to_feedback_page(self):
+        response = self._authenticated_post(
+            reverse("contact-us"), {'contact_type': 'feedback'}
+        )
+        assert response.status_code == 200
+        self.assertRedirects(response, reverse("feedback"))

--- a/dataworkspace/dataworkspace/tests/core/test_views.py
+++ b/dataworkspace/dataworkspace/tests/core/test_views.py
@@ -523,7 +523,7 @@ class TestContactUsViews(BaseTestCase):
     def test_missing_contact_type_returns_expected_error(self):
         response = self._authenticated_post(reverse("contact-us"), {"contact_type": ""})
         assert response.status_code == 200
-        self.assertContains(response, "Please select what you would like to do.")
+        self.assertContains(response, "Select an option for what you would like to do")
 
     def test_invalid_contact_type_returns_expected_error(self):
         response = self._authenticated_post(reverse("contact-us"), {"contact_type": "NOT_REAL"})

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -26,6 +26,7 @@ from dataworkspace.apps.core.views import (
     table_data_view,
     UserSatisfactionSurveyView,
     ServeS3UploadedFileView,
+    ContactUsView,
 )
 from dataworkspace.apps.datasets.views import home_view
 from dataworkspace.apps.appstream.views import (
@@ -124,6 +125,7 @@ urlpatterns = [
         login_required(TechnicalSupportView.as_view()),
         name="technical-support",
     ),
+    path("contact-us", login_required(ContactUsView.as_view()), name="contact-us"),
     path(
         "feedback/",
         login_required(UserSatisfactionSurveyView.as_view()),

--- a/dataworkspace/dataworkspace/urls.py
+++ b/dataworkspace/dataworkspace/urls.py
@@ -125,7 +125,7 @@ urlpatterns = [
         login_required(TechnicalSupportView.as_view()),
         name="technical-support",
     ),
-    path("contact-us", login_required(ContactUsView.as_view()), name="contact-us"),
+    path("contact-us/", login_required(ContactUsView.as_view()), name="contact-us"),
     path(
         "feedback/",
         login_required(UserSatisfactionSurveyView.as_view()),

--- a/test/selenium/test_request_data.py
+++ b/test/selenium/test_request_data.py
@@ -12,6 +12,7 @@ from test.selenium.conftest import (  # pylint: disable=wrong-import-order
     create_zendesk,
 )
 from test.selenium.workspace_pages import (  # pylint: disable=wrong-import-order
+    ContactUsPage,
     HomePage,
     RequestDataOwnerOrManagerPage,
     RequestDataDescriptionPage,
@@ -19,7 +20,6 @@ from test.selenium.workspace_pages import (  # pylint: disable=wrong-import-orde
     RequestDataSecurityClassificationPage,
     RequestDataLocationPage,
     RequestDataCheckAnswersPage,
-    SupportPage,
     RequestDataLicencePage,
 )
 
@@ -71,7 +71,9 @@ class TestRequestData:
         home_page.open()
 
         # Get to the "Request data" starting page
-        support_page = home_page.click_header_link("Contact us", SupportPage)
+        contact_us_page = home_page.click_header_link("Contact us", ContactUsPage)
+
+        support_page = contact_us_page.select_get_help_option()
         request_data_page = support_page.select_new_dataset_option()
 
         who_are_you_page = request_data_page.click_start()

--- a/test/selenium/workspace_pages.py
+++ b/test/selenium/workspace_pages.py
@@ -32,7 +32,7 @@ class SupportPage(_BaseWorkspacePage):
 
 
 class ContactUsPage(_BaseWorkspacePage):
-    _url_path = "/contact_us/"
+    _url_path = "/contact-us/"
 
     def select_get_help_option(self) -> "SupportPage":
         self.select_radio_button("id_contact_type_0")

--- a/test/selenium/workspace_pages.py
+++ b/test/selenium/workspace_pages.py
@@ -31,6 +31,16 @@ class SupportPage(_BaseWorkspacePage):
         return self._check_url_and_return_page(RequestDataPage)
 
 
+class ContactUsPage(_BaseWorkspacePage):
+    _url_path = "/contact_us/"
+
+    def select_get_help_option(self) -> "SupportPage":
+        self.select_radio_button("id_contact_type_0")
+        self._submit("Continue")
+
+        return self._check_url_and_return_page(SupportPage)
+
+
 class RequestDataPage(_BaseWorkspacePage):
     _url_path = "/request-data/"
 


### PR DESCRIPTION
### Description of change

- Add a new contact us page that is accessed via the header and footer Contact Us link.
- The new contact page gives the user the option of getting help or giving feedback


![image](https://github.com/uktrade/data-workspace/assets/102232401/97efa646-a467-46d2-91a3-023ab9493ec2)

### With validation
![image](https://github.com/uktrade/data-workspace/assets/102232401/4cbd0d46-a7d1-4c15-b007-070b1112d6ca)

### Checklist

* [ ] Have tests been added to cover any changes?
