### PR TITLE
refactor: move to Terraform AWS Provider 5.35.0

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -11,7 +11,7 @@ locals {
 
     root_domain               = "${var.admin_domain}"
     admin_db__host            = "${aws_db_instance.admin.address}"
-    admin_db__name            = "${aws_db_instance.admin.name}"
+    admin_db__name            = "${aws_db_instance.admin.db_name}"
     admin_db__password        = "${random_string.aws_db_instance_admin_password.result}"
     admin_db__port            = "${aws_db_instance.admin.port}"
     admin_db__user            = "${aws_db_instance.admin.username}"

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -517,11 +517,11 @@ resource "aws_autoscaling_group" "gitlab_runner" {
   launch_configuration      = "${aws_launch_configuration.gitlab_runner.name}"
   vpc_zone_identifier       = "${aws_subnet.private_without_egress.*.id}"
 
-  tags = [{
+  tag {
     key                 = "Name"
     value               = "${var.prefix}-gitlab-runner-asg"
     propagate_at_launch = true
-  }]
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -598,11 +598,11 @@ resource "aws_autoscaling_group" "gitlab_runner_tap" {
   launch_configuration      = "${aws_launch_configuration.gitlab_runner_tap.name}"
   vpc_zone_identifier       = "${aws_subnet.private_without_egress.*.id}"
 
-  tags = [{
+  tag {
     key                 = "Name"
     value               = "${var.prefix}-gitlab-runner-tap-asg"
     propagate_at_launch = true
-  }]
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -12,7 +12,7 @@ resource "aws_db_instance" "admin" {
   backup_retention_period = 31
   backup_window = "03:29-03:59"
 
-  name = "jupyterhub_admin"
+  db_name = "jupyterhub_admin"
   username = "jupyterhub_admin_master"
   password = "${random_string.aws_db_instance_admin_password.result}"
 


### PR DESCRIPTION
### Description of change

This includes the changes required to move the Terraform AWS provider to 5.35.0. This is done because we're trying to make it easier to apply, and don't want to waste time solving rough edges that will have to be changed anyway when we eventually upgrade.

Note that when applying the terraform you will probably have to run `terraform init -upgrade` to allow selection of the new version.

### Checklist

* [ ] Have tests been added to cover any changes?
