### PR TITLE
ci: move in mkdocs.yml to deploy docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,85 @@
+site_name: Data Workspace Technical Documentation
+repo_name: uktrade/data-workspace
+repo_url: https://github.com/uktrade/data-workspace
+theme:
+  name: tech_docs_template
+  logo: assets/dit-logo.png
+  favicon: assets/dit-favicon.png
+  features:
+    - content.code.copy
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.indexes
+    - navigation.tracking
+    - toc.integrate
+  font:
+    text: Roboto
+    code: Roboto Mono
+  icon:
+    admonition:
+      quote: octicons/quote-16
+      note: material/information
+    tag:
+      draft: material/sticker-outline
+      accepted: material/sticker-check-outline
+      proposed: material/sticker-plus-outline
+      deprecated: material/sticker-minus-outline
+      superseded: material/sticker-alert-outline
+      rejected: material/sticker-remove-outline
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - admonition
+  - pymdownx.details
+  - def_list
+  - tables
+  - attr_list
+  - md_in_html
+extra_css:
+  - stylesheets/tags-color.css
+  - stylesheets/extra.css
+plugins:
+  - material/search
+  - material/tags:
+      tags_file: "architecture/ADRs/README.md"
+extra:
+  tags:
+    Draft: draft
+    Accepted: accepted
+    Proposed: proposed
+    Superseded: superseded
+    Deprecated: deprecated
+    Rejected: rejected
+nav:
+  - Home:
+      - "index.md"
+  - Development:
+      - Running locally: "development/running-locally.md"
+      - Running tests: "development/running-tests.md"
+      - Database migrations: "development/database-migrations.md"
+      - Updating dependencies: "development/updating-dependencies.md"
+      - Remote debugging: "development/remotedebugging.md"
+      - Enhanced tables: "development/enhancedtables.md"
+      - Releases: "development/releases.md"
+  - Deployment:
+      - To AWS: "deployment/aws.md"
+      - To other platforms: "deployment/other-platforms.md"
+  - Data ingestion: "data-ingestion.md"
+  - Architecture:
+      - Components: "architecture/components.md"
+      - Application lifecycle: "architecture/application-lifecycle.md"
+      - Comparison with JupyterHub: "architecture/comparison-with-jupyterhub.md"
+      - ADRs:
+          - "architecture/ADRs/README.md"
+          - "architecture/ADRs/0001.md"
+          - "architecture/ADRs/0002.md"
+  - Contributing: "contributing.md"


### PR DESCRIPTION
This was missed in https://github.com/uktrade/data-workspace/pull/3, bringing in the public facing documentation for Data Workspace