### PR TITLE
 feature/store-airflow-bucket-as-env-var-on-ecs-task-def

### DIFF
--- a/infra/airflow_dag_processor.tf
+++ b/infra/airflow_dag_processor.tf
@@ -49,6 +49,8 @@ locals {
       team                = "${v}"
       team_secret_id      = "${var.prefix}/airflow/${v}"
       dag_sync_github_key = "${var.dag_sync_github_key}"
+
+      aws_s3_bucket = "${aws_s3_bucket.airflow[i].id}"
     }
   ]
 }

--- a/infra/airflow_dag_processor_container_definitions.json
+++ b/infra/airflow_dag_processor_container_definitions.json
@@ -34,6 +34,9 @@
     },{
       "name": "TEAM_SECRET_ID",
       "value": "${team_secret_id}"
+    },{
+      "name": "S3_IMPORT_DATA_BUCKET",
+      "value": "${aws_s3_bucket}"
     }
   ],
     "essential": true,


### PR DESCRIPTION
Store the bucket the ECS task can write to as an env var on the task definition