### PR TITLE
Bugfix/simplify autoscaling

### DIFF
--- a/infra/modules/cloudwatch_alarm/sagemaker/variables.tf
+++ b/infra/modules/cloudwatch_alarm/sagemaker/variables.tf
@@ -1,6 +1,6 @@
-variable "alarm_name" {
+variable "alarm_name_prefix" {
   type        = string
-  description = "The name of the CloudWatch alarm"
+  description = "The name of the CloudWatch alarm (the endpoint name is added after)"
 }
 
 variable "metric_name" {
@@ -47,17 +47,4 @@ variable "datapoints_to_alarm" {
 variable "alarm_description" {
   type        = string
   description = "Description of the Alarm"
-}
-
-variable "endpoint_name" {
-  type        = string
-  description = "Endpoint name - typically /aws/sagemaker/Endpoints for sagemaker"
-}
-
-
-variable "variant_name" {
-  type        = string
-  description = "Vairant name of the endpoint"
-  nullable    = true
-  default     = ""
 }

--- a/infra/modules/logs/variables.tf
+++ b/infra/modules/logs/variables.tf
@@ -17,4 +17,3 @@ variable "endpoint_names" {
 variable "lambda_function_arn" {
   type = string
 }
-

--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -22,17 +22,16 @@ resource "aws_sagemaker_model" "sagemaker_model" {
     security_group_ids = var.security_group_ids
     subnets            = var.subnets
   }
-
 }
 
 resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
-  name = var.endpoint_config_name
+  name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint-config"
 
   production_variants {
-    variant_name           = var.variant_name
+    variant_name           = "AllTraffic"
     model_name             = aws_sagemaker_model.sagemaker_model.name
     instance_type          = var.instance_type
-    initial_instance_count = var.initial_instance_count
+    initial_instance_count = 1
   }
 
   async_inference_config {
@@ -47,7 +46,8 @@ resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
 }
 
 resource "aws_sagemaker_endpoint" "sagemaker_endpoint" {
-  name                 = var.endpoint_name
+  name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint"
+
   endpoint_config_name = aws_sagemaker_endpoint_configuration.endpoint_config.name
   depends_on           = [aws_sagemaker_endpoint_configuration.endpoint_config, var.sns_success_topic_arn]
 }
@@ -55,124 +55,102 @@ resource "aws_sagemaker_endpoint" "sagemaker_endpoint" {
 resource "aws_appautoscaling_target" "autoscaling_target" {
   max_capacity       = var.max_capacity
   min_capacity       = var.min_capacity
-  resource_id        = "endpoint/${aws_sagemaker_endpoint.sagemaker_endpoint.name}/variant/${var.variant_name}"
+  resource_id        = "endpoint/${aws_sagemaker_endpoint.sagemaker_endpoint.name}/variant/${aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name}" # Note this logic would not work if there were ever more than one production variant deployed for an LLM
   scalable_dimension = "sagemaker:variant:DesiredInstanceCount"
   service_namespace  = "sagemaker"
   depends_on         = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sagemaker_endpoint_configuration.endpoint_config]
 }
 
-resource "aws_appautoscaling_policy" "scale_up_policy" {
-  name               = "scale-up-policy-${var.model_name}"
+resource "aws_appautoscaling_policy" "scale_up_to_n_policy" {
+  name = "scale-up-to-n-policy-${var.model_name}"
+
   policy_type        = "StepScaling"
   resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
   scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
   service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
+  depends_on         = [aws_appautoscaling_target.autoscaling_target]
 
   step_scaling_policy_configuration {
-    adjustment_type         = "ChangeInCapacity"
-    metric_aggregation_type = "Average"
-    cooldown                = var.scale_up_cooldown
+    adjustment_type = "ChangeInCapacity"
+    cooldown        = var.scale_up_cooldown
 
     step_adjustment {
+      scaling_adjustment          = 1
       metric_interval_lower_bound = 0
-      scaling_adjustment          = var.scale_up_adjustment
+      metric_interval_upper_bound = null
     }
   }
 }
 
-resource "aws_appautoscaling_policy" "scale_in_to_zero_policy" {
-  name               = "scale-in-to-zero-policy-${var.model_name}"
+resource "aws_appautoscaling_policy" "scale_down_to_n_policy" {
+  name = "scale-down-to-n-policy-${var.model_name}"
+
   policy_type        = "StepScaling"
   resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
   scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
   service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
+  depends_on         = [aws_appautoscaling_target.autoscaling_target]
+
+  step_scaling_policy_configuration {
+    adjustment_type = "ChangeInCapacity"
+    cooldown        = var.scale_down_cooldown
+
+    step_adjustment {
+      scaling_adjustment          = -1
+      metric_interval_lower_bound = null
+      metric_interval_upper_bound = 0
+    }
+  }
+}
+
+
+resource "aws_appautoscaling_policy" "scale_up_to_one_policy" {
+  name = "scale-up-to-one-policy-${var.model_name}"
+
+  policy_type        = "StepScaling"
+  resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
+  scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
+  depends_on         = [aws_appautoscaling_target.autoscaling_target]
 
   step_scaling_policy_configuration {
     adjustment_type = "ExactCapacity"
-
-
-    step_adjustment {
-      metric_interval_lower_bound = null # No lower bound to cover everything
-      metric_interval_upper_bound = 5    # Upper bound is 5%
-      scaling_adjustment          = 0
-    }
+    cooldown        = var.scale_up_cooldown
 
     step_adjustment {
-      metric_interval_lower_bound = 5    # Lower bound starts at 5%
-      metric_interval_upper_bound = null # No upper bound
-      scaling_adjustment          = 1    # Maintains min capacity of one instance
+      scaling_adjustment          = 1 # means set =1 (NOT add or subtract)
+      metric_interval_lower_bound = 0
+      metric_interval_upper_bound = null
     }
-
-    cooldown = var.scale_in_to_zero_cooldown
   }
-  depends_on = [aws_appautoscaling_target.autoscaling_target]
 }
 
-resource "aws_appautoscaling_policy" "scale_in_to_zero_based_on_backlog" {
-  name               = "scale-in-to-zero-backlog-policy-${var.model_name}"
+resource "aws_appautoscaling_policy" "scale_down_to_zero_policy" {
+  name = "scale-down-to-zero-policy-${var.model_name}"
+
   policy_type        = "StepScaling"
   resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
   scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
   service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
-
+  depends_on         = [aws_appautoscaling_target.autoscaling_target]
 
   step_scaling_policy_configuration {
-    adjustment_type = "ExactCapacity" # Set the capacity exactly to zero
+    adjustment_type = "ExactCapacity"
+    cooldown        = var.scale_down_cooldown
 
-    # Step adjustment for when there are zero queries in the backlog
     step_adjustment {
-      metric_interval_lower_bound = null # No lower bound (cover everything below 0)
-      metric_interval_upper_bound = 0    # Exact match for zero backlog size
-      scaling_adjustment          = 0    # Set capacity to zero instances
+      scaling_adjustment          = 0 # means set =0 (NOT add or subtract)
+      metric_interval_lower_bound = null
+      metric_interval_upper_bound = 0
     }
-
-    # Falllback for any value above 0 to prevent overlap
-    step_adjustment {
-      metric_interval_lower_bound = 0    # No lower bound (cover everything below 0)
-      metric_interval_upper_bound = null # Exact match for zero backlog size
-      scaling_adjustment          = 1    # Set capacity to zero instances
-    }
-
-    cooldown = var.scale_in_to_zero_cooldown
-  }
-
-
-  depends_on = [aws_appautoscaling_target.autoscaling_target]
-}
-
-resource "aws_cloudwatch_log_metric_filter" "unatuhorized_operations" {
-  name           = "unauthorized-operations-filter"
-  log_group_name = var.log_group_name
-  pattern        = "{ $.errorCode = \"UnauthorizedOperation\" || $.errorCode = \"AccessDenied\" }"
-
-  metric_transformation {
-    name      = "UnauthorizedOperationsCount"
-    namespace = "CloudTrailMetrics"
-    value     = "1"
   }
 }
 
-# Local for alarms with SNS topics
-locals {
-  alarms_with_sns = [
-    for alarm in var.alarms : alarm
-    if alarm.sns_topic_name != null
-  ]
-}
-
-
-# Local for mapping SNS topic ARNs to Slack webhook URLs
-locals {
-  sns_to_webhook_mapping = {
-    for idx, alarm in local.alarms_with_sns :
-    aws_sns_topic.sns_topic[idx].arn => alarm.slack_webhook_url
-  }
-}
 
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   count = length(var.alarms)
 
-  alarm_name          = var.alarms[count.index].alarm_name
+  alarm_name          = "${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
   alarm_description   = var.alarms[count.index].alarm_description
   metric_name         = var.alarms[count.index].metric_name
   namespace           = var.alarms[count.index].namespace
@@ -182,36 +160,60 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   datapoints_to_alarm = var.alarms[count.index].datapoints_to_alarm
   period              = var.alarms[count.index].period
   statistic           = var.alarms[count.index].statistic
+  alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
+  ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
+  dimensions          = count.index == 0 ? {  # TODO: this logic is brittle as it assumes "backlog" has index 0; it would be better to have a logic that rests on the specific name of that metric
+                                              EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name  # Only EndpointName is used in this case
+                                              } : {
+                                              EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,  # Both EndpointName and VariantName are used in all other cases
+                                              VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name  # Note this logic would not work if there were ever more than one production variant deployed for an LLM
+                                            }
 
-  # Define dimensions based on the count index -
-  # first alarm will not have a null variantName
-  dimensions = count.index == 0 ? {
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name
-    } : {
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,
-    VariantName  = var.variant_name
-  }
 
-  # Conditionally add SNS topics as alarm actions & lazy eval
-  alarm_actions = concat(
-    var.alarms[count.index].alarm_actions != null ? var.alarms[count.index].alarm_actions : [],
-    var.alarms[count.index].sns_topic_name != null ? [
-      lookup(
-        { for idx, alarm in local.alarms_with_sns :
-          alarm.sns_topic_name => aws_sns_topic.sns_topic[idx].arn
-        },
-        var.alarms[count.index].sns_topic_name,
-        null
-      )
-    ] : []
-  )
-
+  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
 }
 
-resource "aws_sns_topic" "sns_topic" {
-  count = length(local.alarms_with_sns)
+resource "aws_sns_topic" "sns_topic_alarmstate" {
+  count = length(var.alarms)
 
-  name = local.alarms_with_sns[count.index].sns_topic_name
+  name       = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "sns:Publish",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_permission" "allow_sns_alarmstate" {
+  count = length(var.alarms)
+
+  statement_id  = "AllowSNS-alarm-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+}
+
+resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
+  count = length(var.alarms)
+
+  topic_arn = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_alert_function.arn
+}
+
+resource "aws_sns_topic" "sns_topic_okstate" {
+  count = length(var.alarms)
+
+  name       = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -222,25 +224,40 @@ resource "aws_sns_topic" "sns_topic" {
           Service = "cloudwatch.amazonaws.com"
         },
         Action   = "sns:Publish",
-        Resource = "arn:aws:sns:eu-west-2:${var.aws_account_id}:${local.alarms_with_sns[count.index].sns_topic_name}"
+        Resource = "*"
       }
     ]
   })
-
-  lifecycle {
-    prevent_destroy = false
-  }
 }
 
+resource "aws_lambda_permission" "allow_sns_okstate" {
+  count = length(var.alarms)
 
-resource "aws_sns_topic_subscription" "sns_lambda_subscription" {
-  count = length(local.alarms_with_sns)
+  statement_id  = "AllowSNS-ok-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topic_okstate[count.index].arn
+}
 
-  topic_arn = aws_sns_topic.sns_topic[count.index].arn
+resource "aws_sns_topic_subscription" "sns_lambda_subscription_okstate" {
+  count = length(var.alarms)
+
+  topic_arn = aws_sns_topic.sns_topic_okstate[count.index].arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.slack_alert_function.arn
 }
 
+# Mpping SNS topic ARNs to Slack webhook URLs
+locals {
+  sns_to_webhook_mapping = merge({
+    for idx, alarm in var.alarms :
+    aws_sns_topic.sns_topic_alarmstate[idx].arn => alarm.slack_webhook_url
+    }, {
+    for idx, alarm in var.alarms :
+    aws_sns_topic.sns_topic_okstate[idx].arn => alarm.slack_webhook_url
+  })
+}
 
 data "archive_file" "lambda_payload" {
   type        = "zip"
@@ -249,7 +266,6 @@ data "archive_file" "lambda_payload" {
 }
 
 
-# Lambda Function for Slack Alerts
 resource "aws_lambda_function" "slack_alert_function" {
   filename         = data.archive_file.lambda_payload.output_path
   source_code_hash = data.archive_file.lambda_payload.output_base64sha256
@@ -312,12 +328,15 @@ resource "aws_iam_role_policy_attachment" "slack_lambda_policy_attachment" {
   policy_arn = aws_iam_policy.slack_lambda_policy.arn
 }
 
-resource "aws_lambda_permission" "allow_sns" {
-  count = length(local.alarms_with_sns)
 
-  statement_id  = "AllowSNS-${count.index}"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.slack_alert_function.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic[count.index].arn
+resource "aws_cloudwatch_log_metric_filter" "unauthorized_operations" {
+  name           = "unauthorized-operations-filter"
+  log_group_name = "/aws/sagemaker/Endpoints/${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  pattern        = "{ $.errorCode = \"UnauthorizedOperation\" || $.errorCode = \"AccessDenied\" }"
+
+  metric_transformation {
+    name      = "UnauthorizedOperationsCount"
+    namespace = "CloudTrailMetrics"
+    value     = "1"
+  }
 }

--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -162,12 +162,12 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   statistic           = var.alarms[count.index].statistic
   alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
   ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
-  dimensions          = count.index == 0 ? {  # TODO: this logic is brittle as it assumes "backlog" has index 0; it would be better to have a logic that rests on the specific name of that metric
-                                              EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name  # Only EndpointName is used in this case
-                                              } : {
-                                              EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,  # Both EndpointName and VariantName are used in all other cases
-                                              VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name  # Note this logic would not work if there were ever more than one production variant deployed for an LLM
-                                            }
+  dimensions = count.index == 0 ? {                               # TODO: this logic is brittle as it assumes "backlog" has index 0; it would be better to have a logic that rests on the specific name of that metric
+    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name # Only EndpointName is used in this case
+    } : {
+    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,                                          # Both EndpointName and VariantName are used in all other cases
+    VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
+  }
 
 
   depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
@@ -176,7 +176,7 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
 resource "aws_sns_topic" "sns_topic_alarmstate" {
   count = length(var.alarms)
 
-  name       = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -213,7 +213,7 @@ resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
 resource "aws_sns_topic" "sns_topic_okstate" {
   count = length(var.alarms)
 
-  name       = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
 
   policy = jsonencode({
     Version = "2012-10-17",

--- a/infra/modules/sagemaker_deployment/outputs.tf
+++ b/infra/modules/sagemaker_deployment/outputs.tf
@@ -6,23 +6,18 @@ output "endpoint_name" {
   value = aws_sagemaker_endpoint.sagemaker_endpoint.name
 }
 
-output "scale_up_policy_arn" {
-  value = aws_appautoscaling_policy.scale_up_policy.arn
+output "scale_up_to_one_policy_arn" {
+  value = aws_appautoscaling_policy.scale_up_to_one_policy.arn
 }
 
-output "scale_in_to_zero_policy_arn" {
-  value = aws_appautoscaling_policy.scale_in_to_zero_policy.arn
+output "scale_down_to_zero_policy_arn" {
+  value = aws_appautoscaling_policy.scale_down_to_zero_policy.arn
 }
 
-output "scale_in_to_zero_based_on_backlog_arn" {
-  description = "ARN of the autoscaling policy to scale in to zero for backlog queries when 0 for x minutes"
-  value       = aws_appautoscaling_policy.scale_in_to_zero_based_on_backlog.arn
+output "scale_up_to_n_policy_arn" {
+  value = aws_appautoscaling_policy.scale_up_to_n_policy.arn
 }
 
-output "sns_topic_arns" {
-  value = [for sns in aws_sns_topic.sns_topic : sns.arn]
-}
-
-output "sns_to_webhook_mapping" {
-  value = local.sns_to_webhook_mapping
+output "scale_down_to_n_policy_arn" {
+  value = aws_appautoscaling_policy.scale_down_to_n_policy.arn
 }

--- a/infra/modules/sagemaker_deployment/variables.tf
+++ b/infra/modules/sagemaker_deployment/variables.tf
@@ -8,6 +8,11 @@ variable "model_name" {
   description = "Name of the SageMaker model"
 }
 
+variable "s3_output_path" {
+  type        = string
+  description = "Where the async output of the model is sent"
+}
+
 variable "execution_role_arn" {
   type        = string
   description = "Execution role ARN for SageMaker"
@@ -43,35 +48,9 @@ variable "subnets" {
   description = "List of subnets for the SageMaker model"
 }
 
-variable "endpoint_config_name" {
-  type        = string
-  description = "Name of the endpoint configuration"
-}
-
-variable "endpoint_name" {
-  type        = string
-  description = "Name of the SageMaker endpoint"
-}
-
-variable "variant_name" {
-  type        = string
-  description = "Name of the production variant"
-  default     = null
-}
-
 variable "instance_type" {
   type        = string
   description = "Instance type for the endpoint"
-}
-
-variable "initial_instance_count" {
-  type        = number
-  description = "Initial instance count for the endpoint"
-}
-
-variable "s3_output_path" {
-  type        = string
-  description = "S3 output path for async inference"
 }
 
 variable "max_capacity" {
@@ -84,17 +63,12 @@ variable "min_capacity" {
   description = "Minimum capacity for autoscaling"
 }
 
-variable "scale_up_adjustment" {
-  type        = number
-  description = "Number of instances to scale up by"
-}
-
 variable "scale_up_cooldown" {
   type        = number
   description = "Cooldown period for scale up"
 }
 
-variable "scale_in_to_zero_cooldown" {
+variable "scale_down_cooldown" {
   type        = number
   description = "Cooldown period for scale down"
 }
@@ -102,7 +76,7 @@ variable "scale_in_to_zero_cooldown" {
 
 variable "alarms" {
   type = list(object({
-    alarm_name          = string
+    alarm_name_prefix   = string
     alarm_description   = string
     metric_name         = string
     namespace           = string
@@ -112,23 +86,13 @@ variable "alarms" {
     datapoints_to_alarm = number
     period              = number
     statistic           = string
-    sns_topic_name      = optional(string, null)
-    slack_webhook_url   = optional(string, null)
-    alarm_actions       = optional(list(string), null)
+    slack_webhook_url   = string
+    alarm_actions       = list(string)
+    ok_actions          = list(string)
   }))
   description = "List of CloudWatch alarms to be created"
 }
 
-variable "log_group_name" {
-  type        = string
-  description = "log group name, i.e. gpt-neo-125m..."
-  default     = ""
-}
-
 variable "aws_account_id" {
-  type = string
-}
-
-variable "slack_lambda_name" {
   type = string
 }

--- a/infra/modules/sagemaker_init/domain/variables.tf
+++ b/infra/modules/sagemaker_init/domain/variables.tf
@@ -3,7 +3,6 @@ variable "domain_name" {
   description = "The Domain name of the service, i.e. SageMaker"
 }
 
-
 variable "vpc_id" {
   type        = string
   description = "VPC ID"

--- a/infra/modules/sagemaker_init/iam/outputs.tf
+++ b/infra/modules/sagemaker_init/iam/outputs.tf
@@ -13,7 +13,6 @@ output "default_sagemaker_bucket" {
   value       = data.aws_s3_bucket.sagemaker_default_bucket
 }
 
-# Output for Lambda Execution Role ARN
 output "lambda_execution_role_arn" {
   value       = aws_iam_role.lambda_execution_role.arn
   description = "The ARN of the Lambda execution role"

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -3,17 +3,6 @@ resource "aws_sns_topic" "budget_alert_topic" {
   policy = data.aws_iam_policy_document.budget_publish_policy.json
 }
 
-resource "aws_sns_topic" "unauthorised_access_topic" {
-  name   = "${var.prefix}-unauthorised-access-alert-topic"
-  policy = data.aws_iam_policy_document.unauthorised_access_policy.json
-}
-
-resource "aws_sns_topic_subscription" "email_subscription" {
-  topic_arn = aws_sns_topic.unauthorised_access_topic.arn
-  protocol  = "email"
-  endpoint  = var.notification_email[0]
-}
-
 data "aws_iam_policy_document" "budget_publish_policy" {
   statement {
     actions = ["SNS:Publish"]
@@ -27,18 +16,3 @@ data "aws_iam_policy_document" "budget_publish_policy" {
     ]
   }
 }
-
-data "aws_iam_policy_document" "unauthorised_access_policy" {
-  statement {
-    actions = ["SNS:Publish"]
-    effect  = "Allow"
-    principals {
-      type        = "Service"
-      identifiers = ["cloudwatch.amazonaws.com"]
-    }
-    resources = [
-      "arn:aws:sns:eu-west-2:${var.account_id}:${var.prefix}-unauthorised-access-alert-topic"
-    ]
-  }
-}
-

--- a/infra/modules/sns/outputs.tf
+++ b/infra/modules/sns/outputs.tf
@@ -1,7 +1,3 @@
 output "sns_topic_arn" {
   value = aws_sns_topic.budget_alert_topic.arn
 }
-
-output "unauthorised_access_sns_topic_arn" {
-  value = aws_sns_topic.unauthorised_access_topic.arn
-}

--- a/infra/modules/sns/variables.tf
+++ b/infra/modules/sns/variables.tf
@@ -7,8 +7,3 @@ variable "account_id" {
   type        = string
   description = "account ID for the SNS topic"
 }
-
-variable "notification_email" {
-  type        = list(string)
-  description = "Emails for SNS subscription"
-}

--- a/infra/sagemaker_llm_resources.tf
+++ b/infra/sagemaker_llm_resources.tf
@@ -1,26 +1,28 @@
+# TODO: better if this is not required to be stated explicitly as it is brittle
 locals {
-  all_endpoint_names = [
-    module.gpt_neo_125m_deployment.endpoint_name,
-    module.phi_2_3b_deployment.endpoint_name,
-    module.mistral_7b_deployment.endpoint_name,
-    module.gemma_2_27b_deployment.endpoint_name,
-    #module.llama_3_70b_deployment.endpoint_name,
-    #module.falcon_bf16_180b_deployment.endpoint_name,
+  all_llm_names = [
+    module.gpt_neo_125m_deployment.model_name,
+    module.phi_2_3b_deployment.model_name,
+    module.mistral_7b_deployment.model_name,
+    module.gemma_2_27b_deployment.model_name,
+    module.llama_3_70b_deployment.model_name,
+    #module.falcon_bf16_180b_deployment.model_name,
   ]
 }
 
 ################
 # GPT Neo 125m
 ###############
-
 module "gpt_neo_125m_deployment" {
-  source                = "./modules/sagemaker_deployment"
   model_name            = "gpt-neo-125m"
-  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn    = module.iam.inference_role
   container_image       = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4.0-gpu-py310-cu121-ubuntu20.04"
   model_uri             = "s3://jumpstart-cache-prod-eu-west-2/huggingface-textgeneration1/huggingface-textgeneration1-gpt-neo-125m/artifacts/inference-prepack/v2.0.0/"
   model_uri_compression = "None"
+  instance_type         = "ml.g5.2xlarge" # 8 vCPU and 1 GPU and 32 GB-RAM
+  max_capacity          = 2
+  min_capacity          = 0
+  scale_up_cooldown     = 0
+  scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
     "HF_MODEL_ID" : "/opt/ml/model",
@@ -32,187 +34,198 @@ module "gpt_neo_125m_deployment" {
     "SAGEMAKER_PROGRAM" : "inference.py",
     "SM_NUM_GPUS" : "1"
   }
-  instance_type             = "ml.g5.2xlarge" # 8 vCPU and 1 GPU and 32 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-gpt-neo-125m"
-  endpoint_name             = "gpt-neo-125m-endpoint"
-  variant_name              = "gpt-neo-125m-endpoint-dev"
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
-  initial_instance_count    = 1
-  max_capacity              = 2
-  min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 60
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.gpt_neo_125m_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
+      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description   = "Scale based on existence of backlog or not"
+      metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
       comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
+      period              = 60
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_to_one_policy_arn]
+      ok_actions          = [module.gpt_neo_125m_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
+      alarm_name_prefix   = "high-cpu"
+      alarm_description   = "Scale up when CPU usage is heavy"
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 8 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-backlog-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 8 # TODO: Number of vCPUs
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 8  # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.gpt_neo_125m_deployment.endpoint_name}"
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-memory-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
+      alarm_name_prefix   = "low-cpu"
+      alarm_description   = "Scale down when CPU usage is light"
+      metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 8  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-GPU-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
+      alarm_name_prefix   = "high-gpu"
+      alarm_description   = "Scale up when GPU usage is heavy"
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 1 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "disk-util-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Inocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01 # Assumes 200 queries within 5 minutes, so 1% of that figure
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "error-rate-high-${module.gpt_neo_125m_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "unathorized-operations-alarm-${module.gpt_neo_125m_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefix   = "low-gpu"
+      alarm_description   = "Scale down when GPU usage is light"
+      metric_name         = "GPUUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-ram"
+      alarm_description   = "Scale up when RAM usage is heavy"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-ram"
+      alarm_description   = "Scale down when RAM usage is light"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-hard-disk"
+      alarm_description   = "Scale up when Hard Disk usage is heavy"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-hard-disk"
+      alarm_description   = "Scale down when Hard Disk usage is light"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gpt_neo_125m_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
-      comparison_operator = "GreaterThanThreshold"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-${module.gpt_neo_125m_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "errors-4XX"
+      alarm_description   = "4XX errors are detected in the CloudTrail Logs"
+      metric_name         = "Invocation4XXErrors"
+      namespace           = "AWS/SageMaker"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 1
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Sum"
+      slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.gpt_neo_125m_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                = "./modules/sagemaker_deployment"
+  security_group_ids    = [aws_security_group.notebooks.id]
+  subnets               = aws_subnet.private_without_egress.*.id
+  s3_output_path        = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id        = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn    = module.iam.inference_role
 }
-
-
 
 ###############
 # Phi 2 3b
 ###############
 module "phi_2_3b_deployment" {
-  source                = "./modules/sagemaker_deployment"
   model_name            = "phi-2-3b"
-  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn    = module.iam.inference_role
   container_image       = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4.2-gpu-py310-cu121-ubuntu22.04"
   model_uri             = "s3://jumpstart-cache-prod-eu-west-2/huggingface-llm/huggingface-llm-phi-2/artifacts/inference-prepack/v1.0.0/"
   model_uri_compression = "None"
+  instance_type         = "ml.g5.xlarge" # 4 vCPU and 1 GPU and 16 GB-RAM
+  max_capacity          = 2
+  min_capacity          = 0
+  scale_up_cooldown     = 0
+  scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
     "HF_MODEL_ID" : "/opt/ml/model",
@@ -223,172 +236,183 @@ module "phi_2_3b_deployment" {
     "SAGEMAKER_MODEL_SERVER_WORKERS" : "1",
     "SAGEMAKER_PROGRAM" : "inference.py"
   }
-  instance_type             = "ml.g5.xlarge" # 4 vCPU and 1 GPU and 16 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-phi-2-3b"
-  endpoint_name             = "phi-2-3b-endpoint"
-  variant_name              = "phi-2-3b-endpoint-dev"
-  initial_instance_count    = 1
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
-  max_capacity              = 2
-  min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 30
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.phi_2_3b_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
+      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description   = "Scale based on existence of backlog or not"
+      metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
       comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.phi_2_3b_deployment.endpoint_name}"
+      period              = 60
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_up_to_one_policy_arn]
+      ok_actions          = [module.phi_2_3b_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
+      alarm_name_prefix   = "high-cpu"
+      alarm_description   = "Scale up when CPU usage is heavy"
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 4 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-in-backlog-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 4 # TODO: Number of vCPUs
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 4  # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.phi_2_3b_deployment.endpoint_name}"
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-memory-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
+      alarm_name_prefix   = "low-cpu"
+      alarm_description   = "Scale down when CPU usage is light"
+      metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 4  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-GPU-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
+      alarm_name_prefix   = "high-gpu"
+      alarm_description   = "Scale up when GPU usage is heavy"
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 1 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.phi_2_3b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10 # More than 10 requests requires scale up
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "dik-util-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Invocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01 # Assumes 200 queries within 5 minutes, so 1% of that figure
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "High-error-rate-operations-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "unathorized-operations-alarm-${module.phi_2_3b_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefix   = "low-gpu"
+      alarm_description   = "Scale down when GPU usage is light"
+      metric_name         = "GPUUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-ram"
+      alarm_description   = "Scale up when RAM usage is heavy"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-ram"
+      alarm_description   = "Scale down when RAM usage is light"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-hard-disk"
+      alarm_description   = "Scale up when Hard Disk usage is heavy"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-hard-disk"
+      alarm_description   = "Scale down when Hard Disk usage is light"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.phi_2_3b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
-      comparison_operator = "GreaterThanThreshold"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-alarm-${module.phi_2_3b_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "errors-4XX"
+      alarm_description   = "4XX errors are detected in the CloudTrail Logs"
+      metric_name         = "Invocation4XXErrors"
+      namespace           = "AWS/SageMaker"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 1
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Sum"
+      slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.phi_2_3b_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                = "./modules/sagemaker_deployment"
+  security_group_ids    = [aws_security_group.notebooks.id]
+  subnets               = aws_subnet.private_without_egress.*.id
+  s3_output_path        = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id        = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn    = module.iam.inference_role
 }
 
 
@@ -396,13 +420,15 @@ module "phi_2_3b_deployment" {
 # Mistral 7b
 ###############
 module "mistral_7b_deployment" {
-  source                = "./modules/sagemaker_deployment"
   model_name            = "mistral-7b"
-  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn    = module.iam.inference_role
   container_image       = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.3.0-tgi2.0.3-gpu-py310-cu121-ubuntu22.04"
   model_uri             = "s3://jumpstart-cache-prod-eu-west-2/huggingface-llm/huggingface-llm-mistral-7b-v3/artifacts/inference-prepack/v1.0.0/"
   model_uri_compression = "None"
+  instance_type         = "ml.g5.12xlarge" # 48 vCPU and 4 GPU and 192 GB-RAM
+  max_capacity          = 2
+  min_capacity          = 0
+  scale_up_cooldown     = 0
+  scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
     "HF_MODEL_ID" : "/opt/ml/model",
@@ -414,172 +440,183 @@ module "mistral_7b_deployment" {
     "SAGEMAKER_MODEL_SERVER_WORKERS" : "1",
     "SAGEMAKER_PROGRAM" : "inference.py"
   }
-  instance_type             = "ml.g5.12xlarge" # 48 vCPU and 4 GPU and 192 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-mistral-7b"
-  endpoint_name             = "mistral-7b-endpoint"
-  variant_name              = "mistral-7b-endpoint-dev"
-  initial_instance_count    = 1
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
-  max_capacity              = 2
-  min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 30
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.mistral_7b_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
+      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description   = "Scale based on existence of backlog or not"
+      metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
       comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.mistral_7b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.mistral_7b_deployment.endpoint_name}"
+      period              = 60
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_up_to_one_policy_arn]
+      ok_actions          = [module.mistral_7b_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
+      alarm_name_prefix   = "high-cpu"
+      alarm_description   = "Scale up when CPU usage is heavy"
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 48 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.mistral_7b_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.mistral_7b_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-in-backlog-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 48 # TODO: Number of vCPUs
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 48  # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.mistral_7b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.mistral_7b_deployment.endpoint_name}"
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-memory-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
+      alarm_name_prefix   = "low-cpu"
+      alarm_description   = "Scale down when CPU usage is light"
+      metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 48  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.mistral_7b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-GPU-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
+      alarm_name_prefix   = "high-gpu"
+      alarm_description   = "Scale up when GPU usage is heavy"
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 4 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.mistral_7b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "dik-util-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Invocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 4  # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "High-error-rate-operations-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "unathorized-operations-alarm-${module.mistral_7b_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefix   = "low-gpu"
+      alarm_description   = "Scale down when GPU usage is light"
+      metric_name         = "GPUUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 4  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-ram"
+      alarm_description   = "Scale up when RAM usage is heavy"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-ram"
+      alarm_description   = "Scale down when RAM usage is light"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-hard-disk"
+      alarm_description   = "Scale up when Hard Disk usage is heavy"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-hard-disk"
+      alarm_description   = "Scale down when Hard Disk usage is light"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.mistral_7b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
-      comparison_operator = "GreaterThanThreshold"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-alarm-${module.mistral_7b_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "errors-4XX"
+      alarm_description   = "4XX errors are detected in the CloudTrail Logs"
+      metric_name         = "Invocation4XXErrors"
+      namespace           = "AWS/SageMaker"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 1
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Sum"
+      slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.mistral_7b_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                = "./modules/sagemaker_deployment"
+  security_group_ids    = [aws_security_group.notebooks.id]
+  subnets               = aws_subnet.private_without_egress.*.id
+  s3_output_path        = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id        = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn    = module.iam.inference_role
 }
 
 
@@ -587,13 +624,15 @@ module "mistral_7b_deployment" {
 # Gemma 2 27b
 ###############
 module "gemma_2_27b_deployment" {
-  source                = "./modules/sagemaker_deployment"
   model_name            = "gemma-2-27b"
-  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn    = module.iam.inference_role
   container_image       = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.4.0-tgi2.3.1-gpu-py311-cu124-ubuntu22.04"
   model_uri             = "s3://jumpstart-private-cache-prod-eu-west-2/huggingface-llm/huggingface-llm-gemma-2-27b/artifacts/inference-prepack/v1.0.0/"
   model_uri_compression = "None"
+  instance_type         = "ml.g5.48xlarge" # 192 vCPU and 8 GPU and 768 GB-RAM
+  max_capacity          = 2
+  min_capacity          = 0
+  scale_up_cooldown     = 0
+  scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
     "HF_MODEL_ID" : "/opt/ml/model",
@@ -604,189 +643,204 @@ module "gemma_2_27b_deployment" {
     "SAGEMAKER_PROGRAM" : "inference.py",
     "SM_NUM_GPUS" : "8"
   }
-  instance_type             = "ml.g5.48xlarge" # 192 vCPU and 8 GPU and 768 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-gemma-2-27b"
-  endpoint_name             = "gemma-2-27b-endpoint"
-  variant_name              = "gemma-2-27b-endpoint-dev"
-  initial_instance_count    = 1
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
-  max_capacity              = 2
-  min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 30
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.gemma_2_27b_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
+      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description   = "Scale based on existence of backlog or not"
+      metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
       comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
+      period              = 60
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_to_one_policy_arn]
+      ok_actions          = [module.gemma_2_27b_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
+      alarm_name_prefix   = "high-cpu"
+      alarm_description   = "Scale up when CPU usage is heavy"
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 192 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-in-backlog-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 192 # TODO: Number of vCPUs
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 192  # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.gemma_2_27b_deployment.endpoint_name}"
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-memory-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
+      alarm_name_prefix   = "low-cpu"
+      alarm_description   = "Scale down when CPU usage is light"
+      metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 192  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-GPU-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
+      alarm_name_prefix   = "high-gpu"
+      alarm_description   = "Scale up when GPU usage is heavy"
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 8 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "dik-util-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Invocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 8  # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "High-error-rate-operations-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "unathorized-operations-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefix   = "low-gpu"
+      alarm_description   = "Scale down when GPU usage is light"
+      metric_name         = "GPUUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 8  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-ram"
+      alarm_description   = "Scale up when RAM usage is heavy"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-ram"
+      alarm_description   = "Scale down when RAM usage is light"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-hard-disk"
+      alarm_description   = "Scale up when Hard Disk usage is heavy"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-hard-disk"
+      alarm_description   = "Scale down when Hard Disk usage is light"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.gemma_2_27b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
-      comparison_operator = "GreaterThanThreshold"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-alarm-${module.gemma_2_27b_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "errors-4XX"
+      alarm_description   = "4XX errors are detected in the CloudTrail Logs"
+      metric_name         = "Invocation4XXErrors"
+      namespace           = "AWS/SageMaker"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 1
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Sum"
+      slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.gemma_2_27b_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                = "./modules/sagemaker_deployment"
+  security_group_ids    = [aws_security_group.notebooks.id]
+  subnets               = aws_subnet.private_without_egress.*.id
+  s3_output_path        = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id        = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn    = module.iam.inference_role
 }
 
 
-/*
+
 ###############
 # Llama 3 70b
 ###############
-
 module "llama_3_70b_deployment" {
-  source                = "./modules/sagemaker_deployment"
   model_name            = "llama-3-70b"
-  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn    = module.iam.inference_role
   container_image       = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/djl-inference:0.31.0-lmi13.0.0-cu124"
   model_uri             = "s3://jumpstart-private-cache-prod-eu-west-2/meta-textgeneration/meta-textgeneration-llama-3-3-70b-instruct/artifacts/inference-prepack/v2.0.0/"
   model_uri_compression = "None"
+  instance_type         = "ml.p4d.24xlarge" # 96 vCPU and 8 GPU and 1152 GB-RAM
+  max_capacity          = 2
+  min_capacity          = 0
+  scale_up_cooldown     = 0
+  scale_down_cooldown   = 0
   environment_variables = {
+    # TODO: This speculative draft feature allows for use of an e.g. 1b parameter model in conjunction with
+    # the main 70b model, but to implement it requires hosting the two models together on one instance
+    # "OPTION_SPECULATIVE_DRAFT_MODEL": "/opt/ml/additional-model-data-sources/draft_model",
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
     "HF_MODEL_ID" : "/opt/ml/model",
     "MODEL_CACHE_ROOT" : "/opt/ml/model",
@@ -798,366 +852,252 @@ module "llama_3_70b_deployment" {
     "SAGEMAKER_ENV" : "1",
     "SAGEMAKER_MODEL_SERVER_WORKERS" : "1",
     "SAGEMAKER_PROGRAM" : "inference.py"
-    # TODO: This speculative draft feature allows for use of an e.g. 1b parameter model in conjunction with
-    # the main 70b model, but to implement it requires hosting the two models together on one instance
-    # "OPTION_SPECULATIVE_DRAFT_MODEL": "/opt/ml/additional-model-data-sources/draft_model",
   }
-  instance_type             = "ml.p4d.24xlarge" # 96 vCPU and 8 GPU and 1152 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-llama-3-70b"
-  endpoint_name             = "llama-3-70b-endpoint"
-  variant_name              = "llama-3-70b-endpoint-dev"
-  initial_instance_count    = 1
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
-  max_capacity              = 2
-  min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 30
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.llama_3_70b_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
+      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description   = "Scale based on existence of backlog or not"
+      metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
       comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.llama_3_70b_deployment.endpoint_name}"
+      period              = 60
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_up_to_one_policy_arn]
+      ok_actions          = [module.llama_3_70b_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
+      alarm_name_prefix   = "high-cpu"
+      alarm_description   = "Scale up when CPU usage is heavy"
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 96 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-in-backlog-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 96 # TODO: Number of vCPUs
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 96
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.llama_3_70b_deployment.endpoint_name}"
+      statistic           = "Maximum"
       slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-memory-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
+      alarm_name_prefix   = "low-cpu"
+      alarm_description   = "Scale down when CPU usage is light"
+      metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 96
+      evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_cpu_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "high-GPU-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
+      alarm_name_prefix   = "high-gpu"
+      alarm_description   = "Scale up when GPU usage is heavy"
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 8 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.llama_3_70b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "dik-util-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Invocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80 * 8
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "High-error-rate-operations-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
     },
     {
-      alarm_name          = "unathorized-operations-alarm-${module.llama_3_70b_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefix   = "low-gpu"
+      alarm_description   = "Scale down when GPU usage is light"
+      metric_name         = "GPUUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20 * 8
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_gpu_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-ram"
+      alarm_description   = "Scale up when RAM usage is heavy"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-ram"
+      alarm_description   = "Scale down when RAM usage is light"
+      metric_name         = "MemoryUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "high-hard-disk"
+      alarm_description   = "Scale up when Hard Disk usage is heavy"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 80
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_up_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "low-hard-disk"
+      alarm_description   = "Scale down when Hard Disk usage is light"
+      metric_name         = "DiskUtilization"
+      namespace           = "/aws/sagemaker/Endpoints"
+      comparison_operator = "LessThanOrEqualToThreshold"
+      threshold           = 20
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Maximum"
+      slack_webhook_url   = var.slack_webhook_resource_alerts
+      alarm_actions       = [module.llama_3_70b_deployment.scale_down_to_n_policy_arn]
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
-      comparison_operator = "GreaterThanThreshold"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-alarm-${module.llama_3_70b_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
+    },
+    {
+      alarm_name_prefix   = "errors-4XX"
+      alarm_description   = "4XX errors are detected in the CloudTrail Logs"
+      metric_name         = "Invocation4XXErrors"
+      namespace           = "AWS/SageMaker"
+      comparison_operator = "GreaterThanOrEqualToThreshold"
+      threshold           = 1
+      evaluation_periods  = 1
+      datapoints_to_alarm = 1
+      period              = 60
+      statistic           = "Sum"
+      slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = [] # SNS to give alert to developers
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.llama_3_70b_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                = "./modules/sagemaker_deployment"
+  security_group_ids    = [aws_security_group.notebooks.id]
+  subnets               = aws_subnet.private_without_egress.*.id
+  s3_output_path        = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id        = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn    = module.iam.inference_role
 }
 
-
+/*
 ###############
 # Falcon bf16 180b
 ###############
 module "falcon_bf16_180b_deployment" {
-  source                  = "./modules/sagemaker_deployment"
-  model_name              = "falcon-bf16-180b"
-  sns_success_topic_arn   = module.sagemaker_output_mover.sns_success_topic_arn
-  execution_role_arn      = module.iam.inference_role
-  container_image         = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4.0-gpu-py310-cu121-ubuntu20.04"
-  model_uri               = "s3://jumpstart-cache-prod-eu-west-2/huggingface-infer/prepack/v1.2.0/infer-prepack-huggingface-llm-falcon-180b-bf16.tar.gz"
-  model_uri_compression   = "Gzip"
-  environment_variables   =  {
-            "ENDPOINT_SERVER_TIMEOUT": "3600",
-            "HF_MODEL_ID": "/opt/ml/model",
-            "MAX_INPUT_LENGTH": "1024",
-            "MAX_TOTAL_TOKENS": "2048",
-            "MODEL_CACHE_ROOT": "/opt/ml/model",
-            "SAGEMAKER_ENV": "1",
-            "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
-            "SAGEMAKER_PROGRAM": "inference.py",
-            "SM_NUM_GPUS": "8"
-        }
+  model_name                = "falcon-bf16-180b"
+  container_image           = "763104351884.dkr.ecr.eu-west-2.amazonaws.com/huggingface-pytorch-tgi-inference:2.1.1-tgi1.4.0-gpu-py310-cu121-ubuntu20.04"
+  model_uri                 = "s3://jumpstart-cache-prod-eu-west-2/huggingface-infer/prepack/v1.2.0/infer-prepack-huggingface-llm-falcon-180b-bf16.tar.gz"
+  model_uri_compression     = "Gzip"
   instance_type             = "ml.p5.48xlarge" # 192 vCPU and 8 GPUs and 2048 GB-RAM
-  security_group_ids        = [aws_security_group.notebooks.id]
-  subnets                   = aws_subnet.private_without_egress.*.id
-  endpoint_config_name      = "sagemaker-endpoint-config-falcon-bf16-180b"
-  endpoint_name             = "falcon-bf16-180b-endpoint"
-  variant_name              = "falcon-bf16-180b-endpoint-dev"
-  initial_instance_count    = 1
-  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
   max_capacity              = 2
   min_capacity              = 0
-  scale_up_adjustment       = 1
-  scale_up_cooldown         = 30
-  scale_in_to_zero_cooldown = 120
-  log_group_name            = "/aws/sagemaker/Endpoints/${module.falcon_bf16_180b_deployment.endpoint_name}"
-  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
+  scale_up_cooldown         = 0
+  scale_down_cooldown       = 0
+  environment_variables     =  {
+    "ENDPOINT_SERVER_TIMEOUT": "3600",
+    "HF_MODEL_ID": "/opt/ml/model",
+    "MAX_INPUT_LENGTH": "1024",
+    "MAX_TOTAL_TOKENS": "2048",
+    "MODEL_CACHE_ROOT": "/opt/ml/model",
+    "SAGEMAKER_ENV": "1",
+    "SAGEMAKER_MODEL_SERVER_WORKERS": "1",
+    "SAGEMAKER_PROGRAM": "inference.py",
+    "SM_NUM_GPUS": "8"
+  }
 
   alarms = [
     {
-      alarm_name          = "backlog-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 when queries are in the backlog, if 0 instances"
-      metric_name         = "HasBacklogWithoutCapacity"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 1
-      evaluation_periods  = 1
-      datapoints_to_alarm = 1
-      period              = 30
-      statistic           = "Average"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "backlog-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
+      alarm_name_prefix       = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_description       = "Scale based on existence of backlog or not"
+      metric_name             = "ApproximateBacklogSize"
+      namespace               = "AWS/SageMaker"
+      comparison_operator     = "GreaterThanOrEqualToThreshold"
+      threshold               = 1
+      evaluation_periods      = 1
+      datapoints_to_alarm     = 1
+      period                  = 60
+      statistic               = "Maximum"
+      slack_webhook_url       = var.slack_webhook_backlog_alerts
+      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_up_from_zero_policy_arn]
+      ok_actions          = [module.falcon_bf16_180b_deployment.scale_down_to_zero_policy_arn]
     },
     {
-      alarm_name          = "low-cpu-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when CPU < 5%"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 5 * 192 # TODO: Number of vCPUs
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_in_to_zero_policy_arn]
-      sns_topic_name      = "low-cpu-alert-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "no-query-in-backlog-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale in to zero when no queries are in the backlog for > 3 minutes"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "LessThanThreshold"
-      threshold           = 1
-      evaluation_periods  = 3
-      datapoints_to_alarm = 2
-      period              = 60
-      statistic           = "Sum"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_in_to_zero_based_on_backlog_arn]
-      sns_topic_name      = "no-query-in-backlog-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_backlog_alerts
-    },
-    {
-      alarm_name          = "high-cpu-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale out when CPU is at 70% threshold"
-      metric_name         = "CPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 192 # TODO: Number of vCPUs
-      evaluation_periods  = 1
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-cpu-alert-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_cpu_alerts
-    },
-    {
-      alarm_name          = "high-memory-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale up memory usage > 80%"
-      metric_name         = "MemoryUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-memory-alert-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "high-GPU-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale up GPU usage > 70%"
-      metric_name         = "GPUUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 70 * 8 # TODO: Number of GPUs
-      evaluation_periods  = 2
-      datapoints_to_alarm = 1
-      period              = 60
-      statistic           = "Average"
-      alarm_actions       = [module.falcon_bf16_180b_deployment.scale_up_policy_arn]
-      sns_topic_name      = "high-gpu-alert-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_gpu_alerts
-    },
-    {
-      alarm_name          = "network-spike-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scale up to 1 (deactivated) when endpoint experiences a backlog of requests beyond threshold"
-      metric_name         = "ApproximateBacklogSize"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 10 # More than 10 requests requires scale up
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "network-spike-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "disk-util-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Alerts when disk util is high"
-      metric_name         = "DiskUtilization"
-      namespace           = "/aws/sagemaker/Endpoints"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 80
-      evaluation_periods  = 2
-      datapoints_to_alarm = 2
-      period              = 30
-      statistic           = "Average"
-      sns_topic_name      = "dik-util-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "error-rate-high-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Scales up (deactivated) when Invocation Error rate exceeds 1% over 5 minutes"
-      metric_name         = "Invocation4XXErrors"
-      namespace           = "AWS/SageMaker"
-      comparison_operator = "GreaterThanThreshold"
-      threshold           = 200 * 0.01 # Assumes 200 queries within 5 minutes, so 1% of that figure
-      evaluation_periods  = 1
-      datapoints_to_alarm = 1
-      period              = 300
-      statistic           = "Sum"
-      sns_topic_name      = "High-error-rate-operations-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      slack_webhook_url   = var.slack_webhook_resource_alerts
-    },
-    {
-      alarm_name          = "unathorized-operations-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
-      alarm_description   = "Triggers when unauthorized operations are detected in the CloudTrail Logs"
+      alarm_name_prefi    = "unauthorized-operations"
+      alarm_description   = "Unauthorized operations are detected in the CloudTrail Logs"
       metric_name         = "UnauthorizedOperationsCount"
       namespace           = "CloudTrailMetrics"
       comparison_operator = "GreaterThanThreshold"
       threshold           = 1
       evaluation_periods  = 1
       datapoints_to_alarm = 1
-      period              = 300
+      period              = 60
       statistic           = "Sum"
-      alarm_actions       = [module.sns.unauthorised_access_sns_topic_arn]
-      sns_topic_name      = "unauthorised-operations-alarm-${module.falcon_bf16_180b_deployment.endpoint_name}"
       slack_webhook_url   = var.slack_webhook_security_alerts
+      alarm_actions       = []
+      ok_actions          = []
     }
   ]
-  slack_lambda_name = "slack-integration-${module.falcon_bf16_180b_deployment.endpoint_name}"
+
+  # These variables do not change between LLMs
+  source                    = "./modules/sagemaker_deployment"
+  security_group_ids        = [aws_security_group.notebooks.id]
+  subnets                   = aws_subnet.private_without_egress.*.id
+  s3_output_path            = "https://${module.iam.default_sagemaker_bucket.bucket_regional_domain_name}"
+  aws_account_id            = data.aws_caller_identity.aws_caller_identity.account_id
+  sns_success_topic_arn     = module.sagemaker_output_mover.sns_success_topic_arn
+  execution_role_arn        = module.iam.inference_role
 }
 */

--- a/infra/sagemaker_llm_resources.tf
+++ b/infra/sagemaker_llm_resources.tf
@@ -37,7 +37,7 @@ module "gpt_neo_125m_deployment" {
 
   alarms = [
     {
-      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_name_prefix   = "backlog" # TODO: backlog is currently required to have index 0, which is brittle
       alarm_description   = "Scale based on existence of backlog or not"
       metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
@@ -57,7 +57,7 @@ module "gpt_neo_125m_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 8  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 80 * 8 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -72,7 +72,7 @@ module "gpt_neo_125m_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 8  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 20 * 8 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -87,7 +87,7 @@ module "gpt_neo_125m_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 80 * 1 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -102,7 +102,7 @@ module "gpt_neo_125m_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 20 * 1 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -239,7 +239,7 @@ module "phi_2_3b_deployment" {
 
   alarms = [
     {
-      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_name_prefix   = "backlog" # TODO: backlog is currently required to have index 0, which is brittle
       alarm_description   = "Scale based on existence of backlog or not"
       metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
@@ -259,7 +259,7 @@ module "phi_2_3b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 4  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 80 * 4 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -274,7 +274,7 @@ module "phi_2_3b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 4  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 20 * 4 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -289,7 +289,7 @@ module "phi_2_3b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 80 * 1 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -304,7 +304,7 @@ module "phi_2_3b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 1  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 20 * 1 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -443,7 +443,7 @@ module "mistral_7b_deployment" {
 
   alarms = [
     {
-      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_name_prefix   = "backlog" # TODO: backlog is currently required to have index 0, which is brittle
       alarm_description   = "Scale based on existence of backlog or not"
       metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
@@ -463,7 +463,7 @@ module "mistral_7b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 48  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 80 * 48 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -478,7 +478,7 @@ module "mistral_7b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 48  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 20 * 48 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -493,7 +493,7 @@ module "mistral_7b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 4  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 80 * 4 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -508,7 +508,7 @@ module "mistral_7b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 4  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 20 * 4 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -646,7 +646,7 @@ module "gemma_2_27b_deployment" {
 
   alarms = [
     {
-      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_name_prefix   = "backlog" # TODO: backlog is currently required to have index 0, which is brittle
       alarm_description   = "Scale based on existence of backlog or not"
       metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"
@@ -666,7 +666,7 @@ module "gemma_2_27b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 192  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 80 * 192 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -681,7 +681,7 @@ module "gemma_2_27b_deployment" {
       metric_name         = "CPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 192  # TODO: we must manually multiply by vCPU count as Normalized metric not available
+      threshold           = 20 * 192 # TODO: we must manually multiply by vCPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -696,7 +696,7 @@ module "gemma_2_27b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "GreaterThanOrEqualToThreshold"
-      threshold           = 80 * 8  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 80 * 8 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -711,7 +711,7 @@ module "gemma_2_27b_deployment" {
       metric_name         = "GPUUtilization"
       namespace           = "/aws/sagemaker/Endpoints"
       comparison_operator = "LessThanOrEqualToThreshold"
-      threshold           = 20 * 8  # TODO: we must manually multiply by GPU count as Normalized metric not available
+      threshold           = 20 * 8 # TODO: we must manually multiply by GPU count as Normalized metric not available
       evaluation_periods  = 1
       datapoints_to_alarm = 1
       period              = 60
@@ -856,7 +856,7 @@ module "llama_3_70b_deployment" {
 
   alarms = [
     {
-      alarm_name_prefix   = "backlog"  # TODO: backlog is currently required to have index 0, which is brittle
+      alarm_name_prefix   = "backlog" # TODO: backlog is currently required to have index 0, which is brittle
       alarm_description   = "Scale based on existence of backlog or not"
       metric_name         = "ApproximateBacklogSize"
       namespace           = "AWS/SageMaker"


### PR DESCRIPTION
This started as a quick bugfix but evolved into a larger piece of work to simplify the way the alarms and autoscaling is working, as it was felt to be confusing and hard to debug in its prior implementation. 

The original bug is that scale-down based on backlog was not working at all in the prior state, rather scale-down by CPU was being applied (this is why it hadn't been noticed). This broke when Llama was added because that was using ~7% CPU at rest compared to a 5% CPU threshold, and so even with no backlog it was failing to scale down.

In the new implementation, scaling is split between a logic for 0-1 instance and a logic for anything above 1 instances. This means rules do not overlap - rather scale up/down for backlog is for 0-1 only and scale up/down for CPU/GPU is for 1+ only. Furthermore where possible alarms are created that trigger actions both in alarm state and also an opposing action in non-alarm (ok) state - this helps ensure consistency as there is only one rule to edit instead of two (actually in the end this could only be done for the backlog alarm and not the others).