### PR TITLE
docs: make it clear this is PostgreSQL-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img alt="Data Workspace logo" width="130" height="160" src="./docs/assets/data-workspace-logo.svg">
 </p>
 
-<p align="center"><strong>Data Workspace</strong> <em>- an open source data analysis platform</em></p>
+<p align="center"><strong>Data Workspace</strong> <em>- a PostgreSQL-based open source data analysis platform</em></p>
 
 ---
 
-This is the core repository for Data Workspace, an open source data analysis platform with features for users with a range of technical skills. It contains the source for the [Data Workspace technical documentation](https://data-workspace.docs.trade.gov.uk/), and the Terraform code to deploy Data Workspace into AWS.
+This is the core repository for Data Workspace, a PostgreSQL-based open source data analysis platform with features for users with a range of technical skills. It contains the source for the [Data Workspace technical documentation](https://data-workspace.docs.trade.gov.uk/), and the Terraform code to deploy Data Workspace into AWS.
 
 > [!TIP]
 > Looking for the Data Workspace Django application? It's now in the [data-workspace-frontend repo](https://github.com/uktrade/data-workspace-frontend).


### PR DESCRIPTION
This puts PostgreSQL up front and center. While there are some components of Data Workspace that would be useful without PostgreSQL, it's certainly the focus/core.