### PR TITLE
feat: increase Arango healthcheck timeout and customisable memory

### DIFF
--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -139,16 +139,13 @@ resource "aws_ecs_task_definition" "arango_service" {
     container_name  = "arango"
     log_group       = "${aws_cloudwatch_log_group.arango[0].name}"
     log_region      = "${data.aws_region.aws_region.name}"
-    cpu             = "${local.arango_container_cpu}"
-    memory          = "${local.arango_container_memory}"
     root_password   = "${random_string.aws_arangodb_root_password[0].result}"
   })
 
   execution_role_arn       = aws_iam_role.arango_task_execution[0].arn
   task_role_arn            = aws_iam_role.arango_task[0].arn
   network_mode             = "awsvpc"
-  cpu                      = local.arango_container_cpu
-  memory                   = local.arango_container_memory
+  memory                   = var.arango_container_memory
   requires_compatibilities = ["EC2"]
 
   volume {
@@ -412,7 +409,8 @@ resource "aws_lb_target_group" "arango" {
 
   health_check {
     protocol            = "HTTP"
-    interval            = 10
+    interval            = 45
+    timeout             = 30
     healthy_threshold   = 2
     unhealthy_threshold = 2
     path                = "/_db/_system/_admin/aardvark/index.html"

--- a/infra/ecs_main_arango_container_definitions.json
+++ b/infra/ecs_main_arango_container_definitions.json
@@ -2,8 +2,6 @@
     {
       "name": "${container_name}",
       "image": "${container_image}",
-      "memoryReservation": ${memory},
-      "cpu": ${cpu},
       "essential": true,
       "portMappings": [{
           "containerPort": 8529,

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -252,6 +252,7 @@ variable "arango_ebs_volume_size" { default = "" }
 variable "arango_ebs_volume_type" { default = "" }
 variable "arango_instance_type" { default = "" }
 variable "arango_image_id" { default = "" }
+variable "arango_container_memory" { default = 1024 }
 
 locals {
   admin_container_name   = "jupyterhub-admin"
@@ -320,9 +321,7 @@ locals {
   flower_container_memory = 8192
   flower_container_cpu    = 1024
 
-  arango_container_memory = 1024
-  arango_container_cpu    = 2048
-  arango_container_port   = 8529
+  arango_container_port = 8529
 
   mlflow_container_memory = 8192
   mlflow_container_cpu    = 1024


### PR DESCRIPTION
This does 2 things

- Increases the healthcheck timeout for Arango - it looked like during normal usage it would take longer than the default (5 seconds?) and cause the instance to deregister

- Makes the memory allocated to Arango customisable, using the current as the default