### PR TITLE
feat: put the Airflow webserver on a fixed public IP address

### DIFF
--- a/infra/airflow_webserver.tf
+++ b/infra/airflow_webserver.tf
@@ -48,21 +48,35 @@ resource "aws_service_discovery_service" "airflow" {
   }
 }
 
+resource "aws_eip" "airflow_webserver" {
+  count = var.airflow_on ? 1 : 0
+  vpc   = true
+
+  lifecycle {
+    # VPN routing may depend on this
+    prevent_destroy = false
+  }
+}
+
 resource "aws_lb" "airflow_webserver" {
   count                      = var.airflow_on ? 1 : 0
   name                       = "${var.prefix}-af-ws" # Having airflow-webserver in the name makes it > the limit of 32
-  load_balancer_type         = "application"
+  load_balancer_type         = "network"
   internal                   = false
   security_groups            = ["${aws_security_group.airflow_webserver_lb.id}"]
-  subnets                    = aws_subnet.public.*.id
   enable_deletion_protection = true
+
+  subnet_mapping {
+    subnet_id     = aws_subnet.public.*.id[0]
+    allocation_id = aws_eip.airflow_webserver[0].id
+  }
 }
 
 resource "aws_lb_listener" "airflow_webserver_443" {
   count             = var.airflow_on ? 1 : 0
   load_balancer_arn = aws_lb.airflow_webserver[count.index].arn
   port              = "443"
-  protocol          = "HTTPS"
+  protocol          = "TLS"
 
   ssl_policy      = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn = aws_acm_certificate_validation.airflow_webserver[count.index].certificate_arn
@@ -79,16 +93,14 @@ resource "aws_lb_target_group" "airflow_webserver_8080" {
   port        = "8080"
   vpc_id      = aws_vpc.main.id
   target_type = "ip"
-  protocol    = "HTTP"
+  protocol    = "TCP"
 
   health_check {
-    protocol            = "HTTP"
+    protocol            = "TCP"
     timeout             = 15
     interval            = 20
     healthy_threshold   = 2
     unhealthy_threshold = 5
-
-    path = "/health"
   }
 
   lifecycle {


### PR DESCRIPTION
This is maybe a bit odd, but it helps certain VPNs route requests appropriately, especially in the case of Airflow being on the subdomain of Data Workspace, which has a wildcard TLS certificate and can cause problems when users flip between Airflow and the rest of Data Workspace (and specifically browsers re-using the connection of one for another).

 This also meant moving to a network load balancer, since application load balancers apparently don't support fixed IP addresses.