### PR TITLE
feat: allow optional enhanced monitoring on the datasets database

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -159,6 +159,10 @@ variable "datasets_rds_cluster_cluster_identifier" {}
 variable "datasets_rds_cluster_instance_class" {}
 variable "datasets_rds_cluster_instance_performance_insights_enabled" {}
 variable "datasets_rds_cluster_instance_identifier" {}
+variable "datasets_rds_cluster_instance_monitoring_interval" {
+  type    = number
+  default = 0
+}
 
 variable "paas_cidr_block" {}
 variable "paas_vpc_id" {}

--- a/infra/rds_datasets.tf
+++ b/infra/rds_datasets.tf
@@ -28,6 +28,7 @@ resource "aws_rds_cluster_instance" "datasets" {
   performance_insights_enabled = var.datasets_rds_cluster_instance_performance_insights_enabled
   promotion_tier               = 1
   db_parameter_group_name      = var.datasets_rds_cluster_instance_parameter_group
+  monitoring_interval          = var.datasets_rds_cluster_instance_monitoring_interval
 
   lifecycle {
     ignore_changes = ["engine_version"]


### PR DESCRIPTION
This adds the option datasets_rds_cluster_instance_monitoring_interval that allows the configuration of enhanced monitoring on the RDS datasets database.

The default 0, means it's disabled, which is existing behaviour.