### PR TITLE
add theia to aws iam policy for gitlab runner

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -863,6 +863,7 @@ data "aws_iam_policy_document" "gitlab_runner" {
       "${aws_ecr_repository.visualisation_base.arn}",
       "${aws_ecr_repository.visualisation_base_r.arn}",
       "${aws_ecr_repository.visualisation_base_rv4.arn}",
+      "${aws_ecr_repository.theia.arn}",
     ]
   }
 


### PR DESCRIPTION
add theia to aws iam policy for gitlab runner, as it contains conda and it can used as base image 