### PR TITLE
Enable intelligent tiering on mirror bucket for objects > 128KB

### DIFF
--- a/infra/s3_mirrors.tf
+++ b/infra/s3_mirrors.tf
@@ -70,3 +70,21 @@ data "aws_iam_policy_document" "mirrors" {
     }
   }
 }
+
+resource "aws_s3_bucket_lifecycle_configuration" "intelligent_tier" {
+  count = var.mirrors_bucket_name != "" ? 1 : 0
+
+  bucket = aws_s3_bucket.mirrors.*.id[count.index]
+
+  rule {
+    id = "Move objects >128KB to Intelligent Tier"
+    # Objects smaller than 128 KB will not transition by default to any storage class
+
+    status = "Enabled"
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a disabled lifecycle rule that would move objects in the mirror bucket > 128KB into the S3 intelligent tier, which once enabled should save money