### PR TITLE
docs: avoid using the word 'core' in multiple ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-This is the core repository for Data Workspace, a PostgreSQL-based open source data analysis platform with features for users with a range of technical skills. It contains the source for the [Data Workspace developer documentation](https://data-workspace.docs.trade.gov.uk/), and the Terraform code to deploy Data Workspace into AWS.
+This is the entry-point repository for Data Workspace, a PostgreSQL-based open source data analysis platform with features for users with a range of technical skills. It contains a brief catalogue of all Data Workspace repositories, the source for the [Data Workspace developer documentation](https://data-workspace.docs.trade.gov.uk/), and the Terraform code to deploy Data Workspace into AWS.
 
 > [!TIP]
 > Looking for the Data Workspace Django application? It's now in the [data-workspace-frontend repo](https://github.com/uktrade/data-workspace-frontend).


### PR DESCRIPTION
The word "core" was used in multiple ways in the README in terms of repositories. Suspect this was confusing.