### PR TITLE
Feat/lengthen scaledown for phi

### DIFF
--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -114,7 +114,7 @@ resource "aws_appautoscaling_policy" "scale_up_to_one_policy" {
 
   step_scaling_policy_configuration {
     adjustment_type = "ExactCapacity"
-    cooldown        = var.scale_down_cooldown
+    cooldown        = var.scale_up_cooldown
 
     step_adjustment {
       scaling_adjustment          = 1 # means set =0 (NOT add or subtract)


### PR DESCRIPTION
Correct an issue where the wrong cooldown was being applied, and confirmed logic that if scaleup_cooldown is extended to e.g. 30 mins as done here for phi-2-3b then this works as expected i.e. after scaling up to 1 instance the instance stays up for 30mins despite alarms for scale down.

Note - also removed references to falcon model which it became clear was not really of practical interest given it is even larger than llama-3-70b.