### PR TITLE
feat: move to single visualisation-base ECR repo, with lifecycle policy

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -929,8 +929,6 @@ data "aws_iam_policy_document" "gitlab_runner" {
 
     resources = [
       "${aws_ecr_repository.visualisation_base.arn}",
-      "${aws_ecr_repository.visualisation_base_r.arn}",
-      "${aws_ecr_repository.visualisation_base_rv4.arn}",
       "${aws_ecr_repository.vscode.arn}",
       "${aws_ecr_repository.theia.arn}",
     ]


### PR DESCRIPTION
We've now moved all visualisation-base images to a single ECR repo, and also use tagged images, so we

- Remove the language-specific visualisaiton base repos
- And give the remaining repo a lifecycle policy to cleanup old images, both for cost reasons and to save us being alerted on vulnrabilities on old images.