### PR TITLE
refactor: move from template_file to templatefile

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -153,7 +153,10 @@ resource "aws_service_discovery_service" "admin" {
 
 resource "aws_ecs_task_definition" "admin" {
   family                   = "${var.prefix}-admin"
-  container_definitions    = "${data.template_file.admin_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_main_admin_container_definitions.json",
+    merge(local.admin_container_vars, tomap({"container_command" = "[\"/dataworkspace/start.sh\"]"}))
+  )
   execution_role_arn       = "${aws_iam_role.admin_task_execution.arn}"
   task_role_arn            = "${aws_iam_role.admin_task.arn}"
   network_mode             = "awsvpc"
@@ -166,12 +169,6 @@ resource "aws_ecs_task_definition" "admin" {
       "revision",
     ]
   }
-}
-
-data "template_file" "admin_container_definitions" {
-  template = "${file("${path.module}/ecs_main_admin_container_definitions.json")}"
-
-  vars = "${merge(local.admin_container_vars, tomap({"container_command" = "[\"/dataworkspace/start.sh\"]"}))}"
 }
 
 data "external" "admin_current_tag" {

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -202,7 +202,10 @@ resource "aws_ecs_service" "admin_celery" {
 
 resource "aws_ecs_task_definition" "admin_celery" {
   family                   = "${var.prefix}-admin-celery"
-  container_definitions    = "${data.template_file.admin_celery_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_main_admin_container_definitions.json",
+    merge(local.admin_container_vars, tomap({"container_command" = "[\"/dataworkspace/start-celery.sh\"]"}))
+  )
   execution_role_arn       = "${aws_iam_role.admin_task_execution.arn}"
   task_role_arn            = "${aws_iam_role.admin_task.arn}"
   network_mode             = "awsvpc"
@@ -215,12 +218,6 @@ resource "aws_ecs_task_definition" "admin_celery" {
       "revision",
     ]
   }
-}
-
-data "template_file" "admin_celery_container_definitions" {
-  template = "${file("${path.module}/ecs_main_admin_container_definitions.json")}"
-
-  vars = "${merge(local.admin_container_vars, tomap({"container_command" = "[\"/dataworkspace/start-celery.sh\"]"}))}"
 }
 
 resource "random_string" "admin_secret_key" {

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -74,7 +74,24 @@ data "external" "dns_rewrite_proxy_current_tag" {
 
 resource "aws_ecs_task_definition" "dns_rewrite_proxy" {
   family                = "${var.prefix}-dns-rewrite-proxy"
-  container_definitions = "${data.template_file.dns_rewrite_proxy_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.dns_rewrite_proxy.repository_url}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
+      container_name     = "${local.dns_rewrite_proxy_container_name}"
+      container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
+      container_memory   = "${local.dns_rewrite_proxy_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.dns_rewrite_proxy.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      dns_server   = "${cidrhost(aws_vpc.main.cidr_block, 2)}"
+      aws_region   = "${data.aws_region.aws_region.name}"
+      aws_ec2_host = "ec2.${data.aws_region.aws_region.name}.amazonaws.com"
+      vpc_id       = "${aws_vpc.notebooks.id}"
+      aws_route53_zone = "${var.aws_route53_zone}"
+      ip_address   = "${aws_lb.dns_rewrite_proxy.subnet_mapping.*.private_ipv4_address[0]}"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.dns_rewrite_proxy_task_execution.arn}"
   task_role_arn         = "${aws_iam_role.dns_rewrite_proxy_task.arn}"
   network_mode          = "awsvpc"
@@ -86,27 +103,6 @@ resource "aws_ecs_task_definition" "dns_rewrite_proxy" {
     ignore_changes = [
       "revision",
     ]
-  }
-}
-
-data "template_file" "dns_rewrite_proxy_container_definitions" {
-  template = "${file("${path.module}/ecs_main_dns_rewrite_proxy_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.dns_rewrite_proxy.repository_url}:${data.external.dns_rewrite_proxy_current_tag.result.tag}"
-    container_name     = "${local.dns_rewrite_proxy_container_name}"
-    container_cpu      = "${local.dns_rewrite_proxy_container_cpu}"
-    container_memory   = "${local.dns_rewrite_proxy_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.dns_rewrite_proxy.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    dns_server   = "${cidrhost(aws_vpc.main.cidr_block, 2)}"
-    aws_region   = "${data.aws_region.aws_region.name}"
-    aws_ec2_host = "ec2.${data.aws_region.aws_region.name}.amazonaws.com"
-    vpc_id       = "${aws_vpc.notebooks.id}"
-    aws_route53_zone = "${var.aws_route53_zone}"
-    ip_address   = "${aws_lb.dns_rewrite_proxy.subnet_mapping.*.private_ipv4_address[0]}"
   }
 }
 

