### PR TITLE
Feat/add arangodb ec2

### DIFF
--- a/infra/arango_user_data.sh
+++ b/infra/arango_user_data.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "ECS_CLUSTER=data-workspace-dev-a" >> /etc/ecs/ecs.config
+# install the REX-Ray Docker volume plugin
+docker plugin install rexray/ebs REXRAY_PREEMPT=true EBS_REGION=${EBS_REGION} --grant-all-permission
+# restart the ECS agent. This ensures the plugin is active and recognized once the agent starts.
+#sudo systemctl restart ecs

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -275,11 +275,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
       "${aws_ecr_repository.superset.arn}",
       "${aws_ecr_repository.flower.arn}",
       "${aws_ecr_repository.mlflow.arn}",
-<<<<<<< HEAD
       "${aws_ecr_repository.arango.arn}"
-=======
-      "${aws_ecr_repository.arango.arn}",
->>>>>>> 9f83c4d94f6574276992d2323b8e89159b9d16a0
     ]
   }
 

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -275,6 +275,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
       "${aws_ecr_repository.superset.arn}",
       "${aws_ecr_repository.flower.arn}",
       "${aws_ecr_repository.mlflow.arn}",
+      "${aws_ecr_repository.arango.arn}"
     ]
   }
 

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -94,6 +94,10 @@ resource "aws_ecr_repository" "mlflow" {
   name = "${var.prefix}-mlflow"
 }
 
+resource "aws_ecr_repository" "arango" {
+  name = "${var.prefix}-arango"
+}
+
 resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecr.dkr"

--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -1,0 +1,199 @@
+resource "aws_ecs_service" "arango" {
+  name            = "${var.prefix}-arango"
+  cluster         = "${aws_ecs_cluster.main_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.arango_service.arn}"
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
+    security_groups = ["${aws_security_group.arango_service.id}"]
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_lb_target_group.arango.arn}"
+    container_port   = "8529"
+    container_name   = "arango"
+  }
+
+  depends_on = [
+    # The target group must have been associated with the listener first
+    "aws_lb_listener.arango",
+  ]
+}
+
+resource "aws_ecs_task_definition" "arango_service" {
+  family                   = "${var.prefix}-arango"
+  container_definitions    = "${data.template_file.arango_service_container_definitions.rendered}"
+  execution_role_arn       = "${aws_iam_role.arango_task_execution.arn}"
+  task_role_arn            = "${aws_iam_role.arango_task.arn}"
+  network_mode             = "awsvpc"
+  cpu                      = "${local.arango_container_cpu}"
+  memory                   = "${local.arango_container_memory}"
+  requires_compatibilities = ["FARGATE"]
+
+  lifecycle {
+    ignore_changes = [
+      "revision",
+    ]
+  }
+}
+
+data "template_file" "arango_service_container_definitions" {
+  template = "${file("${path.module}/ecs_main_arango_container_definitions.json")}"
+
+  vars = {
+    container_image = "339713044404.dkr.ecr.eu-west-2.amazonaws.com/data-workspace-dev-a-arango:latest"
+    container_name  = "arango"
+    log_group       = "${aws_cloudwatch_log_group.arango.name}"
+    log_region      = "${data.aws_region.aws_region.name}"
+    cpu             = "${local.arango_container_cpu}"
+    memory          = "${local.arango_container_memory}"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "arango" {
+  name              = "${var.prefix}-arango"
+  retention_in_days = "3653"
+}
+
+resource "aws_iam_role" "arango_task_execution" {
+  name               = "${var.prefix}-arango-task-execution"
+  path               = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.arango_task_execution_ecs_tasks_assume_role.json}"
+}
+
+data "aws_iam_policy_document" "arango_task_execution_ecs_tasks_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "arango_task_execution" {
+  role       = "${aws_iam_role.arango_task_execution.name}"
+  policy_arn = "${aws_iam_policy.arango_task_execution.arn}"
+}
+
+resource "aws_iam_policy" "arango_task_execution" {
+  name   = "${var.prefix}-arango-task-execution"
+  path   = "/"
+  policy = "${data.aws_iam_policy_document.arango_task_execution.json}"
+}
+
+data "aws_iam_policy_document" "arango_task_execution" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.arango.arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.arango.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "arango_task" {
+  name               = "${var.prefix}-arango-task"
+  path               = "/"
+  assume_role_policy = "${data.aws_iam_policy_document.arango_task_ecs_tasks_assume_role.json}"
+}
+
+data "aws_iam_policy_document" "arango_task_ecs_tasks_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "arango_ecs" {
+  name               = "${var.prefix}-arango-ecs"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.arango_ecs_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "arango_ecs" {
+  role       = aws_iam_role.arango_ecs.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}
+
+data "aws_iam_policy_document" "arango_ecs_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_lb" "arango" {
+  name               = "${var.prefix}-arango"
+  load_balancer_type = "network"
+  security_groups = ["${aws_security_group.arango_lb.id}"]
+  enable_deletion_protection = true
+  timeouts {}
+
+  subnet_mapping {
+    subnet_id     = "${aws_subnet.public.*.id[0]}"
+    
+  }
+}
+
+resource "aws_lb_listener" "arango" {
+  load_balancer_arn = "${aws_lb.arango.arn}"
+  port              = "8529"
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.arango.id}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "arango" {
+  name = "${var.prefix}-arango"
+  port        = "8529"
+  vpc_id      = "${aws_vpc.main.id}"
+  target_type = "ip"
+  protocol    = "TCP"
+  preserve_client_ip = true
+
+  health_check {
+    protocol = "TCP"
+    interval = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+  }
+}

