### PR TITLE
Add https as ArangoDB connection protocol env var

### DIFF
--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -72,6 +72,10 @@
       "value": "${arango_db__password}"
     },
     {
+      "name": "ARANGO_DB__PROTOCOL",
+      "value": "https"
+    },
+    {
       "name": "ALLOWED_HOSTS__1",
       "value": "${root_domain}"
     },


### PR DESCRIPTION
This PR specifies that the protocl for communicating with ArangoDB in non-local environments should be HTTPS rather than HTTP