--- a/infra/ecs_main_healthcheck.tf
+++ b/infra/ecs_main_healthcheck.tf
@@ -58,7 +58,21 @@ resource "aws_service_discovery_service" "healthcheck" {
 
 resource "aws_ecs_task_definition" "healthcheck" {
   family                   = "${var.prefix}-healthcheck"
-  container_definitions    = "${data.template_file.healthcheck_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_main_healthcheck_container_definitions.json", {
+      container_image   = "${aws_ecr_repository.healthcheck.repository_url}:${data.external.healthcheck_current_tag.result.tag}"
+      container_name    = "${local.healthcheck_container_name}"
+      container_port    = "${local.healthcheck_container_port}"
+      container_cpu     = "${local.healthcheck_container_cpu}"
+      container_memory  = "${local.healthcheck_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.healthcheck.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      port = "${local.healthcheck_container_port}"
+      url = "https://${var.admin_domain}/healthcheck"
+    }
+  )
   execution_role_arn       = "${aws_iam_role.healthcheck_task_execution.arn}"
   task_role_arn            = "${aws_iam_role.healthcheck_task.arn}"
   network_mode             = "awsvpc"
@@ -70,24 +84,6 @@ resource "aws_ecs_task_definition" "healthcheck" {
     ignore_changes = [
       "revision",
     ]
-  }
-}
-
-data "template_file" "healthcheck_container_definitions" {
-  template = "${file("${path.module}/ecs_main_healthcheck_container_definitions.json")}"
-
-  vars = {
-    container_image   = "${aws_ecr_repository.healthcheck.repository_url}:${data.external.healthcheck_current_tag.result.tag}"
-    container_name    = "${local.healthcheck_container_name}"
-    container_port    = "${local.healthcheck_container_port}"
-    container_cpu     = "${local.healthcheck_container_cpu}"
-    container_memory  = "${local.healthcheck_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.healthcheck.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    port = "${local.healthcheck_container_port}"
-    url = "https://${var.admin_domain}/healthcheck"
   }
 }
 

--- a/infra/ecs_main_mirrors_sync.tf
+++ b/infra/ecs_main_mirrors_sync.tf
@@ -1,46 +1,63 @@
 resource "aws_ecs_task_definition" "mirrors_sync_conda" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-conda"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_conda.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_container_name}"
+      container_cpu      = "${local.mirrors_sync_container_cpu}"
+      container_memory   = "${local.mirrors_sync_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_region = "${data.aws_region.aws_region.name}"
+      mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+
+      mirror_anaconda_r = "True"
+      mirror_anaconda_conda_forge = "True"
+      mirror_anaconda_conda_anaconda = "True"
+      mirror_cran = "False"
+      mirror_pypi = "False"
+      mirror_debian = "False"
+      mirror_nltk = "False"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
   requires_compatibilities = ["FARGATE"]
-}
-
-data "template_file" "mirrors_sync_container_definitions_conda" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_container_name}"
-    container_cpu      = "${local.mirrors_sync_container_cpu}"
-    container_memory   = "${local.mirrors_sync_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_region = "${data.aws_region.aws_region.name}"
-    mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-
-    mirror_anaconda_r = "True"
-    mirror_anaconda_conda_forge = "True"
-    mirror_anaconda_conda_anaconda = "True"
-    mirror_cran = "False"
-    mirror_pypi = "False"
-    mirror_debian = "False"
-    mirror_nltk = "False"
-  }
 }
 
 resource "aws_ecs_task_definition" "mirrors_sync_cran" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-cran"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_container_name}"
