### PR TITLE
feat: allow logging of S3Sync/mobius3 metrics to CloudWatch

### DIFF
--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -14,6 +14,9 @@ resource "aws_ecs_task_definition" "jupyterlabpython" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.jupyterlabpython_metrics_current_tag.result.tag}"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:${data.external.jupyterlabpython_s3sync_current_tag.result.tag}"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/jovyan"
     }
   )

--- a/infra/ecs_notebooks_notebook_container_definitions.json
+++ b/infra/ecs_notebooks_notebook_container_definitions.json
@@ -67,6 +67,12 @@
     },{
       "name": "SENTRY_ENVIRONMENT",
       "value": "${sentry_environment}"
+    }, {
+      "name": "CLOUDWATCH_MONITORING_NAMESPACE",
+      "value": "${cloudwatch_namespace}/S3Sync"
+    }, {
+      "name": "CLOUDWATCH_MONITORING_REGION",
+      "value": "${cloudwatch_region}"
     }]
   }
 ]

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -14,6 +14,9 @@ resource "aws_ecs_task_definition" "remotedesktop" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:${data.external.remotedesktop_current_tag.result.tag}"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/dw"
     }
   )

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -14,6 +14,9 @@ resource "aws_ecs_task_definition" "superset" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:master"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/superset"
     }
   )

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -14,6 +14,9 @@ resource "aws_ecs_task_definition" "theia" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:master"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/theia"
     }
   )

--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -16,6 +16,9 @@ resource "aws_ecs_task_definition" "pgadmin" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.pgadmin_metrics_current_tag.result.tag}"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:${data.external.pgadmin_s3sync_current_tag.result.tag}"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/pgadmin"
     }
   )

--- a/infra/ecs_rstudio.tf
+++ b/infra/ecs_rstudio.tf
@@ -16,6 +16,9 @@ resource "aws_ecs_task_definition" "rstudio" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:${data.external.rstudio_metrics_current_tag.result.tag}"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:${data.external.rstudio_s3sync_current_tag.result.tag}"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/rstudio"
     }
   )

--- a/infra/ecs_rstudio_rv4.tf
+++ b/infra/ecs_rstudio_rv4.tf
@@ -16,6 +16,9 @@ resource "aws_ecs_task_definition" "rstudio_rv4" {
       metrics_container_image = "${aws_ecr_repository.metrics.repository_url}:master"
       s3sync_container_image  = "${aws_ecr_repository.s3sync.repository_url}:master"
 
+      cloudwatch_namespace = "${var.cloudwatch_namespace}"
+      cloudwatch_region    = "${var.cloudwatch_region}"
+
       home_directory = "/home/rstudio"
     }
   )

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,6 +23,12 @@ variable "ip_whitelist" {
 variable "prefix" {}
 variable "prefix_short" {}
 variable "prefix_underscore" {}
+variable "cloudwatch_namespace" {
+  default = "DataWorkspace"
+}
+variable "cloudwatch_region" {
+  default = "eu-west-2"
+}
 
 variable "vpc_cidr" {}
 variable "subnets_num_bits" {}


### PR DESCRIPTION
This adds the permission for each user to log S3Sync metrics to Cloudwatch, specifically ones added in https://github.com/uktrade/mobius3/releases/tag/v0.0.42

It also tightens up permissions on the Cloudwatch VPC endpoints, making sure that only our AWS accounts can use them.