### PR TITLE
docs: avoid title case on the maintenance page

### DIFF
--- a/docs/development/maintenance-mode.md
+++ b/docs/development/maintenance-mode.md
@@ -1,11 +1,11 @@
 ---
-title: Maintenance Mode
+title: Maintenance mode
 layout: sub-navigation
 ---
 
 This guide will walk you through the process of enabling maintenance mode in your Django application through the admin interface.
 
-## Enabling Maintenance Mode
+## Enabling maintenance mode
 
 1. **Access the Django Admin Interface**: Navigate to the Django Admin Interface (`/admin`).
 


### PR DESCRIPTION
All the other pages from what I can tell don't use title case