### PR TITLE
feat: set admin load balancer healthcheck timeout to 30 seconds

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -679,6 +679,8 @@ resource "aws_alb_target_group" "admin" {
     protocol            = "HTTP"
     healthy_threshold   = 3
     unhealthy_threshold = 2
+    timeout             = 30
+    interval            = 40
   }
 
   lifecycle {


### PR DESCRIPTION
Heavy load on the datasets db can slow down responses from the /healthcheck endpoint. This in turn can cause ECS to start some replacement tasks and casus data workspace to start flapping.

Until we can resolve this in a nicer way, set the timeout to 30 seconds.