+      container_cpu      = "${local.mirrors_sync_container_cpu}"
+      container_memory   = "${local.mirrors_sync_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_region = "${data.aws_region.aws_region.name}"
+      mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+
+      mirror_anaconda_r = "False"
+      mirror_anaconda_conda_forge = "False"
+      mirror_anaconda_conda_anaconda = "False"
+      mirror_cran = "True"
+      mirror_pypi = "False"
+      mirror_debian = "False"
+      mirror_nltk = "False"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
@@ -49,37 +66,22 @@ resource "aws_ecs_task_definition" "mirrors_sync_cran" {
   requires_compatibilities = ["FARGATE"]
 }
 
-data "template_file" "mirrors_sync_container_definitions_cran" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_container_name}"
-    container_cpu      = "${local.mirrors_sync_container_cpu}"
-    container_memory   = "${local.mirrors_sync_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_region = "${data.aws_region.aws_region.name}"
-    mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-
-    mirror_anaconda_r = "False"
-    mirror_anaconda_conda_forge = "False"
-    mirror_anaconda_conda_anaconda = "False"
-    mirror_cran = "True"
-    mirror_pypi = "False"
-    mirror_debian = "False"
-    mirror_nltk = "False"
-  }
-}
-
 resource "aws_ecs_task_definition" "mirrors_sync_cran_binary" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-cran-binary"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran_binary.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_cran_binary_container_definition.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync_cran_binary.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_cran_binary_container_name}"
+      container_cpu      = "${local.mirrors_sync_cran_binary_container_cpu}"
+      container_memory   = "${local.mirrors_sync_cran_binary_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
@@ -91,164 +93,127 @@ resource "aws_ecs_task_definition" "mirrors_sync_cran_binary" {
 resource "aws_ecs_task_definition" "mirrors_sync_cran_binary_rv4" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-cran-binary-rv4"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_cran_binary_rv4.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_cran_binary_container_definition.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync_cran_binary_rv4.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_cran_binary_container_name}"
+      container_cpu      = "${local.mirrors_sync_cran_binary_container_cpu}"
+      container_memory   = "${local.mirrors_sync_cran_binary_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
   requires_compatibilities = ["FARGATE"]
-}
-
-data "template_file" "mirrors_sync_container_definitions_cran_binary" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_cran_binary_container_definition.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync_cran_binary.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_cran_binary_container_name}"
-    container_cpu      = "${local.mirrors_sync_cran_binary_container_cpu}"
-    container_memory   = "${local.mirrors_sync_cran_binary_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-  }
-}
-
-data "template_file" "mirrors_sync_container_definitions_cran_binary_rv4" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_cran_binary_container_definition.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync_cran_binary_rv4.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_cran_binary_container_name}"
-    container_cpu      = "${local.mirrors_sync_cran_binary_container_cpu}"
-    container_memory   = "${local.mirrors_sync_cran_binary_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-  }
 }
 
 resource "aws_ecs_task_definition" "mirrors_sync_pypi" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-pypi"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_pypi.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_container_name}"
+      container_cpu      = "${local.mirrors_sync_container_cpu}"
+      container_memory   = "${local.mirrors_sync_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_region = "${data.aws_region.aws_region.name}"
+      mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+
+      mirror_anaconda_r = "False"
+      mirror_anaconda_conda_forge = "False"
+      mirror_anaconda_conda_anaconda = "False"
+      mirror_cran = "False"
+      mirror_pypi = "True"
+      mirror_debian = "False"
+      mirror_nltk = "False"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
   requires_compatibilities = ["FARGATE"]
-}
-
-data "template_file" "mirrors_sync_container_definitions_pypi" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_container_name}"
-    container_cpu      = "${local.mirrors_sync_container_cpu}"
-    container_memory   = "${local.mirrors_sync_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_region = "${data.aws_region.aws_region.name}"
-    mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-
-    mirror_anaconda_r = "False"
-    mirror_anaconda_conda_forge = "False"
-    mirror_anaconda_conda_anaconda = "False"
-    mirror_cran = "False"
-    mirror_pypi = "True"
-    mirror_debian = "False"
-    mirror_nltk = "False"
-  }
 }
 
 resource "aws_ecs_task_definition" "mirrors_sync_debian" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-debian"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_debian.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_container_name}"
+      container_cpu      = "${local.mirrors_sync_container_cpu}"
+      container_memory   = "${local.mirrors_sync_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_region = "${data.aws_region.aws_region.name}"
+      mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+
+      mirror_anaconda_r = "False"
+      mirror_anaconda_conda_forge = "False"
+      mirror_anaconda_conda_anaconda = "False"
+      mirror_cran = "False"
+      mirror_pypi = "False"
+      mirror_debian = "True"
+      mirror_nltk = "False"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
   requires_compatibilities = ["FARGATE"]
