### PR TITLE
refactor no functional changes

### DIFF
--- a/infra/modules/sagemaker_deployment/cloudwatch.tf
+++ b/infra/modules/sagemaker_deployment/cloudwatch.tf
@@ -14,9 +14,9 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
   ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
   dimensions = (count.index == 0 || count.index == 1 || count.index == 2) ? { # TODO: this logic is brittle as it assumes "backlog" has index [0,1,2]; it would be better to have a logic that rests on the specific name of that metric
-    EndpointName = aws_sagemaker_endpoint.main.name             # Only EndpointName is used in this case
+    EndpointName = aws_sagemaker_endpoint.main.name                           # Only EndpointName is used in this case
     } : {
-    EndpointName = aws_sagemaker_endpoint.main.name,                                          # Both EndpointName and VariantName are used in all other cases
+    EndpointName = aws_sagemaker_endpoint.main.name,                                             # Both EndpointName and VariantName are used in all other cases
     VariantName  = aws_sagemaker_endpoint_configuration.main.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
   }
 

--- a/infra/modules/sagemaker_deployment/cloudwatch.tf
+++ b/infra/modules/sagemaker_deployment/cloudwatch.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   count = length(var.alarms)
 
-  alarm_name          = "${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  alarm_name          = "${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.main.name}"
   alarm_description   = var.alarms[count.index].alarm_description
   metric_name         = var.alarms[count.index].metric_name
   namespace           = var.alarms[count.index].namespace
@@ -14,13 +14,13 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
   ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
   dimensions = (count.index == 0 || count.index == 1 || count.index == 2) ? { # TODO: this logic is brittle as it assumes "backlog" has index [0,1,2]; it would be better to have a logic that rests on the specific name of that metric
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name             # Only EndpointName is used in this case
+    EndpointName = aws_sagemaker_endpoint.main.name             # Only EndpointName is used in this case
     } : {
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,                                          # Both EndpointName and VariantName are used in all other cases
-    VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
+    EndpointName = aws_sagemaker_endpoint.main.name,                                          # Both EndpointName and VariantName are used in all other cases
+    VariantName  = aws_sagemaker_endpoint_configuration.main.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
   }
 
-  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
+  depends_on = [aws_sagemaker_endpoint.main, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
 }
 
 
@@ -33,12 +33,12 @@ resource "null_resource" "wait_for_metric_alarms" {
 resource "aws_cloudwatch_composite_alarm" "composite_alarm" {
   count = length(var.alarm_composites)
 
-  alarm_name        = "${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  alarm_name        = "${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.main.name}"
   alarm_description = var.alarm_composites[count.index].alarm_description
   alarm_rule        = var.alarm_composites[count.index].alarm_rule
   alarm_actions     = concat(var.alarm_composites[count.index].alarm_actions, [aws_sns_topic.alarm_composite_notifications[count.index].arn], [aws_sns_topic.sns_topic_composite[count.index].arn])
   ok_actions        = var.alarm_composites[count.index].ok_actions
 
-  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.alarm_composite_notifications, aws_sns_topic.sns_topic_composite, null_resource.wait_for_metric_alarms]
+  depends_on = [aws_sagemaker_endpoint.main, aws_sns_topic.alarm_composite_notifications, aws_sns_topic.sns_topic_composite, null_resource.wait_for_metric_alarms]
 
 }

--- a/infra/modules/sagemaker_deployment/cloudwatch.tf
+++ b/infra/modules/sagemaker_deployment/cloudwatch.tf
@@ -1,0 +1,42 @@
+resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
+  count = length(var.alarms)
+
+  alarm_name          = "${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  alarm_description   = var.alarms[count.index].alarm_description
+  metric_name         = var.alarms[count.index].metric_name
+  namespace           = var.alarms[count.index].namespace
+  comparison_operator = var.alarms[count.index].comparison_operator
+  threshold           = var.alarms[count.index].threshold
+  evaluation_periods  = var.alarms[count.index].evaluation_periods
+  datapoints_to_alarm = var.alarms[count.index].datapoints_to_alarm
+  period              = var.alarms[count.index].period
+  statistic           = var.alarms[count.index].statistic
+  alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
+  ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
+  dimensions = (count.index == 0 || count.index == 1 || count.index == 2) ? { # TODO: this logic is brittle as it assumes "backlog" has index [0,1,2]; it would be better to have a logic that rests on the specific name of that metric
+    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name             # Only EndpointName is used in this case
+    } : {
+    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,                                          # Both EndpointName and VariantName are used in all other cases
+    VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
+  }
+
+  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
+}
+
+resource "null_resource" "wait_for_metric_alarms" {
+  #  Aggregating metric alarms dependencies so we wait for them to be deleted/created before composite alarms are created or deleted. This prevents cyclic dependency issues.
+  depends_on = [aws_cloudwatch_metric_alarm.cloudwatch_alarm]
+}
+
+resource "aws_cloudwatch_composite_alarm" "composite_alarm" {
+  count = length(var.alarm_composites)
+
+  alarm_name        = "${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  alarm_description = var.alarm_composites[count.index].alarm_description
+  alarm_rule        = var.alarm_composites[count.index].alarm_rule
+  alarm_actions     = concat(var.alarm_composites[count.index].alarm_actions, [aws_sns_topic.alarm_composite_notifications[count.index].arn], [aws_sns_topic.sns_topic_composite[count.index].arn])
+  ok_actions        = var.alarm_composites[count.index].ok_actions
+
+  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.alarm_composite_notifications, aws_sns_topic.sns_topic_composite, null_resource.wait_for_metric_alarms]
+
+}

