### PR TITLE
fix: make recent Superset deployable

### DIFF
--- a/infra/ecs_main_superset.tf
+++ b/infra/ecs_main_superset.tf
@@ -198,7 +198,8 @@ resource "aws_lb_target_group" "superset_8000" {
 
   health_check {
     protocol            = "HTTP"
-    interval            = 10
+    timeout             = 15
+    interval            = 20
     healthy_threshold   = 2
     unhealthy_threshold = 5
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -86,6 +86,18 @@ resource "aws_security_group_rule" "sentryproxy_ingress_http_notebooks" {
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "sentryproxy_ingress_http_superset" {
+  description = "ingress-http-superset"
+
+  security_group_id        = aws_security_group.sentryproxy_service.id
+  source_security_group_id = aws_security_group.superset_service.id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
 resource "aws_security_group" "admin_alb" {
   name        = "${var.prefix}-admin-alb"
   description = "${var.prefix}-admin-alb"


### PR DESCRIPTION
This makes recent Superset deployable by increasing the timeout for its load balance health check, and also opens up the Sentry proxy to allow exceptions to be sent to it.