-}
-
-data "template_file" "mirrors_sync_container_definitions_debian" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_container_name}"
-    container_cpu      = "${local.mirrors_sync_container_cpu}"
-    container_memory   = "${local.mirrors_sync_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_region = "${data.aws_region.aws_region.name}"
-    mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-
-    mirror_anaconda_r = "False"
-    mirror_anaconda_conda_forge = "False"
-    mirror_anaconda_conda_anaconda = "False"
-    mirror_cran = "False"
-    mirror_pypi = "False"
-    mirror_debian = "True"
-    mirror_nltk = "False"
-  }
 }
 
 resource "aws_ecs_task_definition" "mirrors_sync_nltk" {
   count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
   family                = "jupyterhub-mirrors-sync-nltk"
-  container_definitions = "${data.template_file.mirrors_sync_container_definitions_nltk.*.rendered[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_mirrors_sync_container_definitions.json", {
+      container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
+      container_name     = "${local.mirrors_sync_container_name}"
+      container_cpu      = "${local.mirrors_sync_container_cpu}"
+      container_memory   = "${local.mirrors_sync_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      mirrors_bucket_region = "${data.aws_region.aws_region.name}"
+      mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
+      mirrors_bucket_name = "${var.mirrors_bucket_name}"
+
+      mirror_anaconda_r = "False"
+      mirror_anaconda_conda_forge = "False"
+      mirror_anaconda_conda_anaconda = "False"
+      mirror_cran = "False"
+      mirror_pypi = "False"
+      mirror_debian = "False"
+      mirror_nltk = "True"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.mirrors_sync_task_execution.*.arn[count.index]}"
   task_role_arn         = "${aws_iam_role.mirrors_sync_task.*.arn[count.index]}"
   network_mode          = "awsvpc"
   cpu                   = "${local.mirrors_sync_container_cpu}"
   memory                = "${local.mirrors_sync_container_memory}"
   requires_compatibilities = ["FARGATE"]
-}
-
-data "template_file" "mirrors_sync_container_definitions_nltk" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
-  template = "${file("${path.module}/ecs_main_mirrors_sync_container_definitions.json")}"
-
-  vars = {
-    container_image    = "${aws_ecr_repository.mirrors_sync.repository_url}:latest"
-    container_name     = "${local.mirrors_sync_container_name}"
-    container_cpu      = "${local.mirrors_sync_container_cpu}"
-    container_memory   = "${local.mirrors_sync_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    mirrors_bucket_region = "${data.aws_region.aws_region.name}"
-    mirrors_bucket_host = "s3-${data.aws_region.aws_region.name}.amazonaws.com"
-    mirrors_bucket_name = "${var.mirrors_bucket_name}"
-
-    mirror_anaconda_r = "False"
-    mirror_anaconda_conda_forge = "False"
-    mirror_anaconda_conda_anaconda = "False"
-    mirror_cran = "False"
-    mirror_pypi = "False"
-    mirror_debian = "False"
-    mirror_nltk = "True"
-  }
 }
 
 resource "aws_cloudwatch_log_group" "mirrors_sync" {

--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -1,6 +1,22 @@
 resource "aws_ecs_task_definition" "jupyterlabpython" {
   family                = "${var.prefix}-jupyterlabpython"
-  container_definitions = "${data.template_file.jupyterlabpython_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.jupyterlab_python.repository_url}:${data.external.jupyterlabpython_current_tag.result.tag}"
+      container_name   = "${local.notebook_container_name}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_notebooks_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.jupyterlabpython_s3sync_current_tag.result.tag}"
+
+      home_directory = "/home/jovyan"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   # task_role_arn         = "${aws_iam_role.notebook_task.arn}"
   network_mode          = "awsvpc"
@@ -47,25 +63,5 @@ data "external" "jupyterlabpython_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-jupyterlabpython"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "jupyterlabpython_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.jupyterlab_python.repository_url}:${data.external.jupyterlabpython_current_tag.result.tag}"
-    container_name   = "${local.notebook_container_name}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_notebooks_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.jupyterlabpython_s3sync_current_tag.result.tag}"
-
-    home_directory = "/home/jovyan"
   }
 }

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -1,6 +1,22 @@
 resource "aws_ecs_task_definition" "remotedesktop" {
   family                = "${var.prefix}-remotedesktop"
-  container_definitions = "${data.template_file.remotedesktop_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.remotedesktop.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
+      container_name   = "${local.notebook_container_name}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_notebooks_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
+
+      home_directory = "/home/dw"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   network_mode          = "awsvpc"
   cpu                   = "${local.notebook_container_cpu}"
@@ -46,25 +62,5 @@ data "external" "remotedesktop_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-remotedesktop"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "remotedesktop_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.remotedesktop.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
-    container_name   = "${local.notebook_container_name}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_notebooks_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
-
-    home_directory = "/home/dw"
   }
 }

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -1,6 +1,22 @@
 resource "aws_ecs_task_definition" "superset" {
   family                = "${var.prefix}-superset"
-  container_definitions = "${data.template_file.superset_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${var.superset_container_image}:master"
+      container_name   = "${local.notebook_container_name}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_notebooks_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
+
+      home_directory = "/home/superset"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   network_mode          = "awsvpc"
   cpu                   = "${local.notebook_container_cpu}"
@@ -42,25 +58,5 @@ data "external" "superset_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-superset"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "superset_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${var.superset_container_image}:master"
-    container_name   = "${local.notebook_container_name}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_notebooks_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
-
-    home_directory = "/home/superset"
   }
 }

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -1,6 +1,22 @@
 resource "aws_ecs_task_definition" "theia" {
   family                = "${var.prefix}-theia"
-  container_definitions = "${data.template_file.theia_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.theia.repository_url}:master"
+      container_name   = "${local.notebook_container_name}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_notebooks_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
+
+      home_directory = "/home/theia"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   network_mode          = "awsvpc"
   cpu                   = "${local.notebook_container_cpu}"
@@ -46,25 +62,5 @@ data "external" "theia_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-theia"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "theia_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.theia.repository_url}:master"
-    container_name   = "${local.notebook_container_name}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_notebooks_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
-
-    home_directory = "/home/theia"
   }
 }

