### PR TITLE
feat: make rds datasets db engine configurable

### DIFF
--- a/infra/environment-template/main.tf
+++ b/infra/environment-template/main.tf
@@ -131,6 +131,7 @@ module "jupyterhub" {
   superset_admin_users       = "REPLACE_ME"
   superset_db_instance_class = "db.t3.medium"
 
+  datasets_rds_cluster_database_engine                       = "aurora-postgresql"
   datasets_rds_cluster_backup_retention_period               = 10
   datasets_rds_cluster_database_name                         = "REPLACE_ME"
   datasets_rds_cluster_master_username                       = "REPLACE_ME"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -135,6 +135,7 @@ variable superset_internal_domain {}
 variable superset_dw_user_username {}
 variable superset_dw_user_password {}
 
+variable datasets_rds_cluster_database_engine {}
 variable datasets_rds_cluster_backup_retention_period {}
 variable datasets_rds_cluster_database_name {}
 variable datasets_rds_cluster_master_username {}

--- a/infra/rds_datasets.tf
+++ b/infra/rds_datasets.tf
@@ -4,7 +4,7 @@ resource "aws_rds_cluster" "datasets" {
   cluster_identifier            = "${var.datasets_rds_cluster_cluster_identifier}"
   database_name                 = "${var.datasets_rds_cluster_database_name}"
   db_subnet_group_name          = "${aws_db_subnet_group.datasets.name}"
-  engine                        = "aurora-postgresql"
+  engine                        = var.datasets_rds_cluster_database_engine
   master_password               = "${random_string.aws_rds_cluster_instance_datasets_password.result}"
   master_username               = "${var.datasets_rds_cluster_master_username}"
   storage_encrypted             = "${var.datasets_rds_cluster_storage_encryption_enabled}"
@@ -22,7 +22,7 @@ resource "aws_rds_cluster" "datasets" {
 resource "aws_rds_cluster_instance" "datasets" {
   cluster_identifier            = "${aws_rds_cluster.datasets.cluster_identifier}"
   db_subnet_group_name          = "${aws_db_subnet_group.datasets.name}"
-  engine                        = "aurora-postgresql"
+  engine                        = var.datasets_rds_cluster_database_engine
   identifier                    = "${var.datasets_rds_cluster_instance_identifier}"
   instance_class                = "${var.datasets_rds_cluster_instance_class}"
   performance_insights_enabled  = "${var.datasets_rds_cluster_instance_performance_insights_enabled}"


### PR DESCRIPTION
### Description of change

Adds datasets db engine as a variable in the infrastructure.

This is a needed step in allowing for non-aurora datasets dbs

### Checklist

* [ ] Have tests been added to cover any changes?
