### PR TITLE
fix: S3 endpoint in main VPC

### DIFF
--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -501,6 +501,11 @@ resource "aws_vpc_endpoint" "main_s3" {
   vpc_endpoint_type = "Gateway"
 }
 
+resource "aws_vpc_endpoint_route_table_association" "main_s3" {
+  vpc_endpoint_id = aws_vpc_endpoint.main_s3.id
+  route_table_id  = aws_route_table.private_with_egress.id
+}
+
 resource "aws_vpc_endpoint" "ecs" {
   vpc_id              = aws_vpc.main.id
   service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecs"


### PR DESCRIPTION
 We're seeing suspiciously high costs of the main Nat Gatway. We are now running our data pipelines through it, so some increase is to be expected, but it seems still a bit too high.

Reviewing our infrastructure made us realise that the S3 VPC endpoint, although it exists, is not attached to the route table, and so was unused. This means that for some of our S3-intensive pipelines, such as the pipelines that mirror large repositories and push then to S3, the data is going through the Nat Gateway _twice_: once to pull the data into memory in tasks, and then again when getting pushed to S3.

This won't help reduce costs of data on the way in, but hopefully it should eliminate all the costs from pushing data to S3.