### PR TITLE
perf: delete expired object delete markers on notebooks bucket

### DIFF
--- a/infra/s3_notebooks.tf
+++ b/infra/s3_notebooks.tf
@@ -11,6 +11,9 @@ resource "aws_s3_bucket" "notebooks" {
     noncurrent_version_expiration {
       days = 365
     }
+    expiration {
+      expired_object_delete_marker = true
+    }
     abort_incomplete_multipart_upload_days = 7
   }
 


### PR DESCRIPTION
We have no need to keep the old delete markers, and apparently there is a performance benefit.