### PR TITLE
feat: mount home directory in tools in /home/dw-user

### DIFF
--- a/infra/ecs_notebooks_notebook_container_definitions.json
+++ b/infra/ecs_notebooks_notebook_container_definitions.json
@@ -26,6 +26,9 @@
     "mountPoints": [{
       "sourceVolume": "home_directory",
       "containerPath": "${home_directory}"
+    }, {
+      "sourceVolume": "home_directory",
+      "containerPath": "/home/dw-user"
     }]
   },
   {


### PR DESCRIPTION
As a step towards consistency between tools, now also mounting the tools home directory at /home/dw-user as well as /home/<tool-specific-name>.

Once deployed and all tools user /home/dw-user should be able to remove the /home/<tool-specific-name>