### PR TITLE
using admin_environment secrets from aws secrets manager instead of file

### DIFF
--- a/infra/environment-template/main.tf
+++ b/infra/environment-template/main.tf
@@ -71,7 +71,7 @@ module "jupyterhub" {
   admin_authbroker_client_id     = "REPLACE_ME"
   admin_authbroker_client_secret = "REPLACE_ME"
   admin_authbroker_url           = "REPLACE_ME"
-  admin_environment              = file("admin_environment.json")
+  admin_environment              = locals.secret["admin_environment.json"]
   admin_deregistration_delay     = 300
 
   uploads_bucket                = "REPLACE_ME"


### PR DESCRIPTION
This PR is a part of an overall migration task, to migrate GitLab infrastructure project to GitHub. This particular instance is to use admin_environment secrets from AWS secrets manager instead of local file.