### PR TITLE
bugfix/DT-1820-e2e-test-results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   docker-test-unit-js:
@@ -99,19 +99,11 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run:
-          name: Copy sample config
-          command: cp .envs/sample.env .envs/dev.env
-      - run:
-          name: Build docker containers
-          command: |
-            make docker-e2e-build
-      - run:
-          name: Run the e2e tests
-          command: |
-            make docker-e2e-run
-      - store_artifacts:
-          path: cypress/screenshots
+      - run_e2e:
+          build_cmd_name: docker-e2e-build
+          run_cmd_name: docker-e2e-run
+      - store_cypress_artifacts:
+          docker_project_name: e2e
 
   docker-test-a11y:
     machine:
@@ -120,19 +112,50 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - run_e2e:
+          build_cmd_name: docker-a11y-build
+          run_cmd_name: docker-a11y-run
+      - store_cypress_artifacts:
+          docker_project_name: a11y
+
+commands:
+  run_e2e:
+    description: Run the E2E tests
+    parameters:
+      build_cmd_name:
+        type: string
+      run_cmd_name:
+        type: string
+    steps:
       - run:
           name: Copy sample config
           command: cp .envs/sample.env .envs/dev.env
       - run:
           name: Build docker containers
           command: |
-            make docker-a11y-build
+            make << parameters.build_cmd_name >>
       - run:
-          name: Run the a11y tests
+          name: Run the tests
           command: |
-            make docker-a11y-run
+            make << parameters.run_cmd_name >>
+  store_cypress_artifacts:
+    description: Upload the cypress screenshots and test results
+    parameters:
+      docker_project_name:
+        type: string        
+    steps:
+      - run:
+          name: Copy cypress outputs from container
+          when: always
+          command: | 
+            docker cp << parameters.docker_project_name >>-data-workspace-e2e-test-1:/app/test-results test-results
       - store_artifacts:
-          path: cypress/screenshots
+          path: test-results/screenshots
+      - store_artifacts:
+          path: test-results/videos
+      - store_test_results:
+          path: test-results/test-results.xml
+
 
 workflows:
   version: 2

--- a/cypress.a11y.config.ts
+++ b/cypress.a11y.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
     supportFile: "cypress/support/a11y.ts",
     baseUrl: "http://dataworkspace.test:8000",
     screenshotsFolder: "test-results/screenshots",
-    videosFolder: "test-results/screenshots",
+    video:true,
+    videosFolder: "test-results/videos",
     viewportWidth: 1200,
     viewportHeight: 900,
     setupNodeEvents(on, config) {

--- a/cypress.a11y.config.ts
+++ b/cypress.a11y.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     specPattern: "cypress/a11y/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "cypress/support/a11y.ts",
     baseUrl: "http://dataworkspace.test:8000",
+    screenshotsFolder: "test-results/screenshots",
+    videosFolder: "test-results/screenshots",
     viewportWidth: 1200,
     viewportHeight: 900,
     setupNodeEvents(on, config) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   e2e: {
     baseUrl: "http://dataworkspace.test:8000",
+    screenshotsFolder: "test-results/screenshots",
+    videosFolder: "test-results/screenshots",
     viewportWidth: 1200,
     viewportHeight: 900,
     setupNodeEvents(on, config) {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   e2e: {
     baseUrl: "http://dataworkspace.test:8000",
     screenshotsFolder: "test-results/screenshots",
-    videosFolder: "test-results/screenshots",
+    video:true,
+    videosFolder: "test-results/videos",
     viewportWidth: 1200,
     viewportHeight: 900,
     setupNodeEvents(on, config) {

--- a/cypress/Dockerfile
+++ b/cypress/Dockerfile
@@ -15,6 +15,7 @@ WORKDIR app
 
 COPY ./cypress cypress
 COPY ./cypress/package.json .
+COPY ./cypress/cypress-reporter-config.json .
 
 RUN npm install
 

--- a/cypress/cypress-reporter-config.json
+++ b/cypress/cypress-reporter-config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "./test-results/test-results.xml"
+  }
+}

--- a/cypress/e2e/datasets/source-dataset.cy.ts
+++ b/cypress/e2e/datasets/source-dataset.cy.ts
@@ -6,6 +6,6 @@ describe("Source dataset catalogue page", () => {
   });
 
   it("should have a title", () => {
-    cy.contains("h1", "Data cut - links");
+    cy.contains("h1", "Data cut - links - FORCE FAIL");
   });
 });

--- a/cypress/e2e/datasets/source-dataset.cy.ts
+++ b/cypress/e2e/datasets/source-dataset.cy.ts
@@ -6,6 +6,6 @@ describe("Source dataset catalogue page", () => {
   });
 
   it("should have a title", () => {
-    cy.contains("h1", "Data cut - links - FORCE FAIL");
+    cy.contains("h1", "Data cut - links");
   });
 });

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -8,6 +8,8 @@
     "cypress": "13.6.3",
     "cypress-axe": "^1.5.0",
     "cypress-e2e-testing": "file:cypress",
+    "cypress-multi-reporters": "^1.6.4",
+    "mocha-junit-reporter": "^2.2.1",
     "typescript": "^5.2.2"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,7 +206,7 @@ services:
     environment:
       - CYPRESS_baseUrl=http://dataworkspace.test:8000
     entrypoint: dockerize -wait tcp://data-workspace:8000 -timeout 3m -wait-retry-interval 5s
-    command: cypress run
+    command: cypress run --reporter cypress-multi-reporters --reporter-options configFile=cypress-reporter-config.json
     
 
 volumes:

--- a/package.json
+++ b/package.json
@@ -36,10 +36,12 @@
     "cypress": "13.6.3",
     "cypress-axe": "^1.5.0",
     "cypress-e2e-testing": "file:cypress",
+    "cypress-multi-reporters": "^1.6.4",
     "govuk-frontend": "3.14",
     "husky": "^8.0.0",
     "jest": "^29.7.0",
     "js-base64": "^3.7.5",
+    "mocha-junit-reporter": "^2.2.1",
     "node-sass": "^8.0.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"


### PR DESCRIPTION
### Description of change
- Save the cypress test results into a file
- Due to the tests running inside docker, once the tests have finished the cypress files need to be copied back to the host circle machine to be uploaded
- Move the common e2e and a11y logic into a custom circle command

### Checklist

* [ ] Have tests been added to cover any changes?
