### PR TITLE
fix: bootstrappable image tags for task definitions

### DIFF
--- a/infra/container-tag.sh
+++ b/infra/container-tag.sh
@@ -14,4 +14,4 @@ CONTAINER_NAME=`echo $QUERY | jq --raw-output '.container_name'`
 TASK_DEFINITION=`aws ecs describe-services --cluster $CLUSTER_NAME --services $SERVICE_NAME --region eu-west-2 | jq --raw-output .services[0].taskDefinition` 
 IMAGE=`aws ecs describe-task-definition --task-definition $TASK_DEFINITION --region eu-west-2 | jq --raw-output '.taskDefinition.containerDefinitions[] | select(.name=="'${CONTAINER_NAME}'").image'`
 TAG=`echo $IMAGE | sed -E 's/(.*):(.*)/\2/'`
-echo "{\"tag\":\"${TAG}\"}"
+echo "{\"tag\":\"${TAG:=latest}\"}"


### PR DESCRIPTION
### Description of change

Starting up a new Data Workspace environment results in task definitions refering to Docker containers with a tag, so ending in just ":", which is not valid.

Not sure on the best default, but "latest" is probably reasonable, because that usually (always?) exists once there is an image in the ECR repository.

### Checklist

* [ ] Have tests been added to cover any changes?
