### PR TITLE
Fix/DT-1790 Persist search term to the data catalogue page

### DIFF
--- a/cypress/e2e/homepage/dashboard.cy.ts
+++ b/cypress/e2e/homepage/dashboard.cy.ts
@@ -11,18 +11,6 @@ describe("Homepage dashboard", () => {
       cy.visit("/");
     });
 
-    it("should show a search bar with a link to getting started", () => {
-      cy.findByTestId("search-form")
-        .first()
-        .findByRole("heading", {
-          level: 1,
-          name: "Search Data Workspace",
-        })
-        .parent()
-        .findByRole("link", { name: "Getting started as a new user" })
-        .should("have.attr", "href", "/welcome");
-    });
-
     it("should show a support title", () => {
       cy.findByRole("heading", {
         level: 2,

--- a/cypress/e2e/homepage/search.cy.ts
+++ b/cypress/e2e/homepage/search.cy.ts
@@ -1,0 +1,80 @@
+import { datacutWithLinks } from "../../fixtures/datasets";
+export const endpoints = {
+  recentItems: "/api/v2/recent_items/*",
+  recentCollections: "/api/v2/collections/*",
+  recentTools: "/api/v2/recent_tools/*",
+  yourBookmarks: "/api/v2/your_bookmarks/*",
+} as const;
+
+const assertEndPointIsNotCalled = (pathnameToAssert: string): void => {
+  cy.get("@GET.all").then((XHRRequests) => {
+    XHRRequests.map(({ request: { url } }) => {
+      const { pathname } = new URL(url);
+      expect(pathname).not.equal(pathnameToAssert);
+    });
+  });
+};
+
+describe("Homepage search", () => {
+  beforeEach(() => {
+    cy.intercept({ method: "GET", path: "*" }).as("GET");
+    cy.intercept(endpoints.recentItems, { results: [] });
+    cy.intercept(endpoints.recentCollections, { results: [] });
+    cy.intercept(endpoints.recentTools, { results: [] });
+    cy.intercept(endpoints.yourBookmarks, { results: [] });
+    cy.intercept("/find_suggested_searches?query=data", [
+      {
+        name: "Data cut - links",
+        type: "",
+        url: "",
+      },
+    ]);
+    cy.visit("/");
+    cy.findByTestId("search-input").find("input").as("searchInputField");
+    cy.findByTestId("search-input").next("input").as("searchButton");
+  });
+
+  it("should show a search bar with a link to getting started", () => {
+    cy.findByRole("heading", {
+      level: 1,
+      name: "Search Data Workspace",
+    })
+      .parent()
+      .findByRole("link", { name: "Getting started as a new user" })
+      .should("have.attr", "href", "/welcome");
+  });
+
+  context("when a user visits the first time", () => {
+    it("should NOT show search suggestions on page load", () => {
+      cy.findByRole("heading", { level: 3, name: "Suggested searches" }).should(
+        "not.exist"
+      );
+    });
+
+    it("should NOT call the suggested search endpoint when a query param is present", () => {
+      cy.visit("/?q=data");
+      assertEndPointIsNotCalled("/datasets/find_suggested_searches");
+    });
+  });
+
+  context("when a user searches for a dataset", () => {
+    it("should persist the search query to the data catalogue page and NOT show suggested searches", () => {
+      cy.get("@searchInputField").type("Data cut - links");
+      cy.get("@searchButton").click();
+      cy.get("@searchInputField").should("have.value", "Data cut - links");
+      cy.findByRole("heading", { level: 3, name: "Suggested searches" }).should(
+        "not.exist"
+      );
+    });
+  });
+  context("when a user revisits the homepage after viewing a dataset", () => {
+    it("should show suggested searches when typing", () => {
+      cy.visit(`/datasets/${datacutWithLinks}`);
+      cy.visit("/");
+      cy.get("@searchInputField").type("Data");
+      cy.findByRole("heading", { level: 3, name: "Suggested searches" }).should(
+        "exist"
+      );
+    });
+  });
+});

--- a/dataworkspace/dataworkspace/static/search-v2.js
+++ b/dataworkspace/dataworkspace/static/search-v2.js
@@ -2548,6 +2548,17 @@ function accessibleAutocompleteOptions(
 ) {
   var container = document.getElementById("my-autocomplete-container");
 
+  const runAutoCompleteOnceOnLoad = (fn) => {
+    let domLoaded = false;
+    return (query, callback) => {
+      if (!domLoaded && query) {
+        domLoaded = true;
+        return;
+      }
+      fn(query, callback);
+    };
+  };
+
   function handleSearchQuery(query, callback) {
     var suggestedSearchesName = [];
     var dataName = [];
@@ -2646,7 +2657,7 @@ function accessibleAutocompleteOptions(
     placeholder: "Search by dataset name or description",
     showAllValues: true,
     showNoOptionsFound: false,
-    source: handleSearchQuery.bind(container),
+    source: runAutoCompleteOnceOnLoad(handleSearchQuery).bind(container),
     onConfirm: onConfirm,
     templates: {
       inputValue: inputValueTemplate,
@@ -2655,5 +2666,8 @@ function accessibleAutocompleteOptions(
   });
 
   var inputElement = document.getElementById("app-site-search__input");
+  const urlParams = new URLSearchParams(window.location.search);
+  const query = urlParams.get("q");
+  inputElement.value = query;
   inputElement.type = "search";
 }

--- a/dataworkspace/dataworkspace/templates/datasets/data_catalogue.html
+++ b/dataworkspace/dataworkspace/templates/datasets/data_catalogue.html
@@ -36,7 +36,7 @@
 
 {% block content %}
   {% csrf_token %}
-  <form id="live-search-form" action="{% url 'datasets:find_datasets' %}" method="get">
+  <form id="live-search-form" action="{% url 'datasets:find_datasets' %}" method="get" data-test="search-form">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="search-field govuk-!-margin-bottom-2">

--- a/dataworkspace/dataworkspace/templates/partials/search_bar.html
+++ b/dataworkspace/dataworkspace/templates/partials/search_bar.html
@@ -1,28 +1,47 @@
 {% load waffle_tags %}
 <h1 class="search-field__header govuk-heading-l">Search Data Workspace</h1>
 {% if subTitle %}
-<p class="govuk-body-l">
-    {{subTitle}}
-</p>
+<p class="govuk-body-l">{{subTitle}}</p>
 {% endif %}
 <div class="search-field">
-    {% flag ACCESSIBLE_AUTOCOMPLETE_FLAG %}
-    <div class="app-site-search" data-module="app-search">
-      <label class="govuk-visually-hidden" for="app-site-search__input">Search by dataset name or description</label>
-      <div class="search-field-wrapper" id="my-autocomplete-container"></div>
-      <input class="search-field__submit" type="submit" value="Search">
+  {% flag ACCESSIBLE_AUTOCOMPLETE_FLAG %}
+  <div class="app-site-search" data-module="app-search">
+    <label class="govuk-visually-hidden" for="app-site-search__input"
+      >Search by dataset name or description</label
+    >
+    <div
+      class="search-field-wrapper"
+      id="my-autocomplete-container"
+      data-test="search-input"
+    ></div>
+    <input
+      class="search-field__submit"
+      type="submit"
+      value="Search"
+      data-test="search-submit"
+    />
+  </div>
+  {% if gettingStartedLink %}
+  <p class="govuk-body search-field__footer-link">
+    <a href="/welcome" class="search-field__footer__link"
+      >Getting started as a new user</a
+    >
+  </p>
+  {% endif %} {% else %}
+  <div class="search-field-wrapper govuk-!-padding-bottom-6">
+    <input
+      type="text"
+      name="q"
+      id="search"
+      title="Search"
+      class="govuk-input search-field__item search-field__input js-class-toggle"
+      value="{{ query }}"
+      aria-controls="search-summary-accessible-hint-wrapper"
+      placeholder="Search by dataset name or description"
+    />
+    <div class="search-field-submit-wrapper search-field__item">
+      <input class="search-field__submit" type="submit" value="Search" />
     </div>
-    {% if gettingStartedLink %}
-    <p class="govuk-body search-field__footer-link">
-        <a href="/welcome" class="search-field__footer__link">Getting started as a new user</a>
-      </p>
-    {% endif %}
-    {% else %}
-    <div class="search-field-wrapper govuk-!-padding-bottom-6">
-      <input type="text" name="q" id="search" title="Search" class="govuk-input search-field__item search-field__input js-class-toggle" value="{{ query }}" aria-controls="search-summary-accessible-hint-wrapper" placeholder="Search by dataset name or description">
-      <div class="search-field-submit-wrapper search-field__item">
-        <input class="search-field__submit" type="submit" value="Search">
-      </div>
-    </div>
-    {% endflag %}
+  </div>
+  {% endflag %}
 </div>

--- a/dataworkspace/start-e2e.sh
+++ b/dataworkspace/start-e2e.sh
@@ -30,6 +30,7 @@ set -e
 
     django-admin waffle_flag HOME_PAGE_FLAG --everyone --create
     django-admin waffle_flag ACCESSIBLE_AUTOCOMPLETE_FLAG --everyone --create
+    django-admin waffle_flag SUGGESTED_SEARCHES_FLAG --everyone --create
 
     # nginx is configured to log to stdout/stderr, _except_ before
     # it manages to read its config file. To avoid errors on startup,


### PR DESCRIPTION
### Description of change

This change persists the search query to the data catalogue page. UX behaviour:

1. User is on the homepage
2. User searches the term "Data"  
3. User gets directed to the "data catalogue" page showing results based on the search term "data"
4. User can see the term "data" is pre-populated in the search bar input field

### Checklist

* [ ] Have tests been added to cover any changes?
