### PR TITLE
feature/DT-1291-redirect-users-to-catalogue-page

### DIFF
--- a/.envs/test-e2e.env
+++ b/.envs/test-e2e.env
@@ -21,13 +21,6 @@ NOTEBOOKS_URL=something
 
 AWS_DEFAULT_REGION=eu-west-2
 
-# Optional AWS local endpoints for local dev
-# These should point to your localstack instance
-# S3_LOCAL_ENDPOINT_URL=http://data-infrastructure-localstack:4566
-# STS_LOCAL_ENDPOINT_URL=http://data-infrastructure-localstack:4566
-
-
-
 APPLICATION_ROOT_DOMAIN=dataworkspace.test:8000
 APPLICATION_TEMPLATES__1__NICE_NAME=Jupyter lab process
 APPLICATION_TEMPLATES__1__HOST_BASENAME=jupyterlabprocess

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -679,7 +679,7 @@ def get_quicksight_dashboard_name_url(dashboard_id, user):
         aws_access_key_id=role_credentials["AccessKeyId"],
         aws_secret_access_key=role_credentials["SecretAccessKey"],
         aws_session_token=role_credentials["SessionToken"],
-    )   
+    )
 
     # QuickSight manages users in a separate region to our data/dashboards.
     qs_user_client = session.client("quicksight", region_name=user_region)

--- a/dataworkspace/dataworkspace/apps/applications/utils.py
+++ b/dataworkspace/dataworkspace/apps/applications/utils.py
@@ -679,12 +679,10 @@ def get_quicksight_dashboard_name_url(dashboard_id, user):
         aws_access_key_id=role_credentials["AccessKeyId"],
         aws_secret_access_key=role_credentials["SecretAccessKey"],
         aws_session_token=role_credentials["SessionToken"],
-    )
-    
-    print('****get_available_services', session.get_available_services())
+    )   
 
     # QuickSight manages users in a separate region to our data/dashboards.
-    qs_user_client = session.client("quicksight", region_name=user_region, endpoint_url=settings.STS_LOCAL_ENDPOINT_URL)
+    qs_user_client = session.client("quicksight", region_name=user_region)
     qs_dashboard_client = session.client("quicksight")
 
     try:

--- a/dataworkspace/dataworkspace/apps/applications/views.py
+++ b/dataworkspace/dataworkspace/apps/applications/views.py
@@ -328,7 +328,7 @@ def visualisation_link_html_view(request, link_id):
 
     if not visualisation_link.visualisation_catalogue_item.user_has_access(request.user):
         return redirect(
-            "request_access:dataset",
+            "datasets:dataset_detail",
             dataset_uuid=visualisation_link.visualisation_catalogue_item_id,
         )
 


### PR DESCRIPTION
### Description of change
When a user does not have access to a visualisation, instead of showing them the access denied page redirect to the linked dataset page

This is visualisation example on staging that doesn't throw a service error, though it also doesn't load any data but it does render the quicksight dashboard https://data.trade.staging.uktrade.digital/visualisations/link/e351ffac-ee64-4d14-a369-73e302fc619e. You can use this to assign yourself permission in django and then remove it to check the redirection


### Checklist

* [ ] Have tests been added to cover any changes?
