### PR TITLE
feat: tightening security groups between scheduler and webserver

### DIFF
--- a/infra/airflow_scheduler.tf
+++ b/infra/airflow_scheduler.tf
@@ -231,6 +231,17 @@ data "aws_iam_policy_document" "airflow_scheduler_task" {
       "${aws_iam_role.airflow_webserver_execution[count.index].arn}",
     ], [for team_role in aws_iam_role.airflow_team : team_role.arn])
   }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup"
+    ]
+
+    # Should be tighter
+    resources = [
+      "*"
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "airflow_scheduler_execution_ecs_tasks_assume_role" {

--- a/infra/airflow_scheduler.tf
+++ b/infra/airflow_scheduler.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_service" "airflow_scheduler" {
 
   network_configuration {
     subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
-    security_groups = ["${aws_security_group.airflow_webserver.id}"]
+    security_groups = ["${aws_security_group.airflow_scheduler.id}"]
   }
 }
 

--- a/infra/airflow_scheduler_container_definitions.json
+++ b/infra/airflow_scheduler_container_definitions.json
@@ -1,6 +1,7 @@
 [
   {
     "command": ${command},
+    "entryPoint": ["/home/vcap/app/dataflow/bin/aws-wrapper-no-git-sync.sh"],
     "environment": [{
       "name": "DB_HOST",
       "value": "${db_host}"

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -495,3 +495,18 @@ resource "aws_route_table_association" "datasets_quicksight" {
   subnet_id      = aws_subnet.datasets_quicksight.id
   route_table_id = aws_route_table.datasets.id
 }
+
+resource "aws_vpc_endpoint" "main_s3" {
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${data.aws_region.aws_region.name}.s3"
+  vpc_endpoint_type = "Gateway"
+}
+
+resource "aws_vpc_endpoint" "ecs" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecs"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = ["${aws_security_group.ecs.id}"]
+  subnet_ids          = ["${aws_subnet.private_with_egress.*.id[0]}"]
+  private_dns_enabled = true
+}


### PR DESCRIPTION
Currently scheduler and webserver share the same secuirty groups, meaning load server can connect to the scheduler when it should not be able to.

Therefore, we are spliting the security groups, one for scheduler and one for webserver.

This introduces a concept that we haven't used so far: "prefix lists" on a VPC endpoint. This means the scheduler doesn't need to talk to the world in order to pull its docker images from S3, and can just communicate with S3.

We should probably tighten up the permissions on the S3 endpoint, but leaving that to another change (because this change doesn't allow anything that wasn't previously allowed).

This also contains a change to allow the scheduler to create log groups, which seems to be required for it to create tasks. Although it's unknown why this wasn't noticed/needed before.