### PR TITLE
chore/fix-frontend-release-doc-location

### DIFF
--- a/docs/deployment/frontend.md
+++ b/docs/deployment/frontend.md
@@ -1,5 +1,5 @@
 ---
-title: Releases
+title: Deploying the frontend
 layout: sub-navigation
 order: 7
 ---


### PR DESCRIPTION
Rename the release file for deploying the frontend, and move to the deployments folder with other release instructions