### PR TITLE
feat: Airflow webserver connectability

### DIFF
--- a/infra/airflow_webserver_container_definitions.json
+++ b/infra/airflow_webserver_container_definitions.json
@@ -1,6 +1,7 @@
 [
   {
     "command": ${command},
+    "entryPoint": ["/home/vcap/app/dataflow/bin/aws-wrapper-no-git-sync.sh"],
     "environment": [{
       "name": "DB_HOST",
       "value": "${db_host}"


### PR DESCRIPTION
This does 2 things:

- It stops the Airflow webserver from attempting to connect to GitHub on startup. It shouldn't need to do this because the dag-processors and tasks themselves pull from GitHub.

- Uses a "service registry" to allow Airflow to be communcated with from inside Data Workspace without going via the public internet, and specifically under the DNS name "airflow.jupyterhub". This is to support Data Workspace's so-called derived/SQL pipelines to talk to Airflow without going over the public internet.