### PR TITLE
feat: MWAA can communicate with datasets db, and access secrets

### DIFF
--- a/infra/mwaa.tf
+++ b/infra/mwaa.tf
@@ -164,6 +164,16 @@ data "aws_iam_policy_document" "mwaa_execution_role_policy" {
       values   = ["sqs.${data.aws_region.aws_region.name}.amazonaws.com"]
     }
   }
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:secret:${var.mwaa_environment_name}/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "mwaa_execution_role_policy" {

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1643,6 +1643,18 @@ resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_superset" 
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_mwaa" {
+  count       = var.mwaa_environment_name != "" ? 1 : 0
+  description = "ingress-postgres-from-mwaa"
+
+  security_group_id        = aws_security_group.datasets.id
+  source_security_group_id = aws_security_group.mwaa[0].id
+
+  type      = "ingress"
+  from_port = aws_rds_cluster_instance.datasets.port
+  to_port   = aws_rds_cluster_instance.datasets.port
+  protocol  = "tcp"
+}
 
 resource "aws_security_group_rule" "datasets_db_ingress_all_from_quicksight" {
   description = "ingress-all-from-quicksight"


### PR DESCRIPTION
Continuing on the work to add MWAA to Data Workspace, this allows the datasets DB to accept incomming PostgreSQL connections from MWAA, and allows MWAA to take secrets from AWS Secrets Manager.

At this point MWAA _can_ ingest data into Data Workspace.