--- a/infra/modules/sagemaker_deployment/cloudwatch.tf
+++ b/infra/modules/sagemaker_deployment/cloudwatch.tf
@@ -23,10 +23,12 @@ resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
   depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
 }
 
+
 resource "null_resource" "wait_for_metric_alarms" {
   #  Aggregating metric alarms dependencies so we wait for them to be deleted/created before composite alarms are created or deleted. This prevents cyclic dependency issues.
   depends_on = [aws_cloudwatch_metric_alarm.cloudwatch_alarm]
 }
+
 
 resource "aws_cloudwatch_composite_alarm" "composite_alarm" {
   count = length(var.alarm_composites)

--- a/infra/modules/sagemaker_deployment/lambda.tf
+++ b/infra/modules/sagemaker_deployment/lambda.tf
@@ -1,0 +1,107 @@
+
+
+data "archive_file" "lambda_payload" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_function/cloudwatch_alarms_to_slack_alerts.py"
+  output_path = "${path.module}/lambda_function/payload.zip"
+}
+
+
+resource "aws_lambda_function" "slack_alert_function" {
+  filename         = data.archive_file.lambda_payload.output_path
+  source_code_hash = data.archive_file.lambda_payload.output_base64sha256
+  function_name    = "${var.model_name}-slack-alert-lambda"
+  role             = aws_iam_role.slack_lambda_role.arn
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "python3.12"
+  timeout          = 30
+
+  environment {
+    variables = {
+      SNS_TO_WEBHOOK_JSON = jsonencode(local.sns_to_webhook_mapping),
+      ADDRESS             = "arn:aws:sns:eu-west-2:${var.aws_account_id}:"
+    }
+  }
+}
+
+
+resource "aws_lambda_permission" "allow_sns_composite" {
+  count = length(var.alarm_composites)
+
+  statement_id  = "AllowSNS-composite-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topic_composite[count.index].arn
+}
+
+
+resource "aws_lambda_permission" "allow_sns_alarmstate" {
+  count = length(var.alarms)
+
+  statement_id  = "AllowSNS-alarm-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+}
+
+
+resource "aws_lambda_permission" "allow_sns_okstate" {
+  count = length(var.alarms)
+
+  statement_id  = "AllowSNS-ok-${count.index}"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.slack_alert_function.function_name
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.sns_topic_okstate[count.index].arn
+}
+
+
+resource "aws_iam_role" "slack_lambda_role" {
+  name = "${var.model_name}-slack-alert-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_policy" "slack_lambda_policy" {
+  name = "${var.model_name}-slack-alert-lambda-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Effect   = "Allow",
+        Action   = "sns:Publish",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_iam_role_policy_attachment" "slack_lambda_policy_attachment" {
+  role       = aws_iam_role.slack_lambda_role.name
+  policy_arn = aws_iam_policy.slack_lambda_policy.arn
+}

--- a/infra/modules/sagemaker_deployment/lambda.tf
+++ b/infra/modules/sagemaker_deployment/lambda.tf
@@ -30,7 +30,7 @@ resource "aws_lambda_permission" "allow_sns_composite" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.slack_alert_function.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_composite[count.index].arn
+  source_arn    = aws_sns_topic.composite_alarmstate[count.index].arn
 }
 
 
@@ -41,7 +41,7 @@ resource "aws_lambda_permission" "allow_sns_alarmstate" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.slack_alert_function.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+  source_arn    = aws_sns_topic.alarmstate[count.index].arn
 }
 
 
@@ -52,7 +52,7 @@ resource "aws_lambda_permission" "allow_sns_okstate" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.slack_alert_function.function_name
   principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_okstate[count.index].arn
+  source_arn    = aws_sns_topic.okstate[count.index].arn
 }
 
 

