### PR TITLE
bugfix/DT-1770-fix-file-uploader

### DIFF
--- a/dataworkspace/dataworkspace/apps/core/utils.py
+++ b/dataworkspace/dataworkspace/apps/core/utils.py
@@ -1672,3 +1672,7 @@ def clear_table_permissions_cache_for_user(user):
         db_role,
     )
     cache.delete(table_permissions_cache_key(db_role))
+
+
+def get_postgres_datatype_choices():
+    return ((name, name.capitalize()) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items())

--- a/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
@@ -3,6 +3,7 @@ from django import forms
 
 from dataworkspace.apps.core.constants import SCHEMA_POSTGRES_DATA_TYPE_MAP
 from dataworkspace.apps.core.storage import malware_file_validator
+from dataworkspace.apps.core.utils import get_postgres_datatype_choices
 from dataworkspace.forms import (
     GOVUKDesignSystemChoiceField,
     GOVUKDesignSystemFileField,
@@ -49,10 +50,7 @@ class SourceTableUploadColumnConfigForm(GOVUKDesignSystemForm):
             self.fields[col_def["column_name"]] = GOVUKDesignSystemChoiceField(
                 label=col_def["column_name"],
                 initial=col_def["data_type"],
-                choices=(
-                    (value, name.capitalize())
-                    for name, value in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()
-                ),
+                choices=get_postgres_datatype_choices(),
                 widget=GOVUKDesignSystemSelectWidget(
                     label_is_heading=False,
                     extra_label_classes="govuk-visually-hidden",

--- a/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
+++ b/dataworkspace/dataworkspace/apps/datasets/manager/forms.py
@@ -1,7 +1,6 @@
 from django.core.validators import FileExtensionValidator
 from django import forms
 
-from dataworkspace.apps.core.constants import SCHEMA_POSTGRES_DATA_TYPE_MAP
 from dataworkspace.apps.core.storage import malware_file_validator
 from dataworkspace.apps.core.utils import get_postgres_datatype_choices
 from dataworkspace.forms import (

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -6,7 +6,11 @@ from django.core.validators import RegexValidator, MaxLengthValidator
 
 from dataworkspace.apps.core.boto3_client import get_s3_client
 from dataworkspace.apps.core.constants import SCHEMA_POSTGRES_DATA_TYPE_MAP
-from dataworkspace.apps.core.utils import get_all_schemas, get_user_s3_prefixes
+from dataworkspace.apps.core.utils import (
+    get_all_schemas,
+    get_postgres_datatype_choices,
+    get_user_s3_prefixes,
+)
 from dataworkspace.forms import (
     GOVUKDesignSystemCharField,
     GOVUKDesignSystemForm,
@@ -122,9 +126,7 @@ class CreateTableDataTypesForm(CreateTableForm):
             self.fields[col_def["column_name"]] = GOVUKDesignSystemChoiceField(
                 label=col_def["column_name"],
                 initial=col_def["data_type"],
-                choices=(
-                    (name, name.capitalize()) for name, _ in SCHEMA_POSTGRES_DATA_TYPE_MAP.items()
-                ),
+                choices=get_postgres_datatype_choices(),
                 widget=GOVUKDesignSystemSelectWidget(
                     label_is_heading=False,
                     extra_label_classes="govuk-visually-hidden",

--- a/dataworkspace/dataworkspace/apps/your_files/forms.py
+++ b/dataworkspace/dataworkspace/apps/your_files/forms.py
@@ -5,7 +5,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator, MaxLengthValidator
 
 from dataworkspace.apps.core.boto3_client import get_s3_client
-from dataworkspace.apps.core.constants import SCHEMA_POSTGRES_DATA_TYPE_MAP
 from dataworkspace.apps.core.utils import (
     get_all_schemas,
     get_postgres_datatype_choices,

--- a/dataworkspace/dataworkspace/tests/core/test_storage.py
+++ b/dataworkspace/dataworkspace/tests/core/test_storage.py
@@ -54,6 +54,8 @@ def test_file_save_throws_exception_when_virus_found(
 
 @override_settings(LOCAL=True)
 @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
-def test_malware_file_validator_not_called_on_local(mock_upload_to_clamav,):
+def test_malware_file_validator_not_called_on_local(
+    mock_upload_to_clamav,
+):
     malware_file_validator("")
     assert not mock_upload_to_clamav.called

--- a/dataworkspace/dataworkspace/tests/core/test_storage.py
+++ b/dataworkspace/dataworkspace/tests/core/test_storage.py
@@ -54,8 +54,6 @@ def test_file_save_throws_exception_when_virus_found(
 
 @override_settings(LOCAL=True)
 @mock.patch("dataworkspace.apps.core.storage._upload_to_clamav")
-def test_malware_file_validator_not_called_on_local(
-    mock_upload_to_clamav,
-):
+def test_malware_file_validator_not_called_on_local(mock_upload_to_clamav,):
     malware_file_validator("")
     assert not mock_upload_to_clamav.called


### PR DESCRIPTION
### Description of change
Fix the issue where the column select component was using the `SCHEMA_POSTGRES_DATA_TYPE_MAP` value, instead of the key. This caused an issue on the form POST where the values wouldn't match, and so were defaulting to Text data types

### Checklist

* [ ] Have tests been added to cover any changes?
