### PR TITLE
feat: allow multiple secrets for Airflow teams

### DIFF
--- a/infra/airflow_dag_processor.tf
+++ b/infra/airflow_dag_processor.tf
@@ -235,7 +235,20 @@ data "aws_iam_policy_document" "airflow_team" {
     ]
 
     resources = [
-      "arn:aws:secretsmanager:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:secret:${var.prefix}/airflow/${var.airflow_dag_processors[count.index].name}-*"
+      "arn:aws:secretsmanager:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:secret:${var.prefix}/airflow/${var.airflow_dag_processors[count.index].name}-*",
+      "arn:aws:secretsmanager:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:secret:${var.prefix}/airflow/${var.airflow_dag_processors[count.index].name}_2-*"
+    ]
+  }
+
+  # This just gives a permission to call BatchGetSecretValue, but doesn't actually give permission
+  # to look at any secret values themselves - secretsmanager:GetSecretValue does that
+  statement {
+    actions = [
+      "secretsmanager:BatchGetSecretValue"
+    ]
+
+    resources = [
+      "*"
     ]
   }
 


### PR DESCRIPTION
This gives Airflow teams access to a "_2" secret.

This is to work around the limitation that an AWS Secret has a max size of 64KB