### PR TITLE
Feat/matchbox infra tools

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -230,8 +230,7 @@ resource "aws_ecr_repository" "arango" {
 }
 
 resource "aws_ecr_repository" "matchbox" {
-  count = var.matchbox_on ? 1 : 0
-  name  = "${var.prefix}-matchbox"
+  name = "${var.prefix}-matchbox"
 }
 
 resource "aws_ecr_lifecycle_policy" "arango_expire_untagged_after_one_day" {
@@ -499,6 +498,7 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
       "${aws_ecr_repository.airflow.arn}",
       "${aws_ecr_repository.flower.arn}",
       "${aws_ecr_repository.mlflow.arn}",
+      "${aws_ecr_repository.matchbox.arn}",
     ]
   }
 

--- a/infra/ecs_main_matchbox.tf
+++ b/infra/ecs_main_matchbox.tf
@@ -1,7 +1,7 @@
 
 locals {
   matchbox_container_vars = [for i, v in var.matchbox_instances : {
-    container_image = "${aws_ecr_repository.matchbox[0].repository_url}:master"
+    container_image = "${aws_ecr_repository.matchbox.repository_url}:master"
     container_name  = "matchbox"
     cpu             = "${local.matchbox_container_cpu}"
     memory          = "${local.matchbox_container_memory}"
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "matchbox" {
   health_check_grace_period_seconds = "10"
 
   network_configuration {
-    subnets         = ["${aws_subnet.matchbox_private.*.id[0]}"]
+    subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
     security_groups = ["${aws_security_group.matchbox_service[count.index].id}"]
   }
 }
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "matchbox_task_execution" {
     ]
 
     resources = [
-      "${aws_ecr_repository.matchbox[0].arn}",
+      "${aws_ecr_repository.matchbox.arn}",
     ]
   }
 

--- a/infra/ecs_main_matchbox.tf
+++ b/infra/ecs_main_matchbox.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "matchbox" {
   health_check_grace_period_seconds = "10"
 
   network_configuration {
-    subnets         = ["${aws_subnet.private_with_egress.*.id[0]}"]
+    subnets         = ["${aws_subnet.matchbox_private.*.id[0]}"]
     security_groups = ["${aws_security_group.matchbox_service[count.index].id}"]
   }
 }

--- a/infra/ecs_matchbox_matchbox_container_definitions.json
+++ b/infra/ecs_matchbox_matchbox_container_definitions.json
@@ -13,9 +13,22 @@
     "essential": true,
     "image": "${container_image}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${log_region}",
+        "awslogs-stream-prefix": "${container_name}"
+      }
+    },
     "memoryReservation": ${memory},
     "cpu": ${cpu},
     "mountPoints": [],
