### PR TITLE
Remove memory and cpu from airflow DAG tasks

### DIFF
--- a/infra/airflow_dag_tasks.tf
+++ b/infra/airflow_dag_tasks.tf
@@ -11,8 +11,6 @@ resource "aws_ecs_task_definition" "airflow_dag_tasks" {
       container_name  = "airflow"
       log_group       = "${aws_cloudwatch_log_group.airflow_webserver[count.index].name}"
       log_region      = "${data.aws_region.aws_region.name}"
-      cpu             = "${local.airflow_container_cpu}"
-      memory          = "${local.airflow_container_memory}"
 
       db_host     = "${aws_rds_cluster.airflow[count.index].endpoint}"
       db_name     = "${aws_rds_cluster.airflow[count.index].database_name}"

--- a/infra/airflow_dag_tasks_container_definitions.json
+++ b/infra/airflow_dag_tasks_container_definitions.json
@@ -55,8 +55,6 @@
       }
     },
     "networkMode": "awsvpc",
-    "memoryReservation": ${memory},
-    "cpu": ${cpu},
     "mountPoints" : [],
     "name": "${container_name}",
     "portMappings": [{


### PR DESCRIPTION
We always override the cpu and memory from the DAG tasks, it is easier if they
are not specified here to avoid any conflictions and errors.
