### PR TITLE
give visualisation base image access to data science gitlab runner

### DIFF
--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -1037,6 +1037,7 @@ data "aws_iam_policy_document" "gitlab_runner_data_science" {
 
     resources = [
       "${aws_ecr_repository.theia.arn}",
+      "${aws_ecr_repository.visualisation_base.arn}"
     ]
   }
 


### PR DESCRIPTION
This PR adds visualisation base image access to data science gitlab runner security policy

For the GitLab runner to be able to build packages