### PR TITLE
refactor: use way of configuring upload bucket logging that works with new buckets

### DIFF
--- a/infra/s3_uploads.tf
+++ b/infra/s3_uploads.tf
@@ -13,11 +13,12 @@ resource "aws_s3_bucket" "uploads" {
     enabled    = true
     mfa_delete = false
   }
+}
 
-  logging {
-    target_bucket = "${aws_s3_bucket.logging.id}"
-  }
-
+resource "aws_s3_bucket_logging" "uploads_logging" {
+  bucket = aws_s3_bucket.uploads.id
+  target_bucket = aws_s3_bucket.logging.id
+  target_prefix = "logs/"
 }
 
 resource "aws_s3_bucket_policy" "uploads" {
@@ -50,7 +51,6 @@ data "aws_iam_policy_document" "uploads_bucket" {
 
 resource "aws_s3_bucket" "logging" {
   bucket = "${var.uploads_bucket}-logging"
-  acl    = "log-delivery-write"
 
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
### Description of change

The ACL way previously used no longer works with the security settings of new buckets


### Checklist

* [ ] Have tests been added to cover any changes?
