### PR TITLE
feat: add ArangoDB

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -98,6 +98,11 @@ resource "aws_ecr_repository" "mlflow" {
   name = "${var.prefix}-mlflow"
 }
 
+resource "aws_ecr_repository" "arango" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arango"
+}
+
 resource "aws_vpc_endpoint" "ecr_dkr" {
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecr.dkr"

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -1,5 +1,5 @@
 locals {
-  admin_container_vars = {
+  admin_container_vars = merge({
     container_image = "${aws_ecr_repository.admin.repository_url}:${data.external.admin_current_tag.result.tag}"
     container_name  = "${local.admin_container_name}"
     container_port  = "${local.admin_container_port}"
@@ -98,7 +98,16 @@ locals {
 
     jwt_private_key = "${var.jwt_private_key}"
     mlflow_port     = "${local.mlflow_port}"
-  }
+    }, var.arango_on ? {
+    arango_db__host     = "${aws_lb.arango[0].dns_name}"
+    arango_db__password = "${random_string.aws_arangodb_root_password[0].result}"
+    arango_db__port     = "${local.arango_container_port}"
+    } : {
+    arango_db__host     = ""
+    arango_db__password = ""
+    arango_db__port     = ""
+    }
+  )
 }
 
 resource "aws_ecs_service" "admin" {

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -56,6 +56,22 @@
       "value": "datasets_1"
     },
     {
+      "name": "ARANGO_DB__HOST",
+      "value": "${arango_db__host}"
+    },
+    {
+      "name": "ARANGO_DB__PORT",
+      "value": "${arango_db__port}"
+    },
+    {
+      "name": "ARANGO_DB__USER",
+      "value": "root"
+    },
+    {
+      "name": "ARANGO_DB__PASSWORD",
+      "value": "${arango_db__password}"
+    },
+    {
       "name": "ALLOWED_HOSTS__1",
       "value": "${root_domain}"
     },

--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -1,0 +1,489 @@
+resource "aws_ecs_service" "arango" {
+  count           = var.arango_on ? 1 : 0
+  name            = "${var.prefix}-arango"
+  cluster         = aws_ecs_cluster.main_cluster.id
+  task_definition = aws_ecs_task_definition.arango_service[0].arn
+  desired_count   = 1
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.arango_capacity_provider[0].name
+    weight            = 100
+    base              = 1
+  }
+
+  network_configuration {
+    subnets         = [aws_subnet.datasets.*.id[0]]
+    security_groups = [aws_security_group.arango_service[0].id]
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.arango[0].arn
+    container_port   = "8529"
+    container_name   = "arango"
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.arango[0].arn
+  }
+
+  depends_on = [
+    # The target group must have been associated with the listener first
+    "aws_lb_listener.arango",
+    "aws_autoscaling_group.arango_service"
+  ]
+}
+
+resource "aws_service_discovery_service" "arango" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arango"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.jupyterhub.id
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "arango_service" {
+  count                     = var.arango_on ? 1 : 0
+  name_prefix               = "${var.prefix}-arango"
+  max_size                  = 1
+  min_size                  = 1
+  desired_capacity          = 1
+  health_check_grace_period = 120
+  health_check_type         = "EC2"
+  vpc_zone_identifier       = ["${aws_subnet.datasets.*.id[0]}"]
+
+  launch_template {
+    id      = aws_launch_template.arango_service[0].id
+    version = "$Latest"
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "${var.prefix}-arango-service"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_autoscaling_groups" "arango_asgs" {
+  count = var.arango_on ? 1 : 0
+  names = ["${aws_autoscaling_group.arango_service[0].name}"]
+}
+
+resource "aws_launch_template" "arango_service" {
+  count         = var.arango_on ? 1 : 0
+  name_prefix   = "${var.prefix}-arango-service-"
+  image_id      = var.arango_image_id
+  instance_type = var.arango_instance_type
+  key_name      = aws_key_pair.shared.key_name
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  network_interfaces {
+    security_groups = [aws_security_group.arango-ec2[0].id]
+    subnet_id       = aws_subnet.datasets.*.id[0]
+  }
+  iam_instance_profile {
+    name = aws_iam_instance_profile.arango_ec2[0].name
+  }
+
+  user_data = (base64encode(templatefile("${path.module}/ecs_main_arango_user_data.sh",
+    {
+      ECS_CLUSTER   = aws_ecs_cluster.main_cluster.name
+      EBS_REGION    = data.aws_region.aws_region.name
+      EBS_VOLUME_ID = aws_ebs_volume.arango[0].id
+  })))
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_ecs_capacity_provider" "arango_capacity_provider" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arango_service"
+  auto_scaling_group_provider {
+    auto_scaling_group_arn = aws_autoscaling_group.arango_service[0].arn
+    managed_scaling {
+      maximum_scaling_step_size = 1000
+      minimum_scaling_step_size = 1
+      status                    = "ENABLED"
+      target_capacity           = 3
+    }
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "arango" {
+  count              = var.arango_on ? 1 : 0
+  cluster_name       = aws_ecs_cluster.main_cluster.name
+  capacity_providers = [aws_ecs_capacity_provider.arango_capacity_provider[0].name]
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.arango_capacity_provider[0].name
+  }
+}
+
+resource "aws_ecs_task_definition" "arango_service" {
+  count  = var.arango_on ? 1 : 0
+  family = "${var.prefix}-arango"
+  container_definitions = templatefile("${path.module}/ecs_main_arango_container_definitions.json", {
+    container_image = "${aws_ecr_repository.arango[0].repository_url}:latest"
+    container_name  = "arango"
+    log_group       = "${aws_cloudwatch_log_group.arango[0].name}"
+    log_region      = "${data.aws_region.aws_region.name}"
+    cpu             = "${local.arango_container_cpu}"
+    memory          = "${local.arango_container_memory}"
+    root_password   = "${random_string.aws_arangodb_root_password[0].result}"
+  })
+
+  execution_role_arn       = aws_iam_role.arango_task_execution[0].arn
+  task_role_arn            = aws_iam_role.arango_task[0].arn
+  network_mode             = "awsvpc"
+  cpu                      = local.arango_container_cpu
+  memory                   = local.arango_container_memory
+  requires_compatibilities = ["EC2"]
+
+  volume {
+    name      = "data-arango"
+    host_path = "/data/"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "revision",
+    ]
+  }
+}
+
+resource "aws_ebs_volume" "arango" {
+  count             = var.arango_on ? 1 : 0
+  availability_zone = var.aws_availability_zones[0]
+  size              = var.arango_ebs_volume_size
+  type              = var.arango_ebs_volume_type
+  encrypted         = true
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  tags = {
+    Name = "${var.prefix}-arango"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "arango" {
+  count             = var.arango_on ? 1 : 0
+  name              = "${var.prefix}-arango"
+  retention_in_days = "3653"
+}
+
+resource "aws_iam_role" "arango_task_execution" {
+  count              = var.arango_on ? 1 : 0
+  name               = "${var.prefix}-arango-task-execution"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.arango_task_execution_ecs_tasks_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "arango_task_execution_ecs_tasks_assume_role" {
+  count = var.arango_on ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "arango_task_execution" {
+  count      = var.arango_on ? 1 : 0
+  role       = aws_iam_role.arango_task_execution[0].name
+  policy_arn = aws_iam_policy.arango_task_execution[0].arn
+}
+
+resource "aws_iam_policy" "arango_task_execution" {
+  count  = var.arango_on ? 1 : 0
+  name   = "${var.prefix}-arango-task-execution"
+  path   = "/"
+  policy = data.aws_iam_policy_document.arango_task_execution[0].json
+}
+
+data "aws_iam_policy_document" "arango_task_execution" {
+  count = var.arango_on ? 1 : 0
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.arango[0].arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.arango[0].arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "arango_task" {
+  count              = var.arango_on ? 1 : 0
+  name               = "${var.prefix}-arango-task"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.arango_task_ecs_tasks_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "arango_task_ecs_tasks_assume_role" {
+  count = var.arango_on ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "arango_ecs" {
+  count              = var.arango_on ? 1 : 0
+  name               = "${var.prefix}-arango-ecs"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.arango_ecs_assume_role[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "arango_ecs" {
+  count      = var.arango_on ? 1 : 0
+  role       = aws_iam_role.arango_ecs[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
+}
+
+data "aws_iam_policy_document" "arango_ecs_assume_role" {
+  count = var.arango_on ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "arango_ec2" {
+  count              = var.arango_on ? 1 : 0
+  name               = "${var.prefix}-arango-ec2"
+  assume_role_policy = data.aws_iam_policy_document.arango_ec2_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "arango_ec2_assume_role" {
+  count = var.arango_on ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "arango_ec2" {
+  count      = var.arango_on ? 1 : 0
+  role       = aws_iam_role.arango_ec2[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+data "aws_iam_policy_document" "arango_ebs" {
+  count = var.arango_on ? 1 : 0
+  # The Arango EC2 instance attaches the volume dynamically on startup via its userdata. To allow
+  # this, it needs to be able to ec2:AttachVolume on both the EC2 instance and the volume. The
+  # volume permission is fairly straightforward, but because the EC2 is launched by an autoscaling
+  # group, there is no fixed ARN for the instance, so we use a condition on the instance profile as
+  # the next best thing
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+    ]
+    resources = [
+      "${aws_ebs_volume.arango[0].arn}"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:InstanceProfile"
+      values = [
+        aws_iam_instance_profile.arango_ec2[0].arn,
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "arango_ebs" {
+  count       = var.arango_on ? 1 : 0
+  name        = "arango-ebs"
+  description = "enable-mounting-of-ebs-volume"
+  policy      = data.aws_iam_policy_document.arango_ebs[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "arango_ec2_ebs" {
+  count      = var.arango_on ? 1 : 0
+  role       = aws_iam_role.arango_ec2[0].name
+  policy_arn = aws_iam_policy.arango_ebs[0].arn
+}
+
+resource "aws_iam_instance_profile" "arango_ec2" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arango-ec2"
+  role  = aws_iam_role.arango_ec2[0].id
+}
+
+resource "aws_lb" "arango" {
+  count                      = var.arango_on ? 1 : 0
+  name                       = "${var.prefix}-arango"
+  load_balancer_type         = "application"
+  security_groups            = [aws_security_group.arango_lb[0].id]
+  enable_deletion_protection = true
+  internal                   = true
+  subnets                    = aws_subnet.datasets.*.id
+  tags = {
+    name = "arango-to-notebook-lb"
+  }
+}
+
+resource "aws_lb_listener" "arango" {
+  count             = var.arango_on ? 1 : 0
+  load_balancer_arn = aws_lb.arango[0].arn
+  port              = "8529"
+  protocol          = "HTTPS"
+
+  ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn = aws_acm_certificate_validation.arango[count.index].certificate_arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.arango[0].id
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_target_group" "arango" {
+  count       = var.arango_on ? 1 : 0
+  name        = "${var.prefix}-arango"
+  port        = "8529"
+  vpc_id      = aws_vpc.datasets.id
+  target_type = "ip"
+  protocol    = "HTTP"
+
+  health_check {
+    protocol            = "HTTP"
+    interval            = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    path                = "/_db/_system/_admin/aardvark/index.html"
+  }
+}
+
+resource "random_string" "aws_arangodb_root_password" {
+  count   = var.arango_on ? 1 : 0
+  length  = 64
+  special = false
+
+  lifecycle {
+    ignore_changes = all
+  }
+}
+
+resource "aws_backup_vault" "arango_backup_vault" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arangodb-backup-vault"
+}
+
+resource "aws_backup_plan" "arango_backup_plan" {
+  count = var.arango_on ? 1 : 0
+  name  = "${var.prefix}-arangodb-backup-plan"
+  rule {
+    rule_name         = "arangodb-backup-rule"
+    target_vault_name = "${var.prefix}-arangodb-backup-vault"
+    schedule          = "cron(0 0 * * ? *)"
+
+    start_window      = 60
+    completion_window = 360
+    lifecycle {
+      delete_after = 8
+    }
+  }
+
+  depends_on = [aws_backup_vault.arango_backup_vault]
+}
+
+resource "aws_backup_selection" "arango_backup_resource" {
+  count        = var.arango_on ? 1 : 0
+  iam_role_arn = aws_iam_role.arango_ebs_backup[0].arn
+  name         = "arangodb-backup-resources"
+  plan_id      = aws_backup_plan.arango_backup_plan[0].id
+
+  resources = [
+    aws_ebs_volume.arango[0].arn
+  ]
+}
+
+resource "aws_iam_role" "arango_ebs_backup" {
+  count              = var.arango_on ? 1 : 0
+  name               = "${var.prefix}-arango-ebs-backup"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.arango_ebs_backup_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "arango_ebs_backup_assume_role" {
+  count = var.arango_on ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "arango_ec2_ebs_backup" {
+  count      = var.arango_on ? 1 : 0
+  role       = aws_iam_role.arango_ebs_backup[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+}

--- a/infra/ecs_main_arango_container_definitions.json
+++ b/infra/ecs_main_arango_container_definitions.json
@@ -1,0 +1,31 @@
+[
+    {
+      "name": "${container_name}",
+      "image": "${container_image}",
+      "memoryReservation": ${memory},
+      "cpu": ${cpu},
+      "essential": true,
+      "portMappings": [{
+          "containerPort": 8529,
+          "protocol": "tcp"
+      }],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "${log_group}",
+          "awslogs-region": "${log_region}",
+          "awslogs-stream-prefix": "${container_name}"
+        }
+      },
+      "environment": [
+        {
+          "name": "ARANGO_ROOT_PASSWORD",
+          "value": "${root_password}"
+        }
+      ],
+      "mountPoints" : [{
+        "containerPath" : "/var/lib/arangodb3",
+        "sourceVolume" : "data-arango"
+     }]
+    }
+  ]

--- a/infra/ecs_main_arango_user_data.sh
+++ b/infra/ecs_main_arango_user_data.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# install and start ecs agent
+
+EC2_INSTANCE_ID=$(ec2-metadata --instance-id | sed 's/instance-id: //')
+aws ec2 attach-volume --volume-id ${EBS_VOLUME_ID} --instance-id $EC2_INSTANCE_ID --device /dev/xvdf --region ${EBS_REGION}
+# Follow symlinks to find the real device
+device=$(sudo readlink -f /dev/xvdf)
+  # Wait for the drive to be attached
+while [ ! -e $device ] ; do sleep 1 ; done
+# Format /dev/sdh if it does not contain a partition yet
+if [ "$(sudo file -b -s $device)" == "data" ]; then
+sudo mkfs -t ext4 $device
+fi
+# Mount the drive
+sudo mkdir -p /data
+sudo mount $device /data
+
+mkdir -p /etc/ecs/
+echo "ECS_CLUSTER=${ECS_CLUSTER}" >> /etc/ecs/ecs.config
+sudo systemctl enable --now --no-block ecs

--- a/infra/environment-template/main.tf
+++ b/infra/environment-template/main.tf
@@ -141,21 +141,12 @@ module "jupyterhub" {
   datasets_rds_cluster_instance_performance_insights_enabled = "true"
   datasets_rds_cluster_instance_identifier                   = "REPLACE_ME"
 
-  paas_cidr_block       = "10.0.0.0/16"
-  paas_vpc_id           = "REPLACE_ME"
-  quicksight_cidr_block = "172.18.5.128/25"
-  quicksight_vpc_arn    = "REPLACE_ME"
-  datasets_subnet_cidr_blocks = [
-    "172.18.4.0/25",
-    "172.18.4.128/25",
-    "172.18.5.0/25",
-  ]
-  dataset_subnets_availability_zones = [
-    "eu-west-2a",
-    "eu-west-2b",
-    "eu-west-2b",
-  ] # The second and third subnet on the live environment are both in the same az
-
+  paas_cidr_block                       = "10.0.0.0/16"
+  paas_vpc_id                           = "REPLACE_ME"
+  quicksight_cidr_block                 = "172.18.5.128/25"
+  quicksight_vpc_arn                    = "REPLACE_ME"
+  datasets_subnet_cidr_blocks           = ["172.18.4.0/25", "172.18.4.128/25", "172.18.5.0/25", "172.18.6.0/25", "172.18.6.128/25", "172.18.7.0/25"]
+  dataset_subnets_availability_zones    = ["eu-west-2a", "eu-west-2b", "eu-west-2b"] # The second and third subnet on the live environment are both in the same az
   quicksight_security_group_name        = "jupyterhub-quicksight"
   quicksight_security_group_description = "Allow quicksight to connect to data workspace datasets DB"
   quicksight_subnet_availability_zone   = "eu-west-2b"
@@ -176,6 +167,11 @@ module "jupyterhub" {
 
   jwt_private_key = "-----BEGIN PRIVATE KEY-----\\REPLACE_ME\\n-----END PRIVATE KEY-----\\n"
   jwt_public_key  = "-----BEGIN PUBLIC KEY-----\\REPLACE_ME\\n-----END PUBLIC KEY-----\\n"
+
+  arango_image_id        = "ami-093b9bbd71042c2d4"
+  arango_instance_type   = "t2.xlarge"
+  arango_ebs_volume_size = 20
+  arango_ebs_volume_type = "gp3"
 
   mlflow_artifacts_bucket  = "REPLACE_ME"
   mlflow_instances         = ["REPLACE_ME"]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -234,6 +234,16 @@ variable "mlflow_db_instance_class" {}
 variable "jwt_public_key" {}
 variable "jwt_private_key" {}
 
+variable "arango_on" {
+  type    = bool
+  default = false
+}
+
+variable "arango_ebs_volume_size" {}
+variable "arango_ebs_volume_type" {}
+variable "arango_instance_type" {}
+variable "arango_image_id" {}
+
 locals {
   admin_container_name   = "jupyterhub-admin"
   admin_container_port   = "8000"
@@ -300,6 +310,10 @@ locals {
 
   flower_container_memory = 8192
   flower_container_cpu    = 1024
+
+  arango_container_memory = 1024
+  arango_container_cpu    = 2048
+  arango_container_port   = 8529
 
   mlflow_container_memory = 8192
   mlflow_container_cpu    = 1024

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -136,10 +136,9 @@ data "aws_iam_policy_document" "vpc_main_flow_log" {
 }
 
 resource "aws_subnet" "public" {
-  count      = length(var.aws_availability_zones)
-  vpc_id     = aws_vpc.main.id
-  cidr_block = cidrsubnet(aws_vpc.main.cidr_block, var.subnets_num_bits, count.index)
-
+  count             = length(var.aws_availability_zones)
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, var.subnets_num_bits, count.index)
   availability_zone = var.aws_availability_zones[count.index]
 
   tags = {
@@ -303,7 +302,7 @@ resource "aws_vpc" "datasets" {
   cidr_block = var.vpc_datasets_cidr
 
   enable_dns_support   = true
-  enable_dns_hostnames = false
+  enable_dns_hostnames = true
 
   tags = {
     Name = "${var.prefix}-datasets"
@@ -509,4 +508,311 @@ resource "aws_vpc_endpoint" "ecs" {
   security_group_ids  = ["${aws_security_group.ecs.id}"]
   subnet_ids          = ["${aws_subnet.private_with_egress.*.id[0]}"]
   private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "datasets_s3_endpoint" {
+  vpc_id          = aws_vpc.datasets.id
+  service_name    = "com.amazonaws.eu-west-2.s3"
+  route_table_ids = [aws_route_table.datasets.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-s3-endpoint"
+  }
+  policy = data.aws_iam_policy_document.datasets_s3_endpoint.json
+}
+
+data "aws_iam_policy_document" "datasets_s3_endpoint" {
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+
+      actions = [
+        "s3:GetObject",
+      ]
+
+      resources = [
+        "arn:aws:s3:::prod-${data.aws_region.aws_region.name}-starport-layer-bucket/*",
+      ]
+    }
+  }
+}
+
+resource "aws_vpc_endpoint" "datasets_ec2_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ec2"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ec2-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ec2.json
+}
+
+data "aws_iam_policy_document" "aws_datasets_endpoint_ec2" {
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_ec2[0].arn}"]
+      }
+
+      actions = [
+        "ec2:attachVolume",
+      ]
+
+      resources = [
+        "arn:aws:ec2:eu-west-2:${data.aws_caller_identity.aws_caller_identity.account_id}:instance/*",
+        "${aws_ebs_volume.arango[0].arn}"
+      ]
+    }
+  }
+}
+
+resource "aws_vpc_endpoint" "datasets_ec2messages_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ec2messages"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ec2messages-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ssm.json
+}
+
+resource "aws_vpc_endpoint" "datasets_ssm_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ssm"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ssm-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ssm.json
+}
+
+resource "aws_vpc_endpoint" "datasets_ssmmessages_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ssmmessages"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ssmmessages-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ssm.json
+}
+
+data "aws_iam_policy_document" "aws_datasets_endpoint_ssm" {
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_ec2[0].arn}"]
+      }
+
+      actions = [
+        "*"
+      ]
+
+      resources = [
+        "arn:aws:*:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:*"
+      ]
+    }
+  }
+}
+
+resource "aws_vpc_endpoint" "datasets_ecs_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ecs"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ecs-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ecs.json
+}
+
+resource "aws_vpc_endpoint" "datasets_ecs_agent_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ecs-agent"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ecs-agent-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ecs.json
+}
+
+resource "aws_vpc_endpoint" "datasets_ecs_telemetry_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ecs-telemetry"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ecs-telemetry-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ecs.json
+}
+
+data "aws_iam_policy_document" "aws_datasets_endpoint_ecs" {
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_ec2[0].arn}"]
+      }
+
+      actions = [
+        "*"
+      ]
+
+      resources = [
+        "*"
+      ]
+      condition {
+        test     = "ArnEquals"
+        variable = "ecs:cluster"
+        values = [
+          "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:cluster/${aws_ecs_cluster.main_cluster.name}"
+        ]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_ec2[0].arn}"]
+      }
+      actions = [
+        "*"
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
+  }
+}
+
+resource "aws_vpc_endpoint" "datasets_logs_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.logs"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-logs-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_logs.json
+}
+
+data "aws_iam_policy_document" "aws_datasets_endpoint_logs" {
+
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_task_execution[0].arn}"]
+      }
+
+      actions = [
+        "*",
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
+  }
+}
+
+resource "aws_vpc_endpoint" "datasets_ecr_api_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ecr.api"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ecr-api-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ecr.json
+}
+
+resource "aws_vpc_endpoint" "datasets_ecr_dkr_endpoint" {
+  vpc_id             = aws_vpc.datasets.id
+  service_name       = "com.amazonaws.eu-west-2.ecr.dkr"
+  vpc_endpoint_type  = "Interface"
+  subnet_ids         = aws_subnet.datasets.*.id
+  security_group_ids = [aws_security_group.datasets_endpoints.id]
+  tags = {
+    Environment = var.prefix
+    Name        = "datasets-ecr-dkr-endpoint"
+  }
+  private_dns_enabled = true
+  policy              = data.aws_iam_policy_document.aws_datasets_endpoint_ecr.json
+}
+
+
+data "aws_iam_policy_document" "aws_datasets_endpoint_ecr" {
+  # Contains policies for both ECR and DKR endpoints, as recommended
+
+  dynamic "statement" {
+    for_each = var.arango_on ? [0] : []
+    content {
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+
+      principals {
+        type        = "AWS"
+        identifiers = ["${aws_iam_role.arango_task_execution[0].arn}"]
+      }
+
+      actions = [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer"
+      ]
+
+      resources = [
+        "*",
+      ]
+    }
+  }
 }


### PR DESCRIPTION
(Optionally) adds Arango to Data Workspace

# ECS
Includes Arango ECS service connecting to the main ECS cluster.
ArangoDB instance run using EC2 to allow for Elastic Block Storage to attach to ArangoDB instances when spun up (auto-scaling group). There is a load balancer to connect the Data workspace tools to the ArangoDB instance.

# EBS
The EBS volume mounts to /data directory within the instance, and the ArangoDB container task definition mounts the instance's /data directory to /var/lib/arangodb3 directory within the container (as this is where data is stored in an Arango database).

# Connecting to ECS
As the Arango EC2 instance is in a private subnet and the Datasets VPC does not have access to the internet, VPC Endpoints were used too allow the EC2 insrtance to connect to ECS. The endpoints were placed in the Datasets VPC (which did require DNS hostnames to be enabled) and policies were created and attach to the endpoints to restrict access to only the Arango instance.