### PR TITLE
Feat/matchbox infra rds

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -356,5 +356,6 @@ locals {
 
   matchbox_container_memory = 8192
   matchbox_container_cpu    = 1024
-  matchbox_port             = 8000
+  matchbox_api_port         = 8000
+  matchbox_db_port          = 5432
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -279,6 +279,7 @@ variable "matchbox_instances_long" {}
 variable "matchbox_db_instance_class" {}
 variable "vpc_matchbox_subnets_num_bits" {}
 variable "matchbox_artifacts_bucket" {}
+variable "matchbox_debug_mode" {}
 
 locals {
   admin_container_name   = "jupyterhub-admin"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2698,3 +2698,29 @@ resource "aws_security_group_rule" "matchbox_service_egress_https_to_matchbox_db
   to_port   = "5432"
   protocol  = "tcp"
 }
+
+resource "aws_security_group_rule" "matchbox_db_ingress_https_from_notebooks" {
+  count       = var.matchbox_debug_mode ? length(var.matchbox_instances) : 0
+  description = "matchbox-db-ingress-https-from-notebooks"
+
+  security_group_id        = aws_security_group.matchbox_db[count.index].id
+  source_security_group_id = aws_security_group.notebooks.id
+
+  type      = "ingress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "notebooks_egress_https_to_matchbox_db" {
+  count       = var.matchbox_debug_mode ? length(var.matchbox_instances) : 0
+  description = "notebooks-egress-https-to-matchbox-db"
+
+  security_group_id        = aws_security_group.notebooks.id
+  source_security_group_id = aws_security_group.matchbox_db[count.index].id
+
+  type      = "egress"
+  from_port = 5432
+  to_port   = 5432
+  protocol  = "tcp"
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2579,6 +2579,19 @@ resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_endpoints"
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_s3_endpoint" {
+  count       = var.matchbox_on ? 1 : 0
+  description = "egress-https-to-s3"
+
+  security_group_id = aws_security_group.matchbox_service[count.index].id
+  prefix_list_ids   = [aws_vpc_endpoint.matchbox_endpoint_s3.prefix_list_id]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
 resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks" {
   count       = var.matchbox_on ? length(var.matchbox_instances) : 0
   description = "matchbox-api-ingress-https-from-notebooks"
@@ -2696,6 +2709,19 @@ resource "aws_security_group_rule" "matchbox_service_egress_https_to_matchbox_db
   type      = "egress"
   from_port = "5432"
   to_port   = "5432"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_db_egress_https_to_matchbox_s3_endpoint" {
+  count       = length(var.matchbox_instances)
+  description = "egress-https-to-s3"
+
+  security_group_id = aws_security_group.matchbox_db[count.index].id
+  prefix_list_ids   = [aws_vpc_endpoint.matchbox_endpoint_s3.prefix_list_id]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
   protocol  = "tcp"
 }
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2321,8 +2321,8 @@ resource "aws_security_group_rule" "notebooks_egress_http_to_matchbox_service" {
   source_security_group_id = aws_security_group.matchbox_service[count.index].id
 
   type      = "egress"
-  from_port = local.matchbox_port
-  to_port   = local.matchbox_port
+  from_port = local.matchbox_api_port
+  to_port   = local.matchbox_api_port
   protocol  = "tcp"
 }
 
@@ -2613,8 +2613,8 @@ resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks_mat
   source_security_group_id = aws_security_group.notebooks.id
 
   type      = "ingress"
-  from_port = local.matchbox_port
-  to_port   = local.matchbox_port
+  from_port = local.matchbox_api_port
+  to_port   = local.matchbox_api_port
   protocol  = "tcp"
 }
 
@@ -2694,8 +2694,8 @@ resource "aws_security_group_rule" "matchbox_db_https_ingress_from_matchbox_serv
   source_security_group_id = aws_security_group.matchbox_service[count.index].id
 
   type      = "ingress"
-  from_port = "5432"
-  to_port   = "5432"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
   protocol  = "tcp"
 }
 
@@ -2707,8 +2707,8 @@ resource "aws_security_group_rule" "matchbox_service_egress_https_to_matchbox_db
   source_security_group_id = aws_security_group.matchbox_db[count.index].id
 
   type      = "egress"
-  from_port = "5432"
-  to_port   = "5432"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
   protocol  = "tcp"
 }
 
@@ -2733,8 +2733,8 @@ resource "aws_security_group_rule" "matchbox_db_ingress_https_from_notebooks" {
   source_security_group_id = aws_security_group.notebooks.id
 
   type      = "ingress"
-  from_port = 5432
-  to_port   = 5432
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
   protocol  = "tcp"
 }
 
@@ -2746,7 +2746,7 @@ resource "aws_security_group_rule" "notebooks_egress_https_to_matchbox_db" {
   source_security_group_id = aws_security_group.matchbox_db[count.index].id
 
   type      = "egress"
-  from_port = 5432
-  to_port   = 5432
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
   protocol  = "tcp"
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2672,3 +2672,29 @@ resource "aws_security_group_rule" "matchbox_service_egress_udp_to_dns_rewrite_p
   to_port   = "53"
   protocol  = "udp"
 }
+
+resource "aws_security_group_rule" "matchbox_db_https_ingress_from_matchbox_service" {
+  count       = length(var.matchbox_instances)
+  description = "ingress-https-to-matchbox-db"
+
+  security_group_id        = aws_security_group.matchbox_db[count.index].id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "ingress"
+  from_port = "5432"
+  to_port   = "5432"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_service_egress_https_to_matchbox_db" {
+  count       = length(var.matchbox_instances)
+  description = "egress-matchbox-service"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.matchbox_db[count.index].id
+
+  type      = "egress"
+  from_port = "5432"
+  to_port   = "5432"
+  protocol  = "tcp"
+}


### PR DESCRIPTION
This PR contains:
 - IAM roles and RDS feature allowing import from s3 to the RDS.
 - Security groups permitting traffic from the API to the RDS and s3 endpoint. 
 - A temporary route activated under the `matchbox_debug_mode` flag allowing traffic from notebooks to the matchbox RDS. This will be removed once matchbox development is complete. 