### PR TITLE
feat: add matchbox infrastructure

### DIFF
--- a/infra/ecs_matchbox_matchbox.tf
+++ b/infra/ecs_matchbox_matchbox.tf
@@ -1,0 +1,360 @@
+
+locals {
+  matchbox_container_vars = [for i, v in var.matchbox_instances : {
+    container_image        = "${aws_ecr_repository.matchbox[0].repository_url}:master"
+    container_name         = "matchbox"
+    cpu                    = "${local.matchbox_container_cpu}"
+    memory                 = "${local.matchbox_container_memory}"
+    database_uri           = "postgresql://${aws_rds_cluster.matchbox[i].master_username}:${random_string.aws_db_instance_matchbox_password[i].result}@${aws_rds_cluster.matchbox[i].endpoint}:5432/${aws_rds_cluster.matchbox[i].database_name}"
+    matchbox_s3_cache      = "${var.matchbox_s3_cache}-${var.matchbox_instances[i]}"
+    log_group              = "${aws_cloudwatch_log_group.matchbox[0].name}"
+    log_region             = "${data.aws_region.aws_region.name}"
+    mb__postgres__host     = "${aws_rds_cluster.matchbox[i].endpoint}"
+    mb__postgres__user     = "${aws_rds_cluster.matchbox[i].master_username}"
+    mb__postgres__password = "${random_string.aws_db_instance_matchbox_password[i].result}"
+    mb__postgres__database = "${aws_rds_cluster.matchbox[i].database_name}"
+  }]
+}
+
+resource "aws_ecs_service" "matchbox" {
+  count                             = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name                              = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}"
+  cluster                           = aws_ecs_cluster.main_cluster.id
+  task_definition                   = aws_ecs_task_definition.matchbox_service[count.index].arn
+  desired_count                     = 1
+  launch_type                       = "FARGATE"
+  deployment_maximum_percent        = 200
+  platform_version                  = "1.4.0"
+  health_check_grace_period_seconds = "10"
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.matchbox[0].arn
+  }
+
+  network_configuration {
+    subnets         = ["${aws_subnet.matchbox_private.*.id[0]}"]
+    security_groups = ["${aws_security_group.matchbox_service[count.index].id}"]
+  }
+}
+
+resource "aws_service_discovery_service" "matchbox" {
+  count = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name  = "matchbox"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.jupyterhub.id
+    dns_records {
+      ttl  = 10
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_ecs_task_definition" "matchbox_service" {
+  count  = var.matchbox_on ? length(var.matchbox_instances) : 0
+  family = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}"
+  container_definitions = templatefile(
+    "${path.module}/ecs_matchbox_matchbox_container_definitions.json",
+    local.matchbox_container_vars[count.index]
+  )
+  execution_role_arn = aws_iam_role.matchbox_task_execution[count.index].arn
+  task_role_arn      = aws_iam_role.matchbox_task[count.index].arn
+  network_mode       = "awsvpc"
+
+  cpu                      = local.matchbox_container_cpu
+  memory                   = local.matchbox_container_memory
+  requires_compatibilities = ["FARGATE"]
+  tags                     = {}
+
+  lifecycle {
+    ignore_changes = [
+      "revision",
+    ]
+  }
+}
+
+resource "aws_iam_role" "matchbox_task_execution" {
+  count              = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name               = "${var.prefix}-matchbox-task-execution-${var.matchbox_instances[count.index]}"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.matchbox_task_execution_ecs_tasks_assume_role[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox_task_execution_ecs_tasks_assume_role" {
+  count = var.matchbox_on ? length(var.matchbox_instances) : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "matchbox_task_execution" {
+  count      = var.matchbox_on ? length(var.matchbox_instances) : 0
+  role       = aws_iam_role.matchbox_task_execution[count.index].name
+  policy_arn = aws_iam_policy.matchbox_task_execution[count.index].arn
+}
+
+resource "aws_iam_policy" "matchbox_task_execution" {
+  count  = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name   = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-task-execution"
+  path   = "/"
+  policy = data.aws_iam_policy_document.matchbox_task_execution[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox_task_execution" {
+  count = var.matchbox_on ? length(var.matchbox_instances) : 0
+
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "${aws_cloudwatch_log_group.matchbox[0].arn}:*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+
+    resources = [
+      "${aws_ecr_repository.matchbox[0].arn}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "matchbox_task" {
+  count              = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name               = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-task"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.matchbox_task_ecs_tasks_assume_role[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox_task_ecs_tasks_assume_role" {
+  count = var.matchbox_on ? length(var.matchbox_instances) : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "matchbox_task" {
+  count      = var.matchbox_on ? length(var.matchbox_instances) : 0
+  role       = aws_iam_role.matchbox_task[count.index].name
+  policy_arn = aws_iam_policy.matchbox_task[count.index].arn
+}
+
+resource "aws_iam_policy" "matchbox_task" {
+  count  = var.matchbox_on ? length(var.matchbox_instances) : 0
+  name   = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-task"
+  path   = "/"
+  policy = data.aws_iam_policy_document.matchbox_task[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox_task" {
+  count = var.matchbox_on ? length(var.matchbox_instances) : 0
+
+  statement {
+    actions = [
+      "s3:*",
+    ]
+
+    resources = ["arn:aws:s3:::${aws_s3_bucket.matchbox_s3_cache[count.index].id}", "arn:aws:s3:::${aws_s3_bucket.matchbox_s3_cache[count.index].id}/*"]
+  }
+}
+
+resource "aws_rds_cluster" "matchbox" {
+  count                   = var.matchbox_on ? length(var.matchbox_instances) : 0
+  cluster_identifier      = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}"
+  engine                  = "aurora-postgresql"
+  availability_zones      = var.aws_availability_zones
+  database_name           = "${var.prefix_underscore}_matchbox_${var.matchbox_instances[count.index]}"
+  master_username         = "${var.prefix_underscore}_matchbox_master_${var.matchbox_instances[count.index]}"
+  master_password         = random_string.aws_db_instance_matchbox_password[count.index].result
+  backup_retention_period = 1
+  preferred_backup_window = "03:29-03:59"
+  apply_immediately       = true
+
+  vpc_security_group_ids = ["${aws_security_group.matchbox_db[count.index].id}"]
+  db_subnet_group_name   = aws_db_subnet_group.matchbox[count.index].name
+
+  final_snapshot_identifier = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}"
+  copy_tags_to_snapshot     = true
+}
+
+resource "aws_rds_cluster_instance" "matchbox" {
+  count              = var.matchbox_on ? 1 : 0
+  identifier         = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}"
+  cluster_identifier = aws_rds_cluster.matchbox[count.index].id
+  engine             = aws_rds_cluster.matchbox[count.index].engine
+  engine_version     = aws_rds_cluster.matchbox[count.index].engine_version
+  instance_class     = var.matchbox_db_instance_class
+  promotion_tier     = 1
+}
+
+resource "aws_db_subnet_group" "matchbox" {
+  count      = var.matchbox_on ? 1 : 0
+  name       = "${var.prefix}-matchbox"
+  subnet_ids = aws_subnet.matchbox_private.*.id
+
+  tags = {
+    Name = "${var.prefix}-matchbox"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "random_string" "aws_db_instance_matchbox_password" {
+  count   = var.matchbox_on ? length(var.matchbox_instances) : 0
+  length  = 99
+  special = false
+}
+
+resource "aws_rds_cluster_role_association" "matchbox_s3_import_role_association" {
+  count                 = var.matchbox_on ? 1 : 0
+  db_cluster_identifier = aws_rds_cluster.matchbox[count.index].id
+  feature_name          = "s3Import"
+  role_arn              = aws_iam_role.matchbox_s3_import[0].arn
+
+  lifecycle {
+    replace_triggered_by = [
+      aws_rds_cluster.matchbox[count.index].id
+    ]
+  }
+}
+
+resource "aws_iam_role" "matchbox_s3_import" {
+  count = var.matchbox_on ? 1 : 0
+  name  = "matchbox-s3-import-association-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "rds.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "matchbox_s3_import" {
+  count      = var.matchbox_on ? 1 : 0
+  role       = aws_iam_role.matchbox_s3_import[0].name
+  policy_arn = aws_iam_policy.matchbox_s3_import_policy[count.index].arn
+}
+
+resource "aws_iam_policy" "matchbox_s3_import_policy" {
+  count  = var.matchbox_on ? 1 : 0
+  name   = "${var.prefix}-rds-s3-access"
+  path   = "/"
+  policy = data.aws_iam_policy_document.matchbox_s3_import_policy_template[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox_s3_import_policy_template" {
+  count = var.matchbox_on ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = ["arn:aws:s3:::${aws_s3_bucket.matchbox_s3_cache[count.index].id}/*"]
+  }
+}
+
+resource "aws_s3_bucket" "matchbox_dev" {
+  count  = var.matchbox_on && var.matchbox_dev_mode_on ? 1 : 0
+  bucket = var.matchbox_s3_dev_artefacts
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket" "matchbox_s3_cache" {
+  # count  = length(var.matchbox_instances)
+  count  = var.matchbox_on ? 1 : 0
+  bucket = "${var.matchbox_s3_cache}-${var.matchbox_instances[count.index]}"
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = false
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "matchbox" {
+  count  = var.matchbox_on ? length(var.matchbox_instances) : 0
+  bucket = aws_s3_bucket.matchbox_s3_cache[count.index].id
+  policy = data.aws_iam_policy_document.matchbox[count.index].json
+}
+
+data "aws_iam_policy_document" "matchbox" {
+  count = length(var.matchbox_instances)
+  statement {
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.matchbox_s3_cache[count.index].id}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "matchbox" {
+  count             = var.matchbox_on ? 1 : 0
+  name              = "${var.prefix}-matchbox"
+  retention_in_days = "3653"
+}

--- a/infra/ecs_matchbox_matchbox_container_definitions.json
+++ b/infra/ecs_matchbox_matchbox_container_definitions.json
@@ -1,0 +1,74 @@
+[
+  {
+    "environment": [
+      {
+        "name": "DATABASE_URI",
+        "value": "${database_uri}"
+      },
+      {
+        "name": "AWS_DEFAULT_REGION",
+        "value": "eu-west-2"
+      },
+      {
+        "name": "MB__DATASTORE__CACHE_BUCKET_NAME",
+        "value": "${matchbox_s3_cache}"
+      },
+      {
+        "name": "MB__CLIENT__API_ROOT",
+        "value": ""
+      },
+      {
+        "name": "MB__BACKEND_TYPE",
+        "value": "postgres"
+      },
+      {
+        "name": "MB__DATASETS_CONFIG",
+        "value": "datasets.toml"
+      },
+      {
+        "name": "MB__POSTGRES__HOST",
+        "value": "${mb__postgres__host}"
+      },
+      {
+        "name": "MB__POSTGRES__PORT",
+        "value": "5432"
+      },
+      {
+        "name": "MB__POSTGRES__USER",
+        "value": "${mb__postgres__user}"
+      },
+      {
+        "name": "MB__POSTGRES__PASSWORD",
+        "value": "${mb__postgres__password}"
+      },
+      {
+        "name": "MB__POSTGRES__DATABASE",
+        "value": "${mb__postgres__database}"
+      },
+      {
+        "name": "MB__POSTGRES__DB_SCHEMA",
+        "value": "mb"
+      }
+    ],
+    "essential": true,
+    "image": "${container_image}",
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${log_group}",
+        "awslogs-region": "${log_region}",
+        "awslogs-stream-prefix": "${container_name}"
+      }
+    },
+    "memoryReservation": ${memory},
+    "cpu": ${cpu},
+    "mountPoints": [],
+    "name": "${container_name}",
+    "portMappings": [{
+      "containerPort": 8000,
+      "hostPort": 8000,
+      "protocol": "tcp"
+  }]
+  }
+]

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -274,6 +274,43 @@ variable "s3_prefixes_for_external_role_copy" {
   default = ["import-data", "export-data"]
 }
 
+variable "matchbox_on" {
+  type    = bool
+  default = false
+}
+variable "matchbox_dev_mode_on" {
+  type    = bool
+  default = false
+}
+variable "vpc_matchbox_cidr" {
+  type    = string
+  default = ""
+}
+variable "matchbox_instances" {
+  type    = list(string)
+  default = []
+}
+variable "matchbox_instances_long" {
+  type    = list(string)
+  default = []
+}
+variable "matchbox_db_instance_class" {
+  type    = string
+  default = ""
+}
+variable "vpc_matchbox_subnets_num_bits" {
+  type    = string
+  default = ""
+}
+variable "matchbox_s3_cache" {
+  type    = string
+  default = ""
+}
+variable "matchbox_s3_dev_artefacts" {
+  type    = string
+  default = ""
+}
+
 locals {
   admin_container_name   = "jupyterhub-admin"
   admin_container_port   = "8000"
@@ -346,4 +383,9 @@ locals {
   mlflow_container_memory = 8192
   mlflow_container_cpu    = 1024
   mlflow_port             = 8004
+
+  matchbox_container_memory = 8192
+  matchbox_container_cpu    = 1024
+  matchbox_api_port         = 8000
+  matchbox_db_port          = 5432
 }

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -2313,6 +2313,19 @@ resource "aws_security_group_rule" "notebooks_egress_http_to_mlflow_service" {
   protocol  = "tcp"
 }
 
+resource "aws_security_group_rule" "notebooks_egress_http_to_matchbox_service" {
+  count       = length(var.matchbox_instances)
+  description = "egress-http-to-matchbox-service-${var.matchbox_instances[count.index]}-temp"
+
+  security_group_id        = aws_security_group.notebooks.id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "egress"
+  from_port = local.matchbox_api_port
+  to_port   = local.matchbox_api_port
+  protocol  = "tcp"
+}
+
 resource "aws_security_group" "ecs" {
   name   = "${var.prefix}-ecs"
   vpc_id = aws_vpc.main.id
@@ -2535,5 +2548,206 @@ resource "aws_security_group_rule" "datasets_endpoint_ingress_arango_service" {
   type      = "ingress"
   from_port = "443"
   to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group" "matchbox_service" {
+  count       = length(var.matchbox_instances)
+  name        = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
+  description = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
+  vpc_id      = aws_vpc.matchbox[0].id
+
+  tags = {
+    Name = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-service"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_endpoints" {
+  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
+  description = "egress-https-from-matchbox-service"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.matchbox_endpoints[0].id
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_egress_https_to_matchbox_s3_endpoint" {
+  count       = var.matchbox_on ? 1 : 0
+  description = "egress-https-to-s3"
+
+  security_group_id = aws_security_group.matchbox_service[count.index].id
+  prefix_list_ids   = [aws_vpc_endpoint.matchbox_endpoint_s3[0].prefix_list_id]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks" {
+  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
+  description = "matchbox-api-ingress-https-from-notebooks"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.notebooks.id
+
+  type      = "ingress"
+  from_port = "80"
+  to_port   = "80"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_api_ingress_http_from_notebooks_matchbox_port" {
+  count       = var.matchbox_on ? length(var.matchbox_instances) : 0
+  description = "matchbox-api-ingress-https-from-notebooks"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.notebooks.id
+
+  type      = "ingress"
+  from_port = local.matchbox_api_port
+  to_port   = local.matchbox_api_port
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_egress_https_all" {
+  count       = length(var.matchbox_instances)
+  description = "egress-https-to-all"
+
+  security_group_id = aws_security_group.matchbox_service[count.index].id
+  cidr_blocks       = ["0.0.0.0/0"]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group" "matchbox_db" {
+  count       = length(var.matchbox_instances)
+  name        = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-db"
+  description = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-db"
+  vpc_id      = aws_vpc.matchbox[0].id
+
+  tags = {
+    Name = "${var.prefix}-matchbox-${var.matchbox_instances[count.index]}-db"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "matchbox_endpoints" {
+  count       = var.matchbox_on ? 1 : 0
+  name        = "${var.prefix}-matchbox-endpoints"
+  description = "${var.prefix}-matchbox-endpoints"
+  vpc_id      = aws_vpc.matchbox[0].id
+
+  tags = {
+    Name = "${var.prefix}-matchbox-endpoints"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "matchbox_endpoints_https_ingress_from_matchbox_service" {
+  count       = var.matchbox_on ? 1 : 0
+  description = "ingress-matchbox-endpoints"
+
+  security_group_id        = aws_security_group.matchbox_endpoints[0].id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_service_egress_udp_to_dns_rewrite_proxy" {
+  count       = length(var.matchbox_instances)
+  description = "egress-dns-to-dns-rewrite-proxy"
+
+  security_group_id = aws_security_group.matchbox_service[count.index].id
+  cidr_blocks       = ["${aws_subnet.private_with_egress.*.cidr_block[0]}"]
+
+  type      = "egress"
+  from_port = "53"
+  to_port   = "53"
+  protocol  = "udp"
+}
+
+resource "aws_security_group_rule" "matchbox_db_https_ingress_from_matchbox_service" {
+  count       = length(var.matchbox_instances)
+  description = "ingress-https-to-matchbox-db"
+
+  security_group_id        = aws_security_group.matchbox_db[count.index].id
+  source_security_group_id = aws_security_group.matchbox_service[count.index].id
+
+  type      = "ingress"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_service_egress_https_to_matchbox_db" {
+  count       = length(var.matchbox_instances)
+  description = "egress-matchbox-service"
+
+  security_group_id        = aws_security_group.matchbox_service[count.index].id
+  source_security_group_id = aws_security_group.matchbox_db[count.index].id
+
+  type      = "egress"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_db_egress_https_to_matchbox_s3_endpoint" {
+  count       = length(var.matchbox_instances)
+  description = "egress-https-to-s3"
+
+  security_group_id = aws_security_group.matchbox_db[count.index].id
+  prefix_list_ids   = [aws_vpc_endpoint.matchbox_endpoint_s3[0].prefix_list_id]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "matchbox_db_ingress_https_from_notebooks" {
+  count       = var.matchbox_on && var.matchbox_dev_mode_on ? 1 : 0
+  description = "matchbox-db-ingress-https-from-notebooks"
+
+  security_group_id        = aws_security_group.matchbox_db[count.index].id
+  source_security_group_id = aws_security_group.notebooks.id
+
+  type      = "ingress"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "notebooks_egress_https_to_matchbox_db" {
+  count       = var.matchbox_on && var.matchbox_dev_mode_on ? 1 : 0
+  description = "notebooks-egress-https-to-matchbox-db"
+
+  security_group_id        = aws_security_group.notebooks.id
+  source_security_group_id = aws_security_group.matchbox_db[count.index].id
+
+  type      = "egress"
+  from_port = local.matchbox_db_port
+  to_port   = local.matchbox_db_port
   protocol  = "tcp"
 }


### PR DESCRIPTION
Infrastructure for running matchbox https://github.com/uktrade/matchbox in data-workspace. This contains:

 - A Matchbox VPC.
 - A Matchbox Postgres instance.
 - A Fargate task for the Matchbox API.
 - An s3 bucket for caching parquet files uploaded to the API.
 - DNS resolution for the API endpoint.
 - Security groups allowing traffic from tools containers. 
 - Basic Cloudwatch logging. 

Additionally this PR contains a matchbox_dev_mode_on flag for features which assist with development of Matchbox. These are not intended to be included in the final Matchbox infrastructure and will be removed in a future PR:
 - Security groups allowing traffic from tools containers directly to the MatchboxDB database. 
 - An additional s3 bucket for storing development artefacts. 