### PR TITLE
feat: allow toggling of superset as a service

### DIFF
--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -129,14 +129,15 @@ resource "aws_route53_record" "gitlab" {
 }
 
 resource "aws_route53_record" "superset_internal" {
+  count   = var.superset_on ? 1 : 0
   provider = "aws.route53"
   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
   name    = "${var.superset_internal_domain}"
   type    = "A"
 
   alias {
-    name                   = "${aws_lb.superset.dns_name}"
-    zone_id                = "${aws_lb.superset.zone_id}"
+    name                   = "${aws_lb.superset[count.index].dns_name}"
+    zone_id                = "${aws_lb.superset[count.index].zone_id}"
     evaluate_target_health = false
   }
 
@@ -174,7 +175,8 @@ resource "aws_route53_record" "mlflow_data_flow" {
 }
 
 resource "aws_acm_certificate" "superset_internal" {
-  domain_name       = "${aws_route53_record.superset_internal.name}"
+  count             = var.superset_on ? 1 : 0
+  domain_name       = "${aws_route53_record.superset_internal[count.index].name}"
   validation_method = "DNS"
 
   lifecycle {
@@ -183,7 +185,8 @@ resource "aws_acm_certificate" "superset_internal" {
 }
 
 resource "aws_acm_certificate_validation" "superset_internal" {
-  certificate_arn = "${aws_acm_certificate.superset_internal.arn}"
+  count           = var.superset_on ? 1 : 0
+  certificate_arn = "${aws_acm_certificate.superset_internal[count.index].arn}"
 }
 
 # resource "aws_route53_record" "jupyterhub" {


### PR DESCRIPTION
### Description of change

This PR makes use of the new `superset_on` terraform variable to allow us to enable/disable the running onf superset on an environment

### Checklist

* [ ] Have tests been added to cover any changes?
