### PR TITLE
feat: support for a second MLFlow to store artefacts in a bucket

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -260,6 +260,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     resources = [
       "${aws_s3_bucket.notebooks.arn}",
       "${aws_s3_bucket.mlflow[0].arn}",
+      "${aws_s3_bucket.mlflow[1].arn}",
     ]
   }
 
@@ -278,6 +279,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     resources = [
       "${aws_s3_bucket.notebooks.arn}/*",
       "${aws_s3_bucket.mlflow[0].arn}/*",
+      "${aws_s3_bucket.mlflow[1].arn}/*",
     ]
   }
 
@@ -294,6 +296,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
 
     resources = [
       "${aws_s3_bucket.mlflow[0].arn}",
+      "${aws_s3_bucket.mlflow[1].arn}",
     ]
   }
 


### PR DESCRIPTION
This adds support to the VPC endpoint configuration for a second MLFlow instance to access its bucket.

It's not great that the number is hard coded to 2 - others parts of the Terraform support 0 or more. However, leaving that tidy up to further work since it was already hard coded (to 1), and so not a meaningful step backwards.