### PR TITLE
feature/assume-role-for-copy-between-s3-buckets-in-datahub-account

### DIFF
--- a/infra/airflow_s3.tf
+++ b/infra/airflow_s3.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "airflow" {
       }
 
       resources = [
-        "arn:aws:s3:::${aws_s3_bucket.airflow[count.index].id}/*",
+        "arn:aws:s3:::${aws_s3_bucket.airflow[count.index].id}/${var.s3_prefix_for_external_role_copy}/*",
       ]
 
       actions = [

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -253,7 +253,7 @@ variable "arango_ebs_volume_type" { default = "" }
 variable "arango_instance_type" { default = "" }
 variable "arango_image_id" { default = "" }
 
-
+variable "s3_prefix_for_external_role_copy" { default = "export-data" }
 
 locals {
   admin_container_name   = "jupyterhub-admin"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -175,7 +175,7 @@ variable "airflow_on" {
 variable "airflow_db_instance_class" {}
 variable "airflow_domain" {}
 variable "airflow_dag_processors" {
-  type    = list(any)
+  type    = list(object({ name = string, assume_roles = list(string) }))
   default = []
 }
 variable "airflow_bucket_infix" {}
@@ -252,6 +252,8 @@ variable "arango_ebs_volume_size" { default = "" }
 variable "arango_ebs_volume_type" { default = "" }
 variable "arango_instance_type" { default = "" }
 variable "arango_image_id" { default = "" }
+
+
 
 locals {
   admin_container_name   = "jupyterhub-admin"


### PR DESCRIPTION
- Change the `airflow_dag_processors` variable from being a list of strings, to a list of objects that contain the dag processer name as a property and other properties that can be added to these processors later. The first use of this is to add a list of roles the processor can assume, to allow copying to S3 in another AWS account. A separate PR will be raised to update the `airflow_dag_processors` variables in each environment in the gitlab repo. The variable will now look like this:

```
airflow_dag_processors = [
  { name = "TEAM_WITHOUT_ROLES", assume_roles : [] },
  { name = "TEAM_WITH_ROLES", assume_roles : ["arn:aws:iam::ACCOUNT_NUMBER:role/ROLE_NAME"] }
]
```



- Add a new statement to the IAM policy that allows a processor to assume roles in another AWS account if the `assume_roles` prop is populated

- Add a new statement that allows any assume roles in the `assume_roles` prop read access to the S3 bucket used by that processor