### PR TITLE
feat: per-team role arn prefix available to Airflow scheduler

### DIFF
--- a/infra/airflow_scheduler.tf
+++ b/infra/airflow_scheduler.tf
@@ -53,6 +53,8 @@ resource "aws_ecs_task_definition" "airflow_scheduler" {
       task_definition = "${aws_ecs_task_definition.airflow_dag_tasks[0].arn}"
       cluster         = "${aws_ecs_cluster.airflow_dag_tasks.name}"
 
+      task_role_arn_prefix = "arn:aws:iam::${data.aws_caller_identity.aws_caller_identity.account_id}:role/${local.airflow_team_role_prefix}"
+
       cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.airflow_dag_tasks_airflow_logging[0].arn}"
 
       dag_sync_github_key = "${var.dag_sync_github_key}"

--- a/infra/airflow_scheduler_container_definitions.json
+++ b/infra/airflow_scheduler_container_definitions.json
@@ -73,6 +73,9 @@
     },{
       "name": "DAG_SYNC_GITHUB_KEY",
       "value": "${dag_sync_github_key}"
+    },{
+      "name": "CUSTOM_ECS_EXECUTOR__TASK_ROLE_ARN_PREFIX",
+      "value": "${task_role_arn_prefix}"
     }
   ],
     "essential": true,

--- a/infra/airflow_webserver.tf
+++ b/infra/airflow_webserver.tf
@@ -342,10 +342,9 @@ data "aws_iam_policy_document" "airflow_webserver_task" {
     actions = [
       "iam:PassRole"
     ]
-    resources = [
+    resources = concat([
       "${aws_iam_role.airflow_webserver_execution[count.index].arn}",
-      "${aws_iam_role.airflow_webserver_task[count.index].arn}",
-    ]
+    ], [for team_role in aws_iam_role.airflow_team : team_role.arn])
   }
 
   # For viewing logs (webserver)
@@ -355,29 +354,6 @@ data "aws_iam_policy_document" "airflow_webserver_task" {
     ]
 
     # Should be tighter
-    resources = [
-      "*"
-    ]
-  }
-
-  # For the tasks
-  statement {
-    actions = [
-      "logs:CreateLogGroup"
-    ]
-
-    # Should be tighter
-    resources = [
-      "*"
-    ]
-  }
-
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
     resources = [
       "*"
     ]


### PR DESCRIPTION
Our (slightly) custom ECS executor for Airflow will run tasks using a different role for each team. The arn of the roles will follow a pattern - a prefix followed by the folder that the dag of the Airflow task is in.

This change makes that prefix available to the Airflow scheduler that runs the executor, so the executor can then choose the correct role to run each task under.