--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -1,6 +1,24 @@
 resource "aws_ecs_task_definition" "pgadmin" {
   family                = "${var.prefix}-pgadmin"
-  container_definitions = "${data.template_file.pgadmin_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.pgadmin.repository_url}:${data.external.pgadmin_current_tag.result.tag}"
+      container_name   = "${local.notebook_container_name}"
+      container_cpu    = "${local.notebook_container_cpu}"
+      container_memory = "${local.notebook_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.pgadmin_metrics_current_tag.result.tag}"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
+
+      home_directory = "/home/pgadmin"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   # task_role_arn         = "${aws_iam_role.notebook_task.arn}"
   network_mode          = "awsvpc"
@@ -47,27 +65,5 @@ data "external" "pgadmin_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-pgadmin"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "pgadmin_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.pgadmin.repository_url}:${data.external.pgadmin_current_tag.result.tag}"
-    container_name   = "${local.notebook_container_name}"
-    container_cpu    = "${local.notebook_container_cpu}"
-    container_memory = "${local.notebook_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.pgadmin_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
-
-    home_directory = "/home/pgadmin"
   }
 }

--- a/infra/ecs_rstudio.tf
+++ b/infra/ecs_rstudio.tf
@@ -1,6 +1,24 @@
 resource "aws_ecs_task_definition" "rstudio" {
   family                = "${var.prefix}-rstudio"
-  container_definitions = "${data.template_file.rstudio_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.rstudio.repository_url}:${data.external.rstudio_current_tag.result.tag}"
+      container_name   = "${local.notebook_container_name}"
+      container_cpu    = "${local.notebook_container_cpu}"
+      container_memory = "${local.notebook_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.rstudio_metrics_current_tag.result.tag}"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.rstudio_s3sync_current_tag.result.tag}"
+
+      home_directory = "/home/rstudio"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   # task_role_arn         = "${aws_iam_role.notebook_task.arn}"
   network_mode          = "awsvpc"
