### PR TITLE
bugfix/use-links-in-error-summary-messages

### DIFF
--- a/dataworkspace/dataworkspace/forms.py
+++ b/dataworkspace/dataworkspace/forms.py
@@ -278,7 +278,7 @@ class GOVUKDesignSystemForm(forms.Form):
         Prepare a data structure containing all of the errors in order to render an `error summary` GOV.UK Design
         System component.
         """
-        field_errors = [(field.id_for_label, field.errors[0]) for field in self if field.errors]
+        field_errors = [(field.id_for_label if field.id_for_label else field.auto_id, field.errors[0]) for field in self if field.errors]
         non_field_errors = [(None, e) for e in self.non_field_errors()]
 
         return non_field_errors + field_errors

--- a/dataworkspace/dataworkspace/forms.py
+++ b/dataworkspace/dataworkspace/forms.py
@@ -278,7 +278,11 @@ class GOVUKDesignSystemForm(forms.Form):
         Prepare a data structure containing all of the errors in order to render an `error summary` GOV.UK Design
         System component.
         """
-        field_errors = [(field.id_for_label if field.id_for_label else field.auto_id, field.errors[0]) for field in self if field.errors]
+        field_errors = [
+            (field.id_for_label if field.id_for_label else field.auto_id, field.errors[0])
+            for field in self
+            if field.errors
+        ]
         non_field_errors = [(None, e) for e in self.non_field_errors()]
 
         return non_field_errors + field_errors


### PR DESCRIPTION
### Description of change

Not all fields have an id_for_label, where this is missing use the auto_id property instead so the error summary renders with a link to the component

#### Before
![image](https://github.com/uktrade/data-workspace/assets/102232401/2a72bb5a-cb36-482c-a596-cb79e2d12494)

#### After
![image](https://github.com/uktrade/data-workspace/assets/102232401/5ddb9040-d876-4b45-b33c-64efdee9c02e)

### Checklist

* [ ] Have tests been added to cover any changes?
