### PR TITLE
fix: Catch `None` hostname when calculating metrics for app instance

### DIFF
--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -307,7 +307,13 @@ def application_instance_max_cpu(application_instance):
     if application_instance.proxy_url is None:
         raise ExpectedMetricsException("Unknown")
 
-    instance = urllib.parse.urlsplit(application_instance.proxy_url).hostname + ":8889"
+    hostname = urllib.parse.urlsplit(application_instance.proxy_url).hostname
+
+    # If the tool failed to start we then hostname can be None
+    if hostname is None:
+        raise ExpectedMetricsException("Unknown")
+
+    instance = hostname + ":8889"
     url = f"https://{settings.PROMETHEUS_DOMAIN}/api/v1/query"
     params = {
         "query": f'increase(precpu_stats__cpu_usage__total_usage{{instance="{instance}"}}[30s])[2h:30s]'


### PR DESCRIPTION
### Description of change

If a tool has failed to start, there is a chance the hostname was not set. If you then try to view the details of that tool in the admin you get a 500 error as it expects the hostname to not be None.

Workaround this by raising an "expected" exception


### Checklist

* [ ] Have tests been added to cover any changes?
