### PR TITLE
feat: flexible admin rds storage

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -55,6 +55,10 @@ variable "admin_db_instance_allocated_storage" {
   type    = number
   default = 200
 }
+variable "admin_db_instance_max_allocated_storage" {
+  type    = number
+  default = 400
+}
 variable "admin_authbroker_client_id" {}
 variable "admin_authbroker_client_secret" {}
 variable "admin_authbroker_url" {}

--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -1,11 +1,12 @@
 resource "aws_db_instance" "admin" {
   identifier = "${var.prefix}-admin"
 
-  allocated_storage = var.admin_db_instance_allocated_storage
-  storage_type      = "gp2"
-  engine            = "postgres"
-  engine_version    = var.admin_db_instance_version
-  instance_class    = var.admin_db_instance_class
+  allocated_storage     = var.admin_db_instance_allocated_storage
+  max_allocated_storage = var.admin_db_instance_max_allocated_storage
+  storage_type          = "gp2"
+  engine                = "postgres"
+  engine_version        = var.admin_db_instance_version
+  instance_class        = var.admin_db_instance_class
 
   apply_immediately = true
 


### PR DESCRIPTION
* enable max allocated rds storage (autoscaling), running out of storage brings down prod and is a terraform-only fix (can't change storage on console once max storage is reached)