### PR TITLE
docs: add link to sitemap in the footer

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -20,6 +20,10 @@ module.exports = function(eleventyConfig) {
         meta: {
           items: [
             {
+              href: '/sitemap/',
+              text: 'Sitemap'
+            },
+            {
               href: 'https://github.com/uktrade/data-workspace',
               text: 'Data Workspace GitHub repository'
             },


### PR DESCRIPTION
Makes the footer just a touch more useful I think, and maybe gives a bit of an air of a more "finished" site.