### PR TITLE
fix: remove user perms to access SageMaker S3 bucket

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -205,19 +205,6 @@ data "aws_iam_policy_document" "notebook_s3_access_template" {
 
   }
 
-  # temporary policy to allow access to SageMaker bucket
-  statement {
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:DeleteObject",
-      "s3:ListBucket"
-    ]
-
-    resources = ["arn:aws:s3:::*sagemaker*"]
-
-  }
-
   statement {
     actions = [
       "s3:ListBucket",
@@ -411,25 +398,6 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_s3_notebooks" {
     ]
   }
 
-  # Allow access to SageMaker default bucket
-  statement {
-    principals {
-      type        = "*"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "s3:ListBucket",
-      "s3:GetObject",
-      "s3:PutObject",
-      "s3:DeleteObject",
-    ]
-
-    resources = [
-      "arn:aws:s3:::*sagemaker*"
-    ]
-  }
-
   statement {
     principals {
       type        = "AWS"
@@ -479,7 +447,7 @@ data "aws_iam_policy_document" "jupyterhub_notebook_task_boundary" {
     ]
   }
 
-  # Temporary: Allow all tools users to access SageMaker endpoints
+  # Allow all tools users to access SageMaker endpoints
   statement {
     actions = [
       "sagemaker:DescribeEndpoint",
@@ -493,20 +461,6 @@ data "aws_iam_policy_document" "jupyterhub_notebook_task_boundary" {
 
     resources = [
       "*",
-    ]
-  }
-
-  # Temporary: Allow all tools users to access SageMaker S3 bucket
-  statement {
-    actions = [
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:DeleteObject",
-      "s3:ListBucket"
-    ]
-
-    resources = [
-      "arn:aws:s3:::*sagemaker*",
     ]
   }
 


### PR DESCRIPTION
Remove user permissions to access the central SageMaker S3 bucket from Theia/Jupyter.  This is no longer needed as outputs are copied from the SageMaker S3 bucket into the user's own filespace.  I have tested this change by:

- Verifying that it is still possible to access a user's own SageMaker outputs from the user's own file area
- Verifying that it is not possible to access the SageMaker S3 bucket from Theia