### PR TITLE
Exempt healthcheck page from maintenance_mode

### DIFF
--- a/dataworkspace/dataworkspace/apps/maintenance/test_maintenance.py
+++ b/dataworkspace/dataworkspace/apps/maintenance/test_maintenance.py
@@ -67,3 +67,14 @@ class TestMaintenanceWithoutSetup(TestCase):
         )
         updated_maintenance_settings = get_maintenance_settings()
         self.assertHTMLEqual(updated_maintenance_settings.maintenance_text, "Test text")
+
+
+@pytest.mark.django_db
+class TestMaintenanceBaseSettings(TestCase):
+    def test_healthcheck_page_returns_ok_when_maintenance_mode_is_on(self):
+        MaintenanceSettings.objects.create(
+            maintenance_text="Test text", maintenance_toggle=True, contact_email="test@gov.uk"
+        )
+        response = self.client.get("/healthcheck")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"OK")

--- a/dataworkspace/dataworkspace/settings/base.py
+++ b/dataworkspace/dataworkspace/settings/base.py
@@ -834,6 +834,7 @@ MLFLOW_PORT = env.get("MLFLOW_PORT", "")
 DYNAMIC_PIPELINES = ("DataWorkspaceS3ImportPipeline", "DSSGenericPipeline")
 
 MAINTENANCE_MODE = None
+MAINTENANCE_MODE_IGNORE_URLS = (r"^/healthcheck$",)
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_GET_CONTEXT = "dataworkspace.apps.maintenance.maintenance.maintenance_context"
 MAINTENANCE_MODE_STATE_BACKEND = "maintenance_mode.backends.CacheBackend"


### PR DESCRIPTION
### Description of change
This PR makes  the `/healthcheck` page exempt from returning a 503 when maintenance mode is on. This was causing issues in deployments where maintenance mode was on prior to deploying/reploying

### Checklist

* [ ] Have tests been added to cover any changes?
