### PR TITLE
Remove phase banner and move beta tag to header

### DIFF
--- a/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
+++ b/dataworkspace/dataworkspace/apps/explorer/templates/explorer/base.html
@@ -102,13 +102,6 @@
         {% block main %}
         <div class="govuk-width-container">
             {% block before_content %}
-              {% block phase_banner %}
-                  <div class="govuk-phase-banner">
-                      <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">Beta</strong>
-                          <span class="govuk-phase-banner__text">This is a new service – your&nbsp;<a class="govuk-link" href="{% url 'feedback' %}">feedback</a>&nbsp;will help us to improve it.</span>
-                      </p>
-                  </div>
-              {% endblock %}
               {% block back_button %}{% endblock back_button %}
             {% endblock %}
 

--- a/dataworkspace/dataworkspace/templates/_base.html
+++ b/dataworkspace/dataworkspace/templates/_base.html
@@ -79,6 +79,7 @@
       <div class="govuk-header__logotype">
         <a href="{{ root_href }}"
            class="govuk-header__link govuk-header__link--service-name">Data Workspace</a>
+           <strong class="govuk-tag govuk-phase-banner__content__tag ">Beta</strong>
       </div>
       <div class="app-header--suggestion">
         <div class="govuk-header__navigation-item">
@@ -138,7 +139,6 @@
 
 
   <nav class="govuk-width-container">
-    {% include 'partials/beta_banner.html' %}
     {% block breadcrumbs %}{% endblock %}
     {% block go_back %}{% endblock %}
   </nav>

--- a/dataworkspace/dataworkspace/templates/explorer/_base.html
+++ b/dataworkspace/dataworkspace/templates/explorer/_base.html
@@ -62,15 +62,6 @@
   </header>
 
   <div class="govuk-width-container">
-    <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content">
-        <strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
-        <span class="govuk-phase-banner__text">
-          This is a new service – your <a class="govuk-link" href="{% url 'feedback' %}">feedback</a> will help us to improve it.
-        </span>
-      </p>
-    </div>
-
     {% block breadcrumbs %}{% endblock %}
     {% block go_back %}{% endblock %}
 

--- a/dataworkspace/dataworkspace/templates/partials/beta_banner.html
+++ b/dataworkspace/dataworkspace/templates/partials/beta_banner.html
@@ -1,8 +1,0 @@
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag ">Beta</strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="{% url 'feedback' %}">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>

--- a/dataworkspace/dataworkspace/templates/partials/search_bar.html
+++ b/dataworkspace/dataworkspace/templates/partials/search_bar.html
@@ -14,7 +14,7 @@
     </div>
     {% if gettingStartedLink %}
     <p class="govuk-body search-field__footer-link">
-        <a href="https://data.trade.gov.uk/welcome/" class="search-field__footer__link">Getting started as a new user</a>
+        <a href="/welcome" class="search-field__footer__link">Getting started as a new user</a>
       </p>
     {% endif %}
     {% else %}

--- a/dataworkspace/dataworkspace/tests/explorer/test_views.py
+++ b/dataworkspace/dataworkspace/tests/explorer/test_views.py
@@ -11,7 +11,6 @@ from django.core.cache import cache
 from django.db import connections
 from django.contrib.auth import get_user_model
 from django.forms.models import model_to_dict
-from lxml import html
 import pytest
 
 from dataworkspace.apps.core.utils import USER_SCHEMA_STEM, stable_identification_suffix
@@ -240,12 +239,6 @@ class TestHomePage:
     def test_empty_playground_renders(self, staff_client):
         resp = staff_client.get(reverse("explorer:index"))
         assert resp.status_code == 200
-
-    def test_support_and_feedback_link(self, staff_client):
-        resp = staff_client.get(reverse("explorer:index"))
-
-        doc = html.fromstring(resp.content.decode(resp.charset))
-        assert doc.xpath('//a[normalize-space(text()) = "feedback"]/@href')[0] == "/feedback/"
 
     def test_playground_renders_with_query_sql(self, staff_user, staff_client):
         query = SimpleQueryFactory(sql="select 1;", created_by_user=staff_user)


### PR DESCRIPTION
### Description of change
The phase banner has been removed and the Beta tag has moved to the header next to Data Workspace.

Also contains a tiny fix for a link in the search bar which was linking to the live site instead of local.

### Screenshots
![Screenshot 2024-01-25 at 14 54 40](https://github.com/uktrade/data-workspace/assets/54268863/b3263c3e-0e5c-46d3-b14f-e21f12a8da7b)

### Checklist

* [ ] Have tests been added to cover any changes?
