### PR TITLE
feat: move GitLab secrets to secrets manager (part 1)

### DIFF
--- a/infra/ecs_main_gitlab_container_definitions.json
+++ b/infra/ecs_main_gitlab_container_definitions.json
@@ -9,6 +9,9 @@
     }, {
       "name": "AWS_DEFAULT_REGION",
       "value": "${bucket_region}"
+    }, {
+      "name": "SECRET_NAME",
+      "value": "${secret_name}"
     }],
     "essential": true,
     "image": "${container_image}",


### PR DESCRIPTION
 Instead of having to have files local in the filesystem (which is tricky to store securely), that are then copied to S3, which GitLab pulls from on launch, this makes it so GitLab secrets are stored in Secrets Manager, which GitLab pulls from on launch.

This is a part 1 of (probably) 2 parts - this does not remove existing object, permissions or any associated config, to allow environments to keep on accessing the secrets as they were, so we don't have to migrate them all at once. Later parts will likely remove permissions and config.

This is part of our move away from having to have any secrets locally on the filesystem.