--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -129,7 +129,20 @@ resource "aws_ecs_task_definition" "arango_service" {
   network_mode             = "awsvpc"
   cpu                      = "${local.arango_container_cpu}"
   memory                   = "${local.arango_container_memory}"
-  requires_compatibilities = ["FARGATE"]
+  requires_compatibilities = ["EC2"]
+
+  volume {
+    name = "arango-ebs-volume"
+    docker_volume_configuration {
+      scope         = "shared"
+      autoprovision = true
+      driver        = "rexray/ebs"
+      driver_opts = {
+        volumetype = "gp2"
+        size       = 5
+      }
+    }
+  }
 
   lifecycle {
     ignore_changes = [

--- a/infra/ecs_main_arango_container_definitions.json
+++ b/infra/ecs_main_arango_container_definitions.json
@@ -17,6 +17,12 @@
           "awslogs-stream-prefix": "${container_name}"
         }
       },
-      "environment": []
+      "environment": [],
+      "mountPoints": [
+        {
+          "sourceVolume": "arango-ebs-volume",
+          "containerPath": "/var/lib/arangodb3"
+        }
+      ]
     }
   ]

--- a/infra/ecs_main_arango_container_definitions.json
+++ b/infra/ecs_main_arango_container_definitions.json
@@ -1,0 +1,22 @@
+[
+    {
+      "name": "${container_name}",
+      "image": "${container_image}",
+      "memoryReservation": ${memory},
+      "cpu": ${cpu},
+      "essential": true,
+      "portMappings": [{
+          "containerPort": 8529,
+          "protocol": "tcp"
+      }],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "${log_group}",
+          "awslogs-region": "${log_region}",
+          "awslogs-stream-prefix": "${container_name}"
+        }
+      },
+      "environment": []
+    }
+  ]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -260,6 +260,9 @@ locals {
   flower_container_memory = 8192
   flower_container_cpu    = 1024
 
+  arango_container_memory = 8192
+  arango_container_cpu    = 4096
+
   mlflow_container_memory = 8192
   mlflow_container_cpu    = 1024
   mlflow_port             = 8004

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -262,6 +262,7 @@ locals {
 
   arango_container_memory = 8192
   arango_container_cpu    = 4096
+  arango_container_port   = 8529
 
   mlflow_container_memory = 8192
   mlflow_container_cpu    = 1024

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -190,6 +190,38 @@ resource "aws_acm_certificate_validation" "superset_internal" {
   certificate_arn = aws_acm_certificate.superset_internal[count.index].arn
 }
 
+resource "aws_route53_record" "arango" {
+  provider = "aws.route53"
+  zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
+  name     = "arango"
+  type     = "A"
+
+  alias {
+    name                   = aws_lb.arango.dns_name
+    zone_id                = aws_lb.arango.zone_id
+    evaluate_target_health = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "arango" {
+  domain_name       = aws_route53_record.arango.name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate_validation" "arango" {
+  certificate_arn = aws_acm_certificate.arango.arn
+}
+
+
+
 # resource "aws_route53_record" "jupyterhub" {
 #   zone_id = "${data.aws_route53_zone.aws_route53_zone.zone_id}"
 #   name    = "${var.jupyterhub_domain}."

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1926,6 +1926,30 @@ resource "aws_security_group" "arango_lb" {
   }
 }
 
+resource "aws_security_group_rule" "arango_lb_ingress_https_from_whitelist" {
+  description = "ingress-https-from-whitelist"
+
+  security_group_id = aws_security_group.arango_lb.id
+  cidr_blocks       = "${var.ip_whitelist}"
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "arango_lb_egress_https_to_arango_service" {
+  description = "egress-https-to-arango-service"
+
+  security_group_id        = aws_security_group.arango_lb.id
+  source_security_group_id = aws_security_group.arango_service.id
+
+  type      = "egress"
+  from_port = local.arango_container_port
+  to_port   = local.arango_container_port
+  protocol  = "tcp"
+}
+
 resource "aws_security_group" "arango_service" {
   name        = "${var.prefix}-arango"
   description = "${var.prefix}-arango"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -686,6 +686,18 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_healthcheck" {
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_arango_proxy" {
+  description = "ingress-https-from-arango"
+
+  security_group_id        = aws_security_group.ecr_api.id
+  source_security_group_id = aws_security_group.arango_service.id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 
@@ -1930,11 +1942,23 @@ resource "aws_security_group" "arango_service" {
 
 # Connections to ECR and CloudWatch. ECR needs S3, and its VPC endpoint type
 # does not have an IP range or security group to limit access to
+resource "aws_security_group_rule" "arango_egress_ecr_api" {
+  description = "egress-https-to-ecr-api"
+
+  security_group_id = aws_security_group.ecr_api.id
+  source_security_group_id = aws_security_group.arango_service.id
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
 resource "aws_security_group_rule" "arango_egress_https_all" {
   description = "egress-https-to-all"
 
   security_group_id = aws_security_group.arango_service.id
-  source_security_group_id = aws_security_group.ecr_api.id
+  cidr_blocks       = ["0.0.0.0/0"]
 
   type      = "egress"
   from_port = "443"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1922,7 +1922,7 @@ resource "aws_security_group_rule" "arango_egress_https_all" {
   description = "egress-https-to-all"
 
   security_group_id = aws_security_group.arango_service.id
-  cidr_blocks       = ["0.0.0.0/0"]
+  source_security_group_id = aws_security_group.ecr_api.id
 
   type      = "egress"
   from_port = "443"
@@ -1951,5 +1951,17 @@ resource "aws_security_group_rule" "arango_service_egress_8529_arango_lb" {
   type      = "egress"
   from_port = "8529"
   to_port   = "8529"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_arango" {
+  description = "ingress-https-from-arango-service"
+
+  security_group_id        = aws_security_group.arango_service.id
+  source_security_group_id = aws_security_group.ecr_api.id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
   protocol  = "tcp"
 }


### PR DESCRIPTION
This is the draft Terraform to support the deployment of ArangoDB to Data Workspace.  The approach has been modified to use an ECS container with EC2 launch type (managed by an autoscaling group).  An EBS volume has been mounted to support data persistence.  

**Not yet working:** the connection between Theia (notebooks cluster) and ArangoDB (main cluster) via the Arango load balancer. So far, I have checked the VPC peering connection, defined a new target group, added service discovery and added new security group rules.  

Will talk through this tomorrow.  All feedback/suggestions gratefully received.  Thanks.  