### PR TITLE
Remove Datasets DB creds and Sentry DSN from terraform for airflow containers

### DIFF
--- a/infra/airflow_dag_processor_container_definitions.json
+++ b/infra/airflow_dag_processor_container_definitions.json
@@ -20,26 +20,8 @@
       "name": "SECRET_KEY",
       "value": "${secret_key}"
     },{
-      "name": "SENTRY_DSN",
-      "value": "${sentry_dsn}"
-    },{
       "name": "SENTRY_ENVIRONMENT",
       "value": "${sentry_environment}"
-    },{
-      "name": "DATASETS_DB_HOST",
-      "value": "${datasets_db_host}"
-    },{
-      "name": "DATASETS_DB_NAME",
-      "value": "${datasets_db_name}"
-    },{
-      "name": "DATASETS_DB_PASSWORD",
-      "value": "${datasets_db_password}"
-    },{
-      "name": "DATASETS_DB_PORT",
-      "value": "${datasets_db_port}"
-    },{
-      "name": "DATASETS_DB_USER",
-      "value": "${datasets_db_user}"
     },{
       "name": "AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER",
       "value": "cloudwatch://${cloudwatch_log_group_arn}"

--- a/infra/airflow_dag_tasks_container_definitions.json
+++ b/infra/airflow_dag_tasks_container_definitions.json
@@ -16,26 +16,8 @@
       "name": "DB_USER",
       "value": "${db_user}"
     },{
-      "name": "SENTRY_DSN",
-      "value": "${sentry_dsn}"
-    },{
       "name": "SENTRY_ENVIRONMENT",
       "value": "${sentry_environment}"
-    },{
-      "name": "DATASETS_DB_HOST",
-      "value": "${datasets_db_host}"
-    },{
-      "name": "DATASETS_DB_NAME",
-      "value": "${datasets_db_name}"
-    },{
-      "name": "DATASETS_DB_PASSWORD",
-      "value": "${datasets_db_password}"
-    },{
-      "name": "DATASETS_DB_PORT",
-      "value": "${datasets_db_port}"
-    },{
-      "name": "DATASETS_DB_USER",
-      "value": "${datasets_db_user}"
     },{
       "name": "AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER",
       "value": "cloudwatch://${cloudwatch_log_group_arn}"


### PR DESCRIPTION
Removes environment variables that are currently exported from terraform that will be exported from AWS secrets manager during GOV.UK PaaS migration