### PR TITLE
Prefix the name of the ArangoDB EBS IAM policy with the AWS environment name

### DIFF
--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -357,7 +357,7 @@ data "aws_iam_policy_document" "arango_ebs" {
 
 resource "aws_iam_policy" "arango_ebs" {
   count       = var.arango_on ? 1 : 0
-  name        = "arango-ebs"
+  name        = "${var.prefix}-arango-ebs"
   description = "enable-mounting-of-ebs-volume"
   policy      = data.aws_iam_policy_document.arango_ebs[0].json
 }


### PR DESCRIPTION
This adds the AWS environment name prefix (dev-, staging- etc.) to the name of the IAM policy for the ArangoDB EBS, avoiding errors due to resources having the same name