### PR TITLE
feat: only apply cloudwatch subscription filter if configured to do so

### DIFF
--- a/infra/ecs_main_mirrors_sync.tf
+++ b/infra/ecs_main_mirrors_sync.tf
@@ -223,7 +223,7 @@ resource "aws_cloudwatch_log_group" "mirrors_sync" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "mirrors_sync" {
-  count = "${var.mirrors_bucket_name != "" ? 1 : 0}"
+  count = "${var.mirrors_bucket_name != "" && var.cloudwatch_subscription_filter ? 1 : 0}"
   name            = "jupyterhub-mirrors-sync"
   log_group_name  = "${aws_cloudwatch_log_group.mirrors_sync.*.name[count.index]}"
   filter_pattern  = ""


### PR DESCRIPTION
### Description of change

This only creates a aws_cloudwatch_log_subscription_filter on the mirrors sync job if configured to do so. This is consistent with the other cases of aws_cloudwatch_log_subscription_filter

(Note we might not even be using the mirror sync job any more? But leaving investigating that to another time)


### Checklist

* [ ] Have tests been added to cover any changes?
