### PR TITLE
feat: expire preview visualisation (user provided) images

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -10,7 +10,7 @@ resource "aws_ecr_repository" "user_provided" {
 
 resource "aws_ecr_lifecycle_policy" "user_provided_expire_untagged_after_one_day" {
   repository = aws_ecr_repository.user_provided.name
-  policy     = data.aws_ecr_lifecycle_policy_document.expire_untagged_after_one_day.json
+  policy     = data.aws_ecr_lifecycle_policy_document.expire_preview_and_untagged_after_one_day.json
 }
 
 resource "aws_ecr_repository" "admin" {
@@ -238,6 +238,42 @@ resource "aws_ecr_lifecycle_policy" "arango_expire_untagged_after_one_day" {
 data "aws_ecr_lifecycle_policy_document" "expire_untagged_after_one_day" {
   rule {
     priority = 1
+    selection {
+      tag_status   = "untagged"
+      count_type   = "sinceImagePushed"
+      count_unit   = "days"
+      count_number = 1
+    }
+  }
+}
+
+data "aws_ecr_lifecycle_policy_document" "expire_preview_and_untagged_after_one_day" {
+  # Match *--prod images, but expire them in 1000 years...
+  rule {
+    priority = 1
+    selection {
+      tag_status       = "tagged"
+      tag_pattern_list = ["*--prod"]
+      count_type       = "sinceImagePushed"
+      count_unit       = "days"
+      count_number     = 365000
+    }
+  }
+  # ... and images that don't match *--prod, but have "*--*" are "preview" and we expire them 1 day
+  # after they have been pushed
+  rule {
+    priority = 2
+    selection {
+      tag_status       = "tagged"
+      tag_pattern_list = ["*--*"]
+      count_type       = "sinceImagePushed"
+      count_unit       = "days"
+      count_number     = 1
+    }
+  }
+  # ... and just in case we somehow end up with untagged images, expire them after 1 day as well
+  rule {
+    priority = 3
     selection {
       tag_status   = "untagged"
       count_type   = "sinceImagePushed"


### PR DESCRIPTION
This adds to the lifecycle rules for preview visualisation (user provided) images. It should now expire preview images one day after they have been pushed.

In order to leave production images alone robustly, they now have a "--prod" suffix so they will match the rule with pattern "*--prod" that expires them in 1000 years. While odd, it seems to be the best way to make "*--prod" images _never_ expire.