--- a/infra/modules/sagemaker_deployment/lambda.tf
+++ b/infra/modules/sagemaker_deployment/lambda.tf
@@ -1,5 +1,3 @@
-
-
 data "archive_file" "lambda_payload" {
   type        = "zip"
   source_file = "${path.module}/lambda_function/cloudwatch_alarms_to_slack_alerts.py"

--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -24,6 +24,7 @@ resource "aws_sagemaker_model" "sagemaker_model" {
   }
 }
 
+
 resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
   name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint-config"
 
@@ -45,12 +46,14 @@ resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
   }
 }
 
+
 resource "aws_sagemaker_endpoint" "sagemaker_endpoint" {
   name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint"
 
   endpoint_config_name = aws_sagemaker_endpoint_configuration.endpoint_config.name
   depends_on           = [aws_sagemaker_endpoint_configuration.endpoint_config, var.sns_success_topic_arn]
 }
+
 
 resource "aws_appautoscaling_target" "autoscaling_target" {
   max_capacity       = var.max_capacity
@@ -60,6 +63,7 @@ resource "aws_appautoscaling_target" "autoscaling_target" {
   service_namespace  = "sagemaker"
   depends_on         = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sagemaker_endpoint_configuration.endpoint_config]
 }
+
 
 resource "aws_appautoscaling_policy" "scale_up_to_n_policy" {
   name = "scale-up-to-n-policy-${var.model_name}"
@@ -82,6 +86,7 @@ resource "aws_appautoscaling_policy" "scale_up_to_n_policy" {
   }
 }
 
+
 resource "aws_appautoscaling_policy" "scale_down_to_n_policy" {
   name = "scale-down-to-n-policy-${var.model_name}"
 
@@ -102,6 +107,7 @@ resource "aws_appautoscaling_policy" "scale_down_to_n_policy" {
     }
   }
 }
+
 
 resource "aws_appautoscaling_policy" "scale_up_to_one_policy" {
   name = "scale-up-to-one-policy-${var.model_name}"
@@ -124,6 +130,7 @@ resource "aws_appautoscaling_policy" "scale_up_to_one_policy" {
   }
 }
 
+
 resource "aws_appautoscaling_policy" "scale_down_to_zero_policy" {
   name = "scale-down-to-zero-policy-${var.model_name}"
 
@@ -145,6 +152,7 @@ resource "aws_appautoscaling_policy" "scale_down_to_zero_policy" {
   }
 }
 
