### PR TITLE
feat: Airflow scheduler knows the prefix so it can pass the right team secret ID to dags

### DIFF
--- a/infra/airflow_scheduler.tf
+++ b/infra/airflow_scheduler.tf
@@ -58,6 +58,7 @@ resource "aws_ecs_task_definition" "airflow_scheduler" {
       cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.airflow_dag_tasks_airflow_logging[0].arn}"
 
       dag_sync_github_key = "${var.dag_sync_github_key}"
+      prefix              = "${var.prefix}"
     }
   )
   execution_role_arn       = aws_iam_role.airflow_webserver_execution[count.index].arn

--- a/infra/airflow_scheduler_container_definitions.json
+++ b/infra/airflow_scheduler_container_definitions.json
@@ -76,6 +76,9 @@
     },{
       "name": "CUSTOM_ECS_EXECUTOR__TASK_ROLE_ARN_PREFIX",
       "value": "${task_role_arn_prefix}"
+    },{
+      "name": "PREFIX",
+      "value": "${prefix}"
     }
   ],
     "essential": true,


### PR DESCRIPTION
 This passes the prefix (i.e. the environment name) to the the scheduler, so it can in turn work out the secret ID to pass to tasks, so they can retrieve the secret with their team's environment variables in