### PR TITLE
feat: make Airflow variables optional

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -29,8 +29,12 @@ variable "cloudwatch_namespace" {
 variable "cloudwatch_region" {
   default = "eu-west-2"
 }
-variable "mwaa_environment_name" {}
-variable "mwaa_source_bucket_name" {}
+variable "mwaa_environment_name" {
+  default = ""
+}
+variable "mwaa_source_bucket_name" {
+  default = ""
+}
 
 variable "vpc_cidr" {}
 variable "subnets_num_bits" {}


### PR DESCRIPTION
It was a bit of an oversight that they're not - the terraform itself can handle them being the empty string, in which case it won't make the Airflow resources.