### PR TITLE
Validate visualisation catalogue item description to at least 30 words

### DIFF
--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -2772,6 +2772,10 @@ class VisualisationCatalogueItem(DeletableTimestampedUserModel):
     def __str__(self):
         return self.name
 
+    def clean(self):
+        if len(re.findall(r"\w+", self.description)) < 30:
+            raise ValidationError("Description must contain 30 or more words")
+
 
 class AdminVisualisationUserPermission(models.Model):
     user = models.ForeignKey(get_user_model(), on_delete=models.CASCADE)

--- a/dataworkspace/dataworkspace/apps/datasets/models.py
+++ b/dataworkspace/dataworkspace/apps/datasets/models.py
@@ -2773,7 +2773,7 @@ class VisualisationCatalogueItem(DeletableTimestampedUserModel):
         return self.name
 
     def clean(self):
-        if len(re.findall(r"\w+", self.description)) < 30:
+        if self.description and len(re.findall(r"\w+", self.description)) < 30:
             raise ValidationError("Description must contain 30 or more words")
 
 

--- a/dataworkspace/dataworkspace/tests/test_admin.py
+++ b/dataworkspace/dataworkspace/tests/test_admin.py
@@ -3807,3 +3807,20 @@ class TestDatasetAdminPytest:
 
         assert response.status_code == 200
         assert SourceTable.objects.count() == num_tables + 1
+
+
+class TestVisualisationCatalogueItemAdmin(BaseAdminTestCase):
+    def test_update_visualisation_with_description_not_long_enough(self):
+        dataset = factories.VisualisationCatalogueItemFactory.create()
+        response = self._authenticated_post(
+            reverse("admin:datasets_visualisationcatalogueitem_change", args=(dataset.id,)),
+            {
+                "published": dataset.published,
+                "name": dataset.name,
+                "slug": dataset.slug,
+                "short_description": "test short description",
+                "description": "not long enough description",
+                "type": 2,
+            },
+        )
+        self.assertContains(response, "Description must contain 30 or more words")


### PR DESCRIPTION
### Description of change
Custom visualisation description has a minimum word limit of 30.

### Checklist

* [x] Have tests been added to cover any changes?
