### PR TITLE
feat: Airflow teams know the name of the team secret

### DIFF
--- a/infra/airflow_dag_processor.tf
+++ b/infra/airflow_dag_processor.tf
@@ -47,6 +47,7 @@ locals {
       cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.airflow_dag_tasks_airflow_logging[0].arn}"
 
       team                = "${v}"
+      team_secret_id      = "${var.prefix}/airflow/${v}"
       dag_sync_github_key = "${var.dag_sync_github_key}"
     }
   ]

--- a/infra/airflow_dag_processor_container_definitions.json
+++ b/infra/airflow_dag_processor_container_definitions.json
@@ -49,6 +49,9 @@
     },{
       "name": "DAG_SYNC_GITHUB_KEY",
       "value": "${dag_sync_github_key}"
+    },{
+      "name": "TEAM_SECRET_ID",
+      "value": "${team_secret_id}"
     }
   ],
     "essential": true,


### PR DESCRIPTION
This passes the name of the Secrets Manager secret for each team, so the team-specific code can fetch it (and convert it to environment variables for DAG code).