### PR TITLE
ci: fix GitHub pages deployment of docs

### DIFF
--- a/.github/workflows/deploy-docs-to-github-pages.yml
+++ b/.github/workflows/deploy-docs-to-github-pages.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build with Eleventy
       run: npx eleventy
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
 
   deploy:
     runs-on: ubuntu-latest
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This is done by upgrading to more recent versions of the actions involved in deploying