### PR TITLE
Adding the ability to customise the number of admin instances.

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -106,7 +106,7 @@ resource "aws_ecs_service" "admin" {
   name                       = "${var.prefix}-admin"
   cluster                    = "${aws_ecs_cluster.main_cluster.id}"
   task_definition            = "${aws_ecs_task_definition.admin.arn}"
-  desired_count              = 2
+  desired_count              = var.admin_instances
   launch_type                = "FARGATE"
   platform_version           = "1.4.0"
   deployment_maximum_percent = 600

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -47,6 +47,10 @@ variable admin_authbroker_client_id {}
 variable admin_authbroker_client_secret {}
 variable admin_authbroker_url {}
 variable admin_environment {}
+variable admin_instances {
+  type = number
+  default = 2
+}
 variable admin_deregistration_delay {
   type = number
   default = 300


### PR DESCRIPTION
This is because there was high cpu usages for users, therefore we added more instances to mitigate this.

It should be safe as each instance will use no more than 37 data base connections and even during a deployment, we will never have more than 10 instances including celery so we will never use more that 370 data base connections, which is less than the 403 which the data base supports.

### Description of change


### Checklist

* [ ] Have tests been added to cover any changes?
