### PR TITLE
feat: move GitLab secrets to secrets manager (part 2)

### DIFF
--- a/infra/s3_gitlab.tf
+++ b/infra/s3_gitlab.tf
@@ -46,57 +46,57 @@ data "aws_iam_policy_document" "gitlab_bucket" {
 }
 
 resource "aws_s3_bucket_object" "ssh_host_rsa_key" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_rsa_key") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_rsa_key"
   source = "./ssh_host_rsa_key"
-  etag   = md5(file("./ssh_host_rsa_key"))
+  etag   = fileexists("./ssh_host_rsa_key") ? md5(file("./ssh_host_rsa_key")) : ""
 }
 
 resource "aws_s3_bucket_object" "ssh_host_rsa_key_pub" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_rsa_key.pub") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_rsa_key.pub"
   source = "./ssh_host_rsa_key.pub"
-  etag   = md5(file("./ssh_host_rsa_key.pub"))
+  etag   = fileexists("./ssh_host_rsa_key.pub") ? md5(file("./ssh_host_rsa_key.pub")) : ""
 }
 
 resource "aws_s3_bucket_object" "ssh_host_ecdsa_key" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_ecdsa_key") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_ecdsa_key"
   source = "./ssh_host_ecdsa_key"
-  etag   = md5(file("./ssh_host_ecdsa_key"))
+  etag   = fileexists("./ssh_host_ecdsa_key") ? md5(file("./ssh_host_ecdsa_key")) : ""
 }
 
 resource "aws_s3_bucket_object" "ssh_host_ecdsa_key_pub" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_ecdsa_key.pub") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_ecdsa_key.pub"
   source = "./ssh_host_ecdsa_key.pub"
-  etag   = md5(file("./ssh_host_ecdsa_key.pub"))
+  etag   = fileexists("./ssh_host_ecdsa_key.pub") ? md5(file("./ssh_host_ecdsa_key.pub")) : ""
 }
 
 resource "aws_s3_bucket_object" "ssh_host_ed25519_key" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_ed25519_key") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_ed25519_key"
   source = "./ssh_host_ed25519_key"
-  etag   = md5(file("./ssh_host_ed25519_key"))
+  etag   = fileexists("./ssh_host_ed25519_key") ? md5(file("./ssh_host_ed25519_key")) : ""
 }
 
 resource "aws_s3_bucket_object" "ssh_host_ed25519_key_pub" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./ssh_host_ed25519_key.pub") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "sshd/ssh_host_ed25519_key.pub"
   source = "./ssh_host_ed25519_key.pub"
-  etag   = md5(file("./ssh_host_ed25519_key.pub"))
+  etag   = fileexists("./ssh_host_ed25519_key.pub") ? md5(file("./ssh_host_ed25519_key.pub")) : ""
 }
 
 resource "aws_s3_bucket_object" "gitlab_secrets_json" {
-  count  = var.gitlab_on ? 1 : 0
+  count  = var.gitlab_on && fileexists("./gitlab-secrets.json") ? 1 : 0
   bucket = aws_s3_bucket.gitlab[count.index].id
   key    = "secrets/gitlab-secrets.json"
   source = "./gitlab-secrets.json"
-  etag   = md5(file("./gitlab-secrets.json"))
+  etag   = fileexists("./gitlab-secrets.json") ? md5(file("./gitlab-secrets.json")) : ""
 }


### PR DESCRIPTION
This follows up from https://github.com/uktrade/data-workspace/pull/223 by making it possible to apply the terraform with GitLab enabled, but while not have GitLab secrets on the local filesystem.