### PR TITLE
feat: ecs airflow team-based dag processors

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -90,6 +90,10 @@ resource "aws_ecr_repository" "airflow" {
   name = "${var.prefix}-airflow"
 }
 
+resource "aws_ecr_repository" "airflow_dag_processor" {
+  name = "${var.prefix}-airflow-dag-processor"
+}
+
 resource "aws_ecr_repository" "flower" {
   name = "${var.prefix}-flower"
 }
@@ -274,6 +278,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
       "${aws_ecr_repository.mirrors_sync_cran_binary.arn}",
       "${aws_ecr_repository.superset.arn}",
       "${aws_ecr_repository.airflow.arn}",
+      "${aws_ecr_repository.airflow_dag_processor.arn}",
       "${aws_ecr_repository.flower.arn}",
       "${aws_ecr_repository.mlflow.arn}",
     ]

--- a/infra/ecs_main_airflow.tf
+++ b/infra/ecs_main_airflow.tf
@@ -66,10 +66,89 @@ resource "aws_ecs_task_definition" "airflow_service" {
   requires_compatibilities = ["FARGATE"]
 
   lifecycle {
-    ignore_changes = [
-      "revision",
-    ]
+    ignore_changes = [revision]
   }
+}
+
+resource "aws_ecs_service" "airflow_dag_processor" {
+  count                      = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name                       = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  cluster                    = aws_ecs_cluster.main_cluster.id
+  task_definition            = aws_ecs_task_definition.airflow_dag_processor_service[count.index].arn
+  desired_count              = 1
+  launch_type                = "FARGATE"
+  deployment_maximum_percent = 200
+  platform_version           = "1.4.0"
+
+  network_configuration {
+    subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
+    security_groups = ["${aws_security_group.airflow_dag_processor_service.id}"]
+  }
+
+}
+
+locals {
+  airflow_dag_processor_container_vars = [
+    for i, v in var.airflow_dag_processors : {
+      container_image = "${aws_ecr_repository.airflow_dag_processor.repository_url}:master"
+      container_name  = "airflow-dag-processor"
+      log_group       = "${aws_cloudwatch_log_group.airflow_dag_processor[i].name}"
+      log_region      = "${data.aws_region.aws_region.name}"
+      cpu             = "${local.airflow_container_cpu}"
+      memory          = "${local.airflow_container_memory}"
+
+      db_host     = "${aws_rds_cluster.airflow[0].endpoint}"
+      db_name     = "${aws_rds_cluster.airflow[0].database_name}"
+      db_password = "${random_string.aws_db_instance_airflow_password.result}"
+      db_port     = "${aws_rds_cluster.airflow[0].port}"
+      db_user     = "${aws_rds_cluster.airflow[0].master_username}"
+      secret_key  = "${random_string.airflow_secret_key.result}"
+
+      datasets_db_host     = "${aws_rds_cluster.datasets.endpoint}"
+      datasets_db_name     = "${aws_rds_cluster.datasets.database_name}"
+      datasets_db_password = "${random_string.aws_rds_cluster_instance_datasets_password.result}"
+      datasets_db_port     = "${aws_rds_cluster.datasets.port}"
+      datasets_db_user     = "${var.datasets_rds_cluster_master_username}"
+
+      sentry_dsn         = "${var.sentry_notebooks_dsn}"
+      sentry_environment = "${var.sentry_environment}"
+
+      team = "${v}"
+    }
+  ]
+}
+
+resource "aws_ecs_task_definition" "airflow_dag_processor_service" {
+  count  = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  family = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_main_airflow_dag_processor_container_definitions.json",
+    local.airflow_dag_processor_container_vars[count.index]
+  )
+  execution_role_arn       = aws_iam_role.airflow_dag_processor_task_execution[count.index].arn
+  task_role_arn            = aws_iam_role.airflow_dag_processor_task[count.index].arn
+  network_mode             = "awsvpc"
+  cpu                      = local.airflow_container_cpu
+  memory                   = local.airflow_container_memory
+  requires_compatibilities = ["FARGATE"]
+
+  lifecycle {
+    ignore_changes = [revision]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "airflow_dag_processor" {
+  count             = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name              = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  retention_in_days = "3653"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "airflow_dag_processor" {
+  count           = var.cloudwatch_subscription_filter && var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name            = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  log_group_name  = aws_cloudwatch_log_group.airflow_dag_processor[count.index].name
+  filter_pattern  = ""
+  destination_arn = var.cloudwatch_destination_arn
 }
 
 resource "aws_cloudwatch_log_group" "airflow" {
@@ -85,6 +164,96 @@ resource "aws_cloudwatch_log_subscription_filter" "airflow" {
   filter_pattern  = ""
   destination_arn = var.cloudwatch_destination_arn
 }
+
+#################
+
+resource "aws_iam_role" "airflow_dag_processor_task_execution" {
+  count              = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name               = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.airflow_dag_processor_task_execution_ecs_tasks_assume_role[count.index].json
+}
+
+data "aws_iam_policy_document" "airflow_dag_processor_task_execution_ecs_tasks_assume_role" {
+  count = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "airflow_dag_processor_task_execution" {
+  count      = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  role       = aws_iam_role.airflow_dag_processor_task_execution[count.index].name
+  policy_arn = aws_iam_policy.airflow_dag_processor_task_execution[count.index].arn
+}
+
+resource "aws_iam_policy" "airflow_dag_processor_task_execution" {
+  count  = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name   = "${var.prefix}-airflow-dag-processor-${var.airflow_dag_processors[count.index]}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.airflow_dag_processor_task_execution[count.index].json
+}
+
+data "aws_iam_policy_document" "airflow_dag_processor_task_execution" {
+  count = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.airflow_dag_processor[count.index].arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.airflow_dag_processor.arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "airflow_dag_processor_task" {
+  count              = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  name               = "${var.prefix}-airflow-dp-task-${var.airflow_dag_processors[count.index]}"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.airflow_dag_processor_task_ecs_tasks_assume_role[count.index].json
+}
+
+data "aws_iam_policy_document" "airflow_dag_processor_task_ecs_tasks_assume_role" {
+  count = var.airflow_on ? length(var.airflow_dag_processors) : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+#################
 
 resource "aws_iam_role" "airflow_task_execution" {
   count              = var.airflow_on ? 1 : 0

--- a/infra/ecs_main_airflow_dag_processor_container_definitions.json
+++ b/infra/ecs_main_airflow_dag_processor_container_definitions.json
@@ -1,0 +1,68 @@
+[
+  {
+    "environment": [{
+      "name": "DB_HOST",
+      "value": "${db_host}"
+    },{
+      "name": "DB_NAME",
+      "value": "${db_name}"
+    },{
+      "name": "DB_PASSWORD",
+      "value": "${db_password}"
+    },{
+      "name": "DB_PORT",
+      "value": "${db_port}"
+    },{
+      "name": "DB_USER",
+      "value": "${db_user}"
+    },{
+      "name": "SECRET_KEY",
+      "value": "${secret_key}"
+    },{
+      "name": "SENTRY_DSN",
+      "value": "${sentry_dsn}"
+    },{
+      "name": "SENTRY_ENVIRONMENT",
+      "value": "${sentry_environment}"
+    },{
+      "name": "DATASETS_DB_HOST",
+      "value": "${datasets_db_host}"
+    },{
+      "name": "DATASETS_DB_NAME",
+      "value": "${datasets_db_name}"
+    },{
+      "name": "DATASETS_DB_PASSWORD",
+      "value": "${datasets_db_password}"
+    },{
+      "name": "DATASETS_DB_PORT",
+      "value": "${datasets_db_port}"
+    },{
+      "name": "DATASETS_DB_USER",
+      "value": "${datasets_db_user}"
+    },{
+      "name": "TEAM",
+      "value": "${team}"
+    }
+  ],
+    "essential": true,
+    "image": "${container_image}",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${log_region}",
+        "awslogs-stream-prefix": "${container_name}"
+      }
+    },
+    "networkMode": "awsvpc",
+    "memoryReservation": ${memory},
+    "cpu": ${cpu},
+    "mountPoints" : [],
+    "name": "${container_name}",
+    "portMappings": [{
+        "containerPort": 8080,
+        "hostPort": 8080,
+        "protocol": "tcp"
+    }]
+  }
+]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -166,6 +166,7 @@ variable "airflow_on" {
 
 variable "airflow_db_instance_class" {}
 variable "airflow_domain" {}
+variable "airflow_dag_processors" {}
 
 variable "datasets_rds_cluster_database_engine" {}
 variable "datasets_rds_cluster_instance_parameter_group" {}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1558,6 +1558,80 @@ resource "aws_security_group" "airflow_service" {
   }
 }
 
+resource "aws_security_group_rule" "airflow_dag_processor_service_egress_https_to_cloudwatch" {
+  description = "egress-https-to-cloudwatch"
+
+  security_group_id        = aws_security_group.airflow_dag_processor_service.id
+  source_security_group_id = aws_security_group.cloudwatch.id
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "airflow_dag_processor_egress_https_all" {
+  description = "egress-https-to-all"
+
+  security_group_id = aws_security_group.airflow_dag_processor_service.id
+  cidr_blocks       = ["0.0.0.0/0"]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "ecr_api_ingress_https_from_airflow_dag_processor" {
+  description = "ingress-https-from-airflow"
+
+  security_group_id        = aws_security_group.ecr_api.id
+  source_security_group_id = aws_security_group.airflow_dag_processor_service.id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "airflow_dag_processor_service_egress_postgres_airflow_db" {
+  description = "egress-postgres-airflow-db"
+
+  security_group_id        = aws_security_group.airflow_dag_processor_service.id
+  source_security_group_id = aws_security_group.airflow_db.id
+
+  type      = "egress"
+  from_port = "5432"
+  to_port   = "5432"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "postgres_airflow_db_ingress_airflow_dag_processor_service" {
+  description = "ingress-airflow-dag-processor-service"
+
+  security_group_id        = aws_security_group.airflow_db.id
+  source_security_group_id = aws_security_group.airflow_dag_processor_service.id
+
+  type      = "ingress"
+  from_port = "5432"
+  to_port   = "5432"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group" "airflow_dag_processor_service" {
+  name        = "${var.prefix}-airflow-dag-processor-service"
+  description = "${var.prefix}-airflow-dag-processor-service"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.prefix}-airflow-dag-processor-service"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_security_group" "airflow_lb" {
   name        = "${var.prefix}-airflow-lb"
   description = "${var.prefix}-airflow-lb"


### PR DESCRIPTION
Infra work for detaching DAG processors from the ECS Airflow scheduler. Each DAG processor is now a standalone ECS service, allowing for scalability based on the number of teams. This change enables a clear separation of environments, aligning with the principles outlined in AIP-43: DAG Processor separation (https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-43+DAG+Processor+separation).