-    "name": "${container_name}"
+    "name": "${container_name}",
+    "portMappings": [{
+      "containerPort": 8000,
+      "hostPort": 8000,
+      "protocol": "tcp"
+  }]
   }
 ]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -355,4 +355,5 @@ locals {
 
   matchbox_container_memory = 8192
   matchbox_container_cpu    = 1024
+  matchbox_port             = 8000
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -725,19 +725,6 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_healthcheck" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "ecr_api_ingress_https_from_matchbox" {
-  count       = var.matchbox_on ? 1 : 0
-  description = "ingress-https-from-matchbox-service"
-
-  security_group_id        = aws_security_group.ecr_api.id
-  source_security_group_id = aws_security_group.matchbox_service[count.index].id
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
 resource "aws_security_group_rule" "cloudwatch_ingress_https_from_all" {
   description = "ingress-https-from-everywhere"
 
@@ -2555,7 +2542,7 @@ resource "aws_security_group" "matchbox_service" {
   count       = length(var.matchbox_instances)
   name        = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
   description = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
-  vpc_id      = aws_vpc.main.id
+  vpc_id      = aws_vpc.matchbox.id
 
   tags = {
     Name = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
@@ -2566,12 +2553,12 @@ resource "aws_security_group" "matchbox_service" {
   }
 }
 
-resource "aws_security_group_rule" "matchbox_egress_https_all" {
-  count       = length(var.matchbox_instances)
-  description = "egress-https-to-all"
+resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_endpoints" {
+  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
+  description = "egress-https-from-matchbox-service"
 
-  security_group_id = aws_security_group.matchbox_service[count.index].id
-  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.matchbox_endpoints.id
 
   type      = "egress"
   from_port = "443"
@@ -2579,12 +2566,12 @@ resource "aws_security_group_rule" "matchbox_egress_https_all" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "matchbox_egress_https_to_ecr_api" {
-  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
-  description = "egress-https-from-matchbox"
+resource "aws_security_group_rule" "matchbox_egress_https_all" {
+  count       = length(var.matchbox_instances)
+  description = "egress-https-to-all"
 
-  security_group_id        = aws_security_group.matchbox_service[count.index].id
-  source_security_group_id = aws_security_group.ecr_api.id
+  security_group_id = aws_security_group.matchbox_service[count.index].id
+  cidr_blocks       = ["0.0.0.0/0"]
 
   type      = "egress"
   from_port = "443"
@@ -2605,4 +2592,31 @@ resource "aws_security_group" "matchbox_db" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+resource "aws_security_group" "matchbox_endpoints" {
+  name        = "${var.prefix}-matchbox-endpoints"
+  description = "${var.prefix}-matchbox-endpoints"
+  vpc_id      = aws_vpc.matchbox.id
+
+  tags = {
+    Name = "${var.prefix}-matchbox-endpoints"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "matchbox_endpoints_https_ingress_https_from_matchbox_service" {
+  count       = var.matchbox_on ? 1 : 0
+  description = "ingress-matchbox-endpoints"
+
+  security_group_id        = aws_security_group.matchbox_endpoints.id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2579,7 +2579,7 @@ resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_endpoints"
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "matchbox_api_ingress_https_from_notebooks_80" {
+resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks" {
   count       = var.matchbox_on ? length(var.matchbox_instances) : 0
   description = "matchbox-api-ingress-https-from-notebooks"
 
@@ -2592,7 +2592,7 @@ resource "aws_security_group_rule" "matchbox_api_ingress_https_from_notebooks_80
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "matchbox_api_ingress_https_from_notebooks_matchbox_port" {
+resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks_matchbox_port" {
   count       = var.matchbox_on ? length(var.matchbox_instances) : 0
   description = "matchbox-api-ingress-https-from-notebooks"
 
@@ -2647,7 +2647,7 @@ resource "aws_security_group" "matchbox_endpoints" {
   }
 }
 
-resource "aws_security_group_rule" "matchbox_endpoints_https_ingress_https_from_matchbox_service" {
+resource "aws_security_group_rule" "matchbox_endpoints_https_ingress_from_matchbox_service" {
   count       = var.matchbox_on ? 1 : 0
   description = "ingress-matchbox-endpoints"
 
@@ -2660,7 +2660,7 @@ resource "aws_security_group_rule" "matchbox_endpoints_https_ingress_https_from_
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "matchbox_service_egress_dns_udp_to_dns_rewrite_proxy" {
+resource "aws_security_group_rule" "matchbox_service_egress_udp_to_dns_rewrite_proxy" {
   count       = length(var.matchbox_instances)
   description = "egress-dns-to-dns-rewrite-proxy"
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2313,6 +2313,19 @@ resource "aws_security_group_rule" "notebooks_egress_http_to_mlflow_service" {
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "notebooks_egress_http_to_matchbox_service" {
+  count       = length(var.matchbox_instances)
+  description = "egress-http-to-matchbox-service-${var.matchbox_instances[count.index]}-temp"
+
+  security_group_id        = aws_security_group.notebooks.id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "egress"
+  from_port = "8000"
+  to_port   = "8000"
+  protocol  = "tcp"
+}
+
 resource "aws_security_group" "ecs" {
   name   = "${var.prefix}-ecs"
   vpc_id = aws_vpc.main.id
@@ -2563,6 +2576,19 @@ resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_endpoints"
   type      = "egress"
   from_port = "443"
   to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_api_ingress_https_from_notebooks" {
+  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
+  description = "matchbox-api-ingress-https-from-notebooks"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.notebooks.id
+
+  type      = "ingress"
+  from_port = "8000"
+  to_port   = "8000"
   protocol  = "tcp"
 }
 


### PR DESCRIPTION
This PR allows the matchbox to:
 - Deploy the matchbox service with Fargate using VPC endpoints to access services.
 - Be accessible from Theia via DNS resolution with dns-rewrite-proxy to the tasks private IP. 