+
 # Mapping SNS topic ARNs to Slack webhook URLs
 locals {
   sns_to_webhook_mapping = merge({
@@ -158,281 +166,6 @@ locals {
     replace(aws_sns_topic.sns_topic_composite[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm_composite.slack_webhook_url
     }
   )
-}
-
-resource "aws_cloudwatch_metric_alarm" "cloudwatch_alarm" {
-  count = length(var.alarms)
-
-  alarm_name          = "${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
-  alarm_description   = var.alarms[count.index].alarm_description
-  metric_name         = var.alarms[count.index].metric_name
-  namespace           = var.alarms[count.index].namespace
-  comparison_operator = var.alarms[count.index].comparison_operator
-  threshold           = var.alarms[count.index].threshold
-  evaluation_periods  = var.alarms[count.index].evaluation_periods
-  datapoints_to_alarm = var.alarms[count.index].datapoints_to_alarm
-  period              = var.alarms[count.index].period
-  statistic           = var.alarms[count.index].statistic
-  alarm_actions       = concat(var.alarms[count.index].alarm_actions, [aws_sns_topic.sns_topic_alarmstate[count.index].arn])
-  ok_actions          = concat(var.alarms[count.index].ok_actions, [aws_sns_topic.sns_topic_okstate[count.index].arn])
-  dimensions = (count.index == 0 || count.index == 1 || count.index == 2) ? { # TODO: this logic is brittle as it assumes "backlog" has index [0,1]; it would be better to have a logic that rests on the specific name of that metric
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name             # Only EndpointName is used in this case
-    } : {
-    EndpointName = aws_sagemaker_endpoint.sagemaker_endpoint.name,                                          # Both EndpointName and VariantName are used in all other cases
-    VariantName  = aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name # Note this logic would not work if there were ever more than one production variant deployed for an LLM
-  }
-
-  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.sns_topic_alarmstate, aws_sns_topic.sns_topic_okstate]
-}
-
-resource "null_resource" "wait_for_metric_alarms" {
-  #  Aggregating metric alarms dependencies so we wait for them to be deleted/created before composite alarms are created or deleted. This prevents cyclic dependency issues.
-  depends_on = [aws_cloudwatch_metric_alarm.cloudwatch_alarm]
-}
-
-resource "aws_cloudwatch_composite_alarm" "composite_alarm" {
-  count = length(var.alarm_composites)
-
-  alarm_name        = "${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
-  alarm_description = var.alarm_composites[count.index].alarm_description
-  alarm_rule        = var.alarm_composites[count.index].alarm_rule
-  alarm_actions     = concat(var.alarm_composites[count.index].alarm_actions, [aws_sns_topic.alarm_composite_notifications[count.index].arn], [aws_sns_topic.sns_topic_composite[count.index].arn])
-  ok_actions        = var.alarm_composites[count.index].ok_actions
-
-  depends_on = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sns_topic.alarm_composite_notifications, aws_sns_topic.sns_topic_composite, null_resource.wait_for_metric_alarms]
-
-}
-
-resource "aws_sns_topic" "sns_topic_composite" {
-  count = length(var.alarm_composites)
-
-  name = "alarm-alarm-composite-lambda-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-topic"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Service = "cloudwatch.amazonaws.com"
-        },
-        Action   = "sns:Publish",
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_lambda_permission" "allow_sns_composite" {
-  count = length(var.alarm_composites)
-
-  statement_id  = "AllowSNS-composite-${count.index}"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.slack_alert_function.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_composite[count.index].arn
-}
-
-resource "aws_sns_topic_subscription" "sns_lambda_subscription_composite" {
-  count = length(var.alarm_composites)
-
-  topic_arn = aws_sns_topic.sns_topic_composite[count.index].arn
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.slack_alert_function.arn
-}
-
-resource "aws_sns_topic" "alarm_composite_notifications" {
-  count = length(var.alarm_composites)
-  name  = "alarm-composite-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-sns-topic"
-
-}
-
-resource "aws_sns_topic_policy" "composite_sns_topic_policy" {
-  count = length(var.alarm_composites)
-
-  arn = aws_sns_topic.alarm_composite_notifications[count.index].arn
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "AllowPublishFromCloudWatch"
-        Effect = "Allow",
-        Principal = {
-          Service = "cloudwatch.amazonaws.com"
-        },
-        Action   = "SNS:Publish",
-        Resource = aws_sns_topic.alarm_composite_notifications[count.index].arn
-      },
-      {
-        Sid       = "AllowSubscriptionActions"
-        Effect    = "Allow",
-        Principal = "*",
-        Action = [
-          "sns:Subscribe",
-          "sns:Receive"
-        ],
-        Resource = aws_sns_topic.alarm_composite_notifications[count.index].arn
-      }
-    ]
-  })
-
-}
-
-resource "aws_sns_topic_subscription" "email_subscription" {
-  count     = length(var.alarm_composites)
-  topic_arn = aws_sns_topic.alarm_composite_notifications[count.index].arn
-  protocol  = "email"
-  endpoint = flatten([
-    for variables in var.alarm_composites :
-    [
-      for email in variables.emails :
-      email
-    ]
-  ])[count.index]
-}
-
-resource "aws_sns_topic" "sns_topic_alarmstate" {
-  count = length(var.alarms)
-
-  name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Service = "cloudwatch.amazonaws.com"
-        },
-        Action   = "sns:Publish",
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_lambda_permission" "allow_sns_alarmstate" {
-  count = length(var.alarms)
-
-  statement_id  = "AllowSNS-alarm-${count.index}"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.slack_alert_function.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_alarmstate[count.index].arn
-}
-
-resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
-  count = length(var.alarms)
-
-  topic_arn = aws_sns_topic.sns_topic_alarmstate[count.index].arn
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.slack_alert_function.arn
-}
-
-resource "aws_sns_topic" "sns_topic_okstate" {
-  count = length(var.alarms)
-
-  name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Service = "cloudwatch.amazonaws.com"
-        },
-        Action   = "sns:Publish",
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_lambda_permission" "allow_sns_okstate" {
-  count = length(var.alarms)
-
-  statement_id  = "AllowSNS-ok-${count.index}"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.slack_alert_function.function_name
-  principal     = "sns.amazonaws.com"
-  source_arn    = aws_sns_topic.sns_topic_okstate[count.index].arn
-}
-
-resource "aws_sns_topic_subscription" "sns_lambda_subscription_okstate" {
-  count = length(var.alarms)
-
-  topic_arn = aws_sns_topic.sns_topic_okstate[count.index].arn
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.slack_alert_function.arn
-}
-data "archive_file" "lambda_payload" {
-  type        = "zip"
-  source_file = "${path.module}/lambda_function/cloudwatch_alarms_to_slack_alerts.py"
-  output_path = "${path.module}/lambda_function/payload.zip"
-}
-
-
-resource "aws_lambda_function" "slack_alert_function" {
-  filename         = data.archive_file.lambda_payload.output_path
-  source_code_hash = data.archive_file.lambda_payload.output_base64sha256
-  function_name    = "${var.model_name}-slack-alert-lambda"
-  role             = aws_iam_role.slack_lambda_role.arn
-  handler          = "lambda_function.lambda_handler"
-  runtime          = "python3.12"
-  timeout          = 30
-
-  environment {
-    variables = {
-      SNS_TO_WEBHOOK_JSON = jsonencode(local.sns_to_webhook_mapping),
-      ADDRESS             = "arn:aws:sns:eu-west-2:${var.aws_account_id}:"
-    }
-  }
-}
-
-resource "aws_iam_role" "slack_lambda_role" {
-  name = "${var.model_name}-slack-alert-lambda-role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        },
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_policy" "slack_lambda_policy" {
-  name = "${var.model_name}-slack-alert-lambda-policy"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Action = [
-          "logs:CreateLogGroup",
-          "logs:CreateLogStream",
-          "logs:PutLogEvents"
-        ],
-        Resource = "arn:aws:logs:*:*:*"
-      },
-      {
-        Effect   = "Allow",
-        Action   = "sns:Publish",
-        Resource = "*"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "slack_lambda_policy_attachment" {
-  role       = aws_iam_role.slack_lambda_role.name
-  policy_arn = aws_iam_policy.slack_lambda_policy.arn
 }
 
 

--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -157,13 +157,13 @@ resource "aws_appautoscaling_policy" "scale_down_to_zero_policy" {
 locals {
   sns_to_webhook_mapping = merge({
     for idx, alarm in var.alarms :
-    replace(aws_sns_topic.sns_topic_alarmstate[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm.slack_webhook_url
+    replace(aws_sns_topic.alarmstate[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm.slack_webhook_url
     }, {
     for idx, alarm in var.alarms :
-    replace(aws_sns_topic.sns_topic_okstate[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm.slack_webhook_url
+    replace(aws_sns_topic.okstate[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm.slack_webhook_url
     }, {
     for idx, alarm_composite in var.alarm_composites :
-    replace(aws_sns_topic.sns_topic_composite[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm_composite.slack_webhook_url
+    replace(aws_sns_topic.composite_alarmstate[idx].arn, "arn:aws:sns:eu-west-2:${var.aws_account_id}:", "") => alarm_composite.slack_webhook_url
     }
   )
 }

--- a/infra/modules/sagemaker_deployment/main.tf
+++ b/infra/modules/sagemaker_deployment/main.tf
@@ -1,4 +1,4 @@
-resource "aws_sagemaker_model" "sagemaker_model" {
+resource "aws_sagemaker_model" "main" {
   name               = var.model_name
   execution_role_arn = var.execution_role_arn
 
@@ -25,12 +25,12 @@ resource "aws_sagemaker_model" "sagemaker_model" {
 }
 
 
-resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
-  name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint-config"
+resource "aws_sagemaker_endpoint_configuration" "main" {
+  name = "${aws_sagemaker_model.main.name}-endpoint-config"
 
   production_variants {
     variant_name           = "AllTraffic"
-    model_name             = aws_sagemaker_model.sagemaker_model.name
+    model_name             = aws_sagemaker_model.main.name
     instance_type          = var.instance_type
     initial_instance_count = 1
   }
@@ -47,21 +47,21 @@ resource "aws_sagemaker_endpoint_configuration" "endpoint_config" {
 }
 
 
-resource "aws_sagemaker_endpoint" "sagemaker_endpoint" {
-  name = "${aws_sagemaker_model.sagemaker_model.name}-endpoint"
+resource "aws_sagemaker_endpoint" "main" {
+  name = "${aws_sagemaker_model.main.name}-endpoint"
 
-  endpoint_config_name = aws_sagemaker_endpoint_configuration.endpoint_config.name
-  depends_on           = [aws_sagemaker_endpoint_configuration.endpoint_config, var.sns_success_topic_arn]
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.main.name
+  depends_on           = [aws_sagemaker_endpoint_configuration.main, var.sns_success_topic_arn]
 }
 
 
-resource "aws_appautoscaling_target" "autoscaling_target" {
+resource "aws_appautoscaling_target" "main" {
   max_capacity       = var.max_capacity
   min_capacity       = var.min_capacity
-  resource_id        = "endpoint/${aws_sagemaker_endpoint.sagemaker_endpoint.name}/variant/${aws_sagemaker_endpoint_configuration.endpoint_config.production_variants[0].variant_name}" # Note this logic would not work if there were ever more than one production variant deployed for an LLM
+  resource_id        = "endpoint/${aws_sagemaker_endpoint.main.name}/variant/${aws_sagemaker_endpoint_configuration.main.production_variants[0].variant_name}" # Note this logic would not work if there were ever more than one production variant deployed for an LLM
   scalable_dimension = "sagemaker:variant:DesiredInstanceCount"
   service_namespace  = "sagemaker"
-  depends_on         = [aws_sagemaker_endpoint.sagemaker_endpoint, aws_sagemaker_endpoint_configuration.endpoint_config]
+  depends_on         = [aws_sagemaker_endpoint.main, aws_sagemaker_endpoint_configuration.main]
 }
 
 
@@ -69,17 +69,17 @@ resource "aws_appautoscaling_policy" "scale_up_to_n_policy" {
   name = "scale-up-to-n-policy-${var.model_name}"
 
   policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
-  depends_on         = [aws_appautoscaling_target.autoscaling_target]
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+  depends_on         = [aws_appautoscaling_target.main]
 
   step_scaling_policy_configuration {
     adjustment_type = "ChangeInCapacity"
     cooldown        = var.scale_up_cooldown
 
     step_adjustment {
-      scaling_adjustment          = 1
+      scaling_adjustment          = 1 # means add 1
       metric_interval_lower_bound = 0
       metric_interval_upper_bound = null
     }
@@ -91,17 +91,17 @@ resource "aws_appautoscaling_policy" "scale_down_to_n_policy" {
   name = "scale-down-to-n-policy-${var.model_name}"
 
   policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
-  depends_on         = [aws_appautoscaling_target.autoscaling_target]
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+  depends_on         = [aws_appautoscaling_target.main]
 
   step_scaling_policy_configuration {
     adjustment_type = "ChangeInCapacity"
     cooldown        = var.scale_down_cooldown
 
     step_adjustment {
-      scaling_adjustment          = -1
+      scaling_adjustment          = -1 # mean subtract 1
       metric_interval_lower_bound = null
       metric_interval_upper_bound = 0
     }
@@ -113,10 +113,10 @@ resource "aws_appautoscaling_policy" "scale_up_to_one_policy" {
   name = "scale-up-to-one-policy-${var.model_name}"
 
   policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
-  depends_on         = [aws_appautoscaling_target.autoscaling_target]
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+  depends_on         = [aws_appautoscaling_target.main]
 
   step_scaling_policy_configuration {
     adjustment_type = "ExactCapacity"
@@ -135,10 +135,10 @@ resource "aws_appautoscaling_policy" "scale_down_to_zero_policy" {
   name = "scale-down-to-zero-policy-${var.model_name}"
 
   policy_type        = "StepScaling"
-  resource_id        = aws_appautoscaling_target.autoscaling_target.resource_id
-  scalable_dimension = aws_appautoscaling_target.autoscaling_target.scalable_dimension
-  service_namespace  = aws_appautoscaling_target.autoscaling_target.service_namespace
-  depends_on         = [aws_appautoscaling_target.autoscaling_target]
+  resource_id        = aws_appautoscaling_target.main.resource_id
+  scalable_dimension = aws_appautoscaling_target.main.scalable_dimension
+  service_namespace  = aws_appautoscaling_target.main.service_namespace
+  depends_on         = [aws_appautoscaling_target.main]
 
   step_scaling_policy_configuration {
     adjustment_type = "ExactCapacity"
@@ -171,7 +171,7 @@ locals {
 
 resource "aws_cloudwatch_log_metric_filter" "unauthorized_operations" {
   name           = "unauthorized-operations-filter"
-  log_group_name = "/aws/sagemaker/Endpoints/${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  log_group_name = "/aws/sagemaker/Endpoints/${aws_sagemaker_endpoint.main.name}"
   pattern        = "{ $.errorCode = \"UnauthorizedOperation\" || $.errorCode = \"AccessDenied\" }"
 
   metric_transformation {

--- a/infra/modules/sagemaker_deployment/outputs.tf
+++ b/infra/modules/sagemaker_deployment/outputs.tf
@@ -2,21 +2,26 @@ output "model_name" {
   value = aws_sagemaker_model.sagemaker_model.name
 }
 
+
 output "endpoint_name" {
   value = aws_sagemaker_endpoint.sagemaker_endpoint.name
 }
+
 
 output "scale_up_to_one_policy_arn" {
   value = aws_appautoscaling_policy.scale_up_to_one_policy.arn
 }
 
+
 output "scale_down_to_zero_policy_arn" {
   value = aws_appautoscaling_policy.scale_down_to_zero_policy.arn
 }
 
+
 output "scale_up_to_n_policy_arn" {
   value = aws_appautoscaling_policy.scale_up_to_n_policy.arn
 }
+
 
 output "scale_down_to_n_policy_arn" {
   value = aws_appautoscaling_policy.scale_down_to_n_policy.arn

--- a/infra/modules/sagemaker_deployment/outputs.tf
+++ b/infra/modules/sagemaker_deployment/outputs.tf
@@ -1,10 +1,10 @@
 output "model_name" {
-  value = aws_sagemaker_model.sagemaker_model.name
+  value = aws_sagemaker_model.main.name
 }
 
 
 output "endpoint_name" {
-  value = aws_sagemaker_endpoint.sagemaker_endpoint.name
+  value = aws_sagemaker_endpoint.main.name
 }
 
 

--- a/infra/modules/sagemaker_deployment/sns.tf
+++ b/infra/modules/sagemaker_deployment/sns.tf
@@ -1,7 +1,7 @@
 resource "aws_sns_topic" "sns_topic_alarmstate" {
   count = length(var.alarms)
 
-  name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.main.name}"
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -21,7 +21,7 @@ resource "aws_sns_topic" "sns_topic_alarmstate" {
 resource "aws_sns_topic" "sns_topic_okstate" {
   count = length(var.alarms)
 
-  name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.main.name}"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -42,7 +42,7 @@ resource "aws_sns_topic" "sns_topic_okstate" {
 resource "aws_sns_topic" "sns_topic_composite" {
   count = length(var.alarm_composites)
 
-  name = "alarm-alarm-composite-lambda-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-topic"
+  name = "alarm-alarm-composite-lambda-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.main.name}-topic"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -62,7 +62,7 @@ resource "aws_sns_topic" "sns_topic_composite" {
 
 resource "aws_sns_topic" "alarm_composite_notifications" {
   count = length(var.alarm_composites)
-  name  = "alarm-composite-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-sns-topic"
+  name  = "alarm-composite-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.main.name}-sns-topic"
 }
 
 

--- a/infra/modules/sagemaker_deployment/sns.tf
+++ b/infra/modules/sagemaker_deployment/sns.tf
@@ -1,0 +1,137 @@
+resource "aws_sns_topic" "sns_topic_alarmstate" {
+  count = length(var.alarms)
+
+  name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "sns:Publish",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_sns_topic" "sns_topic_okstate" {
+  count = length(var.alarms)
+
+  name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "sns:Publish",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_sns_topic" "sns_topic_composite" {
+  count = length(var.alarm_composites)
+
+  name = "alarm-alarm-composite-lambda-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-topic"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "sns:Publish",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+
+resource "aws_sns_topic" "alarm_composite_notifications" {
+  count = length(var.alarm_composites)
+  name  = "alarm-composite-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.sagemaker_endpoint.name}-sns-topic"
+}
+
+
+resource "aws_sns_topic_policy" "composite_sns_topic_policy" {
+  count = length(var.alarm_composites)
+
+  arn = aws_sns_topic.alarm_composite_notifications[count.index].arn
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "AllowPublishFromCloudWatch"
+        Effect = "Allow",
+        Principal = {
+          Service = "cloudwatch.amazonaws.com"
+        },
+        Action   = "SNS:Publish",
+        Resource = aws_sns_topic.alarm_composite_notifications[count.index].arn
+      },
+      {
+        Sid       = "AllowSubscriptionActions"
+        Effect    = "Allow",
+        Principal = "*",
+        Action = [
+          "sns:Subscribe",
+          "sns:Receive"
+        ],
+        Resource = aws_sns_topic.alarm_composite_notifications[count.index].arn
+      }
+    ]
+  })
+}
+
+
+resource "aws_sns_topic_subscription" "sns_lambda_subscription_okstate" {
+  count = length(var.alarms)
+
+  topic_arn = aws_sns_topic.sns_topic_okstate[count.index].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_alert_function.arn
+}
+
+
+resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
+  count = length(var.alarms)
+
+  topic_arn = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_alert_function.arn
+}
+
+resource "aws_sns_topic_subscription" "sns_lambda_subscription_composite" {
+  count = length(var.alarm_composites)
+
+  topic_arn = aws_sns_topic.sns_topic_composite[count.index].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.slack_alert_function.arn
+}
+
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  count     = length(var.alarm_composites)
+  topic_arn = aws_sns_topic.alarm_composite_notifications[count.index].arn
+  protocol  = "email"
+  endpoint = flatten([
+    for variables in var.alarm_composites :
+    [
+      for email in variables.emails :
+      email
+    ]
+  ])[count.index]
+}

--- a/infra/modules/sagemaker_deployment/sns.tf
+++ b/infra/modules/sagemaker_deployment/sns.tf
@@ -1,4 +1,4 @@
-resource "aws_sns_topic" "sns_topic_alarmstate" {
+resource "aws_sns_topic" "alarmstate" {
   count = length(var.alarms)
 
   name = "alarm-alarmstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.main.name}"
@@ -18,7 +18,7 @@ resource "aws_sns_topic" "sns_topic_alarmstate" {
 }
 
 
-resource "aws_sns_topic" "sns_topic_okstate" {
+resource "aws_sns_topic" "okstate" {
   count = length(var.alarms)
 
   name = "alarm-okstate-${var.alarms[count.index].alarm_name_prefix}-${aws_sagemaker_endpoint.main.name}"
@@ -39,7 +39,7 @@ resource "aws_sns_topic" "sns_topic_okstate" {
 }
 
 
-resource "aws_sns_topic" "sns_topic_composite" {
+resource "aws_sns_topic" "composite_alarmstate" {
   count = length(var.alarm_composites)
 
   name = "alarm-alarm-composite-lambda-${var.alarm_composites[count.index].alarm_name}-${aws_sagemaker_endpoint.main.name}-topic"
@@ -100,7 +100,7 @@ resource "aws_sns_topic_policy" "composite_sns_topic_policy" {
 resource "aws_sns_topic_subscription" "sns_lambda_subscription_okstate" {
   count = length(var.alarms)
 
-  topic_arn = aws_sns_topic.sns_topic_okstate[count.index].arn
+  topic_arn = aws_sns_topic.okstate[count.index].arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.slack_alert_function.arn
 }
@@ -109,7 +109,7 @@ resource "aws_sns_topic_subscription" "sns_lambda_subscription_okstate" {
 resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
   count = length(var.alarms)
 
-  topic_arn = aws_sns_topic.sns_topic_alarmstate[count.index].arn
+  topic_arn = aws_sns_topic.alarmstate[count.index].arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.slack_alert_function.arn
 }
@@ -117,7 +117,7 @@ resource "aws_sns_topic_subscription" "sns_lambda_subscription_alarmstate" {
 resource "aws_sns_topic_subscription" "sns_lambda_subscription_composite" {
   count = length(var.alarm_composites)
 
-  topic_arn = aws_sns_topic.sns_topic_composite[count.index].arn
+  topic_arn = aws_sns_topic.composite_alarmstate[count.index].arn
   protocol  = "lambda"
   endpoint  = aws_lambda_function.slack_alert_function.arn
 }

--- a/infra/modules/sagemaker_deployment/variables.tf
+++ b/infra/modules/sagemaker_deployment/variables.tf
@@ -3,70 +3,84 @@ variable "sns_success_topic_arn" {
   description = "ARN of the SNS topic for Sagemaker successful async outputs"
 }
 
+
 variable "model_name" {
   type        = string
   description = "Name of the SageMaker model"
 }
+
 
 variable "s3_output_path" {
   type        = string
   description = "Where the async output of the model is sent"
 }
 
+
 variable "execution_role_arn" {
   type        = string
   description = "Execution role ARN for SageMaker"
 }
+
 
 variable "container_image" {
   type        = string
   description = "Container image for the model"
 }
 
+
 variable "model_uri" {
   type        = string
   description = "S3 URL where the model data is located"
 }
+
 
 variable "model_uri_compression" {
   type        = string
   description = "Whether the model weights are stored compressed and if so what compression type"
 }
 
+
 variable "environment_variables" {
   type        = map(string)
   description = "Environment variables for the container"
 }
+
 
 variable "security_group_ids" {
   type        = list(string)
   description = "List of security group IDs for the SageMaker model"
 }
 
+
 variable "subnets" {
   type        = list(string)
   description = "List of subnets for the SageMaker model"
 }
+
 
 variable "instance_type" {
   type        = string
   description = "Instance type for the endpoint"
 }
 
+
 variable "max_capacity" {
   type        = number
   description = "Maximum capacity for autoscaling"
 }
+
 
 variable "min_capacity" {
   type        = number
   description = "Minimum capacity for autoscaling"
 }
 
+
 variable "scale_up_cooldown" {
   type        = number
   description = "Cooldown period for scale up"
 }
+
 
 variable "scale_down_cooldown" {
   type        = number
@@ -93,6 +107,7 @@ variable "alarms" {
   description = "List of CloudWatch alarms to be created"
 }
 
+
 variable "alarm_composites" {
   type = list(object({
     alarm_name        = string
@@ -105,6 +120,7 @@ variable "alarm_composites" {
   }))
   description = "List of CloudWatch composite alarms to be created utilizing pre-existing alarms"
 }
+
 
 variable "aws_account_id" {
   type = string


### PR DESCRIPTION
To make the changes I'm implementing for composite alarms easier, I propose to refactor the sagemaker_deployment module by splitting it into multiple files. In this first MR I implement that split with no functional changes - so this terraform applies exactly to feat/sagemaker-llms. Merging this first should then make it easier to follow the changes in my second MR to follow where the functional changes will be.

Please see here for guidance on resource naming conventions:
https://developer.hashicorp.com/terraform/language/style#resource-naming