@@ -47,27 +65,5 @@ data "external" "rstudio_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-rstudio"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "rstudio_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.rstudio.repository_url}:${data.external.rstudio_current_tag.result.tag}"
-    container_name   = "${local.notebook_container_name}"
-    container_cpu    = "${local.notebook_container_cpu}"
-    container_memory = "${local.notebook_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.rstudio_metrics_current_tag.result.tag}"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:${data.external.rstudio_s3sync_current_tag.result.tag}"
-
-    home_directory = "/home/rstudio"
   }
 }

--- a/infra/ecs_rstudio_rv4.tf
+++ b/infra/ecs_rstudio_rv4.tf
@@ -1,6 +1,24 @@
 resource "aws_ecs_task_definition" "rstudio_rv4" {
   family                = "${var.prefix}-rstudio-rv4"
-  container_definitions = "${data.template_file.rstudio_rv4_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_notebooks_notebook_container_definitions.json", {
+      container_image  = "${aws_ecr_repository.rstudio_rv4.repository_url}:master"
+      container_name   = "${local.notebook_container_name}"
+      container_cpu    = "${local.notebook_container_cpu}"
+      container_memory = "${local.notebook_container_memory}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+      s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
+
+      home_directory = "/home/rstudio"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   network_mode          = "awsvpc"
   cpu                   = "${local.notebook_container_cpu}"
@@ -46,27 +64,5 @@ data "external" "rstudio_rv4_s3sync_current_tag" {
   query = {
     task_family = "${var.prefix}-rstudio-rv4"
     container_name = "s3sync"
-  }
-}
-
-data "template_file" "rstudio_rv4_container_definitions" {
-  template = "${file("${path.module}/ecs_notebooks_notebook_container_definitions.json")}"
-
-  vars = {
-    container_image  = "${aws_ecr_repository.rstudio_rv4.repository_url}:master"
-    container_name   = "${local.notebook_container_name}"
-    container_cpu    = "${local.notebook_container_cpu}"
-    container_memory = "${local.notebook_container_memory}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_dsn}"
-    sentry_environment = "${var.sentry_environment}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
-    s3sync_container_image = "${aws_ecr_repository.s3sync.repository_url}:master"
-
-    home_directory = "/home/rstudio"
   }
 }

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -1,6 +1,20 @@
 resource "aws_ecs_task_definition" "user_provided" {
   family                = "${var.prefix}-user-provided"
-  container_definitions = "${data.template_file.user_provided_container_definitions.rendered}"
+  container_definitions    = templatefile(
+    "${path.module}/ecs_user_provided_container_definitions.json", {
+      container_name   = "${local.user_provided_container_name}"
+      container_cpu    = "${local.user_provided_container_cpu}"
+      container_memory = "${local.user_provided_container_memory}"
+      container_image  = "${aws_ecr_repository.user_provided.repository_url}"
+
+      log_group  = "${aws_cloudwatch_log_group.notebook.name}"
+      log_region = "${data.aws_region.aws_region.name}"
+
+      sentry_dsn = "${var.sentry_notebooks_dsn}"
+
+      metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
+    }
+  )
   execution_role_arn    = "${aws_iam_role.notebook_task_execution.arn}"
   network_mode          = "awsvpc"
   cpu                   = "${local.user_provided_container_cpu}"
@@ -21,24 +35,6 @@ data "external" "user_provided_metrics_current_tag" {
   query = {
     task_family = "${var.prefix}-user-provided"
     container_name = "metrics"
-  }
-}
-
-data "template_file" "user_provided_container_definitions" {
-  template = "${file("${path.module}/ecs_user_provided_container_definitions.json")}"
-
-  vars = {
-    container_name   = "${local.user_provided_container_name}"
-    container_cpu    = "${local.user_provided_container_cpu}"
-    container_memory = "${local.user_provided_container_memory}"
-    container_image  = "${aws_ecr_repository.user_provided.repository_url}"
-
-    log_group  = "${aws_cloudwatch_log_group.notebook.name}"
-    log_region = "${data.aws_region.aws_region.name}"
-
-    sentry_dsn = "${var.sentry_notebooks_dsn}"
-
-    metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
   }
 }
 


### PR DESCRIPTION
### Description of change

This changes the use of the deprecated template_file provider to the now built in templatefile function in terraform.

This is done because the template_file provider as no current version for the arm processor (e.g. modern macs), and so it should make it easier to apply the terraform.

### Checklist

* [ ] Have tests been added to cover any changes?
