### PR TITLE
feat: make it possible for other AWS accounts to use the mirror bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -88,6 +88,10 @@ variable "cloudwatch_destination_arn" {}
 
 variable "mirrors_bucket_name" {}
 variable "mirrors_data_bucket_name" {}
+variable "mirrors_bucket_non_prod_account_ids" {
+  type    = list(string)
+  default = []
+}
 
 variable "sentry_dsn" {}
 variable "sentry_notebooks_dsn" {}


### PR DESCRIPTION
The mirror bucket has essentially two modes:

- As a "resource", which is used for the live/production environment
- As a "data source", which is used for non-prod environments, and refers to the one in the production account (to not have to duplicate the bucket - it's big, and only contains public code)

However, before this change the non-prod environment had to be in the same AWS account as the prod one... which is a bit odd in many setups. Now the non-prod environments can be in another AWS account, but still use the mirror bucket from the prod one.