### PR TITLE
docs: add 404 page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,10 @@
+---
+eleventyExcludeFromCollections: true
+layout: post
+title: Page not found
+permalink: 404.html
+---
+
+If you entered a web address please check it was correct.
+
+You can browse from [the homepage](/) or use the [sitemap](/sitemap) to find the information you need.


### PR DESCRIPTION
This adds a custom 404 page, which replaces GitHub Pages default. It's now very similar to
https://github.com/x-govuk/govuk-eleventy-plugin/blob/main/docs/404.md, which is itself similar to gov.uk's 404 page.