### PR TITLE
feature/DT-1805-setup-cypress-testing-library

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   e2e: {
     baseUrl: "http://dataworkspace.test:8000",
     screenshotsFolder: "test-results/screenshots",
-    video:true,
+    video: true,
     videosFolder: "test-results/videos",
     viewportWidth: 1200,
     viewportHeight: 900,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,2 +1,3 @@
 /// <reference types="cypress" />
 import "@testing-library/cypress/add-commands";
+import "./setup-cypress-testing-library";

--- a/cypress/support/setup-cypress-testing-library.ts
+++ b/cypress/support/setup-cypress-testing-library.ts
@@ -1,0 +1,5 @@
+import { configure } from "@testing-library/dom";
+
+configure({
+  testIdAttribute: "data-test",
+});


### PR DESCRIPTION
### Description of change
Add some config setup for the cypress testing library, that sets the data test attribute to look for `data-test`. This matches the datahub syntax.

### Checklist

* [ ] Have tests been added to cover any changes?
