### PR TITLE
security policy change for private python index for ddat data science

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -927,7 +927,13 @@ data "aws_iam_policy_document" "gitlab_runner" {
       "ecr:GetDownloadUrlForLayer",
     ]
 
-    resources = "${aws_ecr_repository.theia.arn}"
+    resources = [
+      "${aws_ecr_repository.visualisation_base.arn}",
+      "${aws_ecr_repository.visualisation_base_r.arn}",
+      "${aws_ecr_repository.visualisation_base_rv4.arn}",
+      "${aws_ecr_repository.vscode.arn}",
+      "${aws_ecr_repository.theia.arn}",
+    ]
   }
 
 }
@@ -990,13 +996,7 @@ data "aws_iam_policy_document" "gitlab_runner_data_science" {
       "ecr:GetDownloadUrlForLayer",
     ]
 
-    resources = [
-      "${aws_ecr_repository.visualisation_base.arn}",
-      "${aws_ecr_repository.visualisation_base_r.arn}",
-      "${aws_ecr_repository.visualisation_base_rv4.arn}",
-      "${aws_ecr_repository.vscode.arn}",
-      "${aws_ecr_repository.theia.arn}",
-    ]
+    resources = "${aws_ecr_repository.theia.arn}"
   }
 
   # All for user-provided

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -927,13 +927,7 @@ data "aws_iam_policy_document" "gitlab_runner" {
       "ecr:GetDownloadUrlForLayer",
     ]
 
-    resources = [
-      "${aws_ecr_repository.visualisation_base.arn}",
-      "${aws_ecr_repository.visualisation_base_r.arn}",
-      "${aws_ecr_repository.visualisation_base_rv4.arn}",
-      "${aws_ecr_repository.vscode.arn}",
-      "${aws_ecr_repository.theia.arn}",
-    ]
+    resources = "${aws_ecr_repository.theia.arn}"
   }
 
 }

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -936,25 +936,6 @@ data "aws_iam_policy_document" "gitlab_runner" {
     ]
   }
 
-  # All for user-provided
-  statement {
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
-    ]
-    resources = [
-      "${aws_ecr_repository.user_provided.arn}",
-    ]
-  }
 }
 
 resource "aws_iam_policy_attachment" "gitlab_runner" {

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -996,7 +996,7 @@ data "aws_iam_policy_document" "gitlab_runner_data_science" {
       "ecr:GetDownloadUrlForLayer",
     ]
 
-    resources = "${aws_ecr_repository.theia.arn}"
+    resources = aws_ecr_repository.theia.arn
   }
 
   # All for user-provided

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -811,7 +811,7 @@ resource "aws_launch_configuration" "gitlab_runner_data_science" {
   # types of infrastructure
   image_id             = "ami-0749bd3fac17dc2cc"
   instance_type        = var.gitlab_runner_data_science_instance_type
-  iam_instance_profile = aws_iam_instance_profile.gitlab_runner[count.index].name
+  iam_instance_profile = aws_iam_instance_profile.gitlab_runner_data_science[count.index].name
   security_groups      = ["${aws_security_group.gitlab_runner[count.index].id}"]
   key_name             = aws_key_pair.shared.key_name
 
@@ -1034,10 +1034,6 @@ data "aws_iam_policy_document" "gitlab_runner_data_science" {
       "ecr:ListImages",
       "ecr:DescribeImages",
       "ecr:BatchGetImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
     ]
     resources = [
       "${aws_ecr_repository.user_provided.arn}",


### PR DESCRIPTION
This change allows ddat data science gitlab runner to list and put objects to their space in notebooks bucket for private python index.

List is needed to check what whl files are available in the package folder and create appropriate index html from gitlab CI pipeline. And Put is to push this html as well as the python build files.