### PR TITLE
fix: support any number of MLFlow instances in bucket config

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -256,12 +256,11 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     actions = [
       "s3:ListBucket",
     ]
-
-    resources = [
+    resources = concat([
       "${aws_s3_bucket.notebooks.arn}",
-      "${aws_s3_bucket.mlflow[0].arn}",
-      "${aws_s3_bucket.mlflow[1].arn}",
-    ]
+      ], [
+      for bucket in aws_s3_bucket.mlflow : bucket.arn
+    ])
   }
 
   statement {
@@ -276,11 +275,11 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
       "s3:DeleteObject"
     ]
 
-    resources = [
+    resources = concat([
       "${aws_s3_bucket.notebooks.arn}/*",
-      "${aws_s3_bucket.mlflow[0].arn}/*",
-      "${aws_s3_bucket.mlflow[1].arn}/*",
-    ]
+      ], [
+      for bucket in aws_s3_bucket.mlflow : "${bucket.arn}/*"
+    ])
   }
 
   statement {
@@ -295,8 +294,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     ]
 
     resources = [
-      "${aws_s3_bucket.mlflow[0].arn}",
-      "${aws_s3_bucket.mlflow[1].arn}",
+      for bucket in aws_s3_bucket.mlflow : bucket.arn
     ]
   }
 


### PR DESCRIPTION
This continues (or maybe, fixes?) the change from
f8368806c87f2763705528829538988dc31c8ffc and makes the number of MLFlow instance not as hard coded as it was - any number, 0 or more, should be now supported.