### PR TITLE
chore: remove license year and specify more accurate copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Department for Business and Trade
+Copyright (c) Crown Copyright (Department for Business and Trade)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This remove the year from copyright notice in the license file, and changes the owner of the copyright from

"Department for Business and Trade""

to

"Crown Copyright (Department for Business and Trade)"

The year is removed because there is no need for it - see https://hynek.me/til/copyright-years/ and links from it for details.

The owner is changed to be consistent with GDS, e.g. https://github.com/alphagov/govuk-design-system/blob/main/LICENSE

For background, from
https://cdn.nationalarchives.gov.uk/documents/information-management/crown-copyright-an-overview-for-government-departments.pdf, the Crown is a single legal entity, and this is the "true" owner of the copyright. The name of the department in brackets is, I think, more for informative reasons.