### PR TITLE
add list object permissions to check for whl files in each package

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -1024,6 +1024,14 @@ data "aws_iam_policy_document" "gitlab_runner_data_science" {
   statement {
     actions = [
       "s3:ListBucket",
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.notebooks.id}",
+    ]
+  }
+
+  statement {
+    actions = [
       "s3:PutObject"
     ]
     resources = [


### PR DESCRIPTION
we need to create an index html at the root of package, for that it needs to list all available whl files and create the html. So it needs relevant permissions.