### PR TITLE
fix: visualisation-base lifecycle rule

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -281,20 +281,31 @@ data "aws_ecr_lifecycle_policy_document" "expire_preview_and_untagged_after_one_
 }
 
 data "aws_ecr_lifecycle_policy_document" "visualisation_base_expire_old_after_one_day" {
-  # Match tagged python and rv4 images, but expire them in 1000 years...
+  # Match tagged python, but expire them in 1000 years...
   rule {
     priority = 1
     selection {
       tag_status       = "tagged"
-      tag_pattern_list = ["python", "rv4"]
+      tag_pattern_list = ["python"]
       count_type       = "sinceImagePushed"
       count_unit       = "days"
       count_number     = 365000
     }
   }
-  # ... and images that don't match python and rv4, but have a tag, are cached layers
+  # otherwise match tagged rv4, but expire them in 1000 years...
   rule {
     priority = 2
+    selection {
+      tag_status       = "tagged"
+      tag_pattern_list = ["rv4"]
+      count_type       = "sinceImagePushed"
+      count_unit       = "days"
+      count_number     = 365000
+    }
+  }
+  # ... and images that don't match python or rv4, but have a tag, are cached layers
+  rule {
+    priority = 3
     selection {
       tag_status       = "tagged"
       tag_pattern_list = ["*"]
@@ -305,7 +316,7 @@ data "aws_ecr_lifecycle_policy_document" "visualisation_base_expire_old_after_on
   }
   # ... and for when we end up with untagged images, expire them after 1 day as well
   rule {
-    priority = 3
+    priority = 4
     selection {
       tag_status   = "untagged"
       count_type   = "sinceImagePushed"


### PR DESCRIPTION
This fixes the issue where "python" and "rv4" images were being expired from the visualisation-base repository.

I incorrectly thought that if an image matches any of the patterns in the tag_pattern_list in a rule, it would match the rule and stop processing. However, it has to match _all_ of the patterns.

So to fix the issue, the one rule that matches "python","rv4" is split into two rules.