### PR TITLE
feat:Changing the secret key to airflow webserver secret key

### DIFF
--- a/infra/airflow_webserver_container_definitions.json
+++ b/infra/airflow_webserver_container_definitions.json
@@ -17,7 +17,7 @@
       "name": "DB_USER",
       "value": "${db_user}"
     },{
-      "name": "SECRET_KEY",
+      "name": "AIRFLOW_WEBSERVER_SECRET_KEY",
       "value": "${secret_key}"
     },{
       "name": "SENTRY_DSN",


### PR DESCRIPTION
Whilst investigating a potential webserver issues, noticed that we were "name" secret key instead of Airflow Webserver Secret Key.