### PR TITLE
Chore/update versions and silence warning

### DIFF
--- a/infra/airflow_dag_tasks.tf
+++ b/infra/airflow_dag_tasks.tf
@@ -41,7 +41,7 @@ resource "aws_ecs_task_definition" "airflow_dag_tasks" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/airflow_scheduler.tf
+++ b/infra/airflow_scheduler.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_task_definition" "airflow_scheduler" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/airflow_webserver.tf
+++ b/infra/airflow_webserver.tf
@@ -163,7 +163,7 @@ resource "aws_ecs_task_definition" "airflow_webserver" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -138,7 +138,7 @@ resource "aws_ecs_service" "admin" {
 
   depends_on = [
     # The target group must have been associated with the listener first
-    "aws_alb_listener.admin",
+    aws_alb_listener.admin,
   ]
 }
 
@@ -175,7 +175,7 @@ resource "aws_ecs_task_definition" "admin" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }
@@ -221,7 +221,7 @@ resource "aws_ecs_task_definition" "admin_celery" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }
@@ -648,7 +648,7 @@ resource "aws_alb" "admin" {
   }
 
   depends_on = [
-    "aws_s3_bucket_policy.alb_access_logs",
+    aws_s3_bucket_policy.alb_access_logs,
   ]
 }
 

--- a/infra/ecs_main_arango.tf
+++ b/infra/ecs_main_arango.tf
@@ -28,8 +28,8 @@ resource "aws_ecs_service" "arango" {
 
   depends_on = [
     # The target group must have been associated with the listener first
-    "aws_lb_listener.arango",
-    "aws_autoscaling_group.arango_service"
+    aws_lb_listener.arango,
+    aws_autoscaling_group.arango_service
   ]
 }
 
@@ -155,7 +155,7 @@ resource "aws_ecs_task_definition" "arango_service" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_dns_rewrite_proxy.tf
+++ b/infra/ecs_main_dns_rewrite_proxy.tf
@@ -39,7 +39,7 @@ resource "aws_lb_target_group" "dns_rewrite_proxy" {
     port     = "8888"
   }
 
-  depends_on = ["aws_lb.dns_rewrite_proxy"]
+  depends_on = [aws_lb.dns_rewrite_proxy]
 }
 
 resource "aws_ecs_service" "dns_rewrite_proxy" {
@@ -101,7 +101,7 @@ resource "aws_ecs_task_definition" "dns_rewrite_proxy" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_dns_rewrite_proxy_new.tf
+++ b/infra/ecs_main_dns_rewrite_proxy_new.tf
@@ -39,7 +39,7 @@ resource "aws_lb_target_group" "dns_rewrite_proxy_new" {
     path     = "/"
   }
 
-  depends_on = ["aws_lb.dns_rewrite_proxy_new"]
+  depends_on = [aws_lb.dns_rewrite_proxy_new]
 }
 
 resource "aws_ecs_service" "dns_rewrite_proxy_new" {
@@ -91,7 +91,7 @@ resource "aws_ecs_task_definition" "dns_rewrite_proxy_new" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_flower.tf
+++ b/infra/ecs_main_flower.tf
@@ -20,7 +20,7 @@ resource "aws_ecs_service" "flower" {
   }
 
   depends_on = [
-    "aws_lb_listener.flower_80",
+    aws_lb_listener.flower_80,
   ]
 }
 
@@ -48,7 +48,7 @@ resource "aws_ecs_task_definition" "flower_service" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_gitlab.tf
+++ b/infra/ecs_main_gitlab.tf
@@ -31,8 +31,8 @@ resource "aws_ecs_service" "gitlab" {
 
   depends_on = [
     # The target group must have been associated with the listener first
-    "aws_lb_listener.gitlab_443",
-    "aws_lb_listener.gitlab_22",
+    aws_lb_listener.gitlab_443,
+    aws_lb_listener.gitlab_22,
   ]
 }
 
@@ -110,7 +110,7 @@ resource "aws_ecs_task_definition" "gitlab" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }
@@ -408,7 +408,7 @@ resource "aws_rds_cluster" "gitlab" {
 
   lifecycle {
     ignore_changes = [
-      "engine_version",
+      engine_version,
     ]
   }
 }

--- a/infra/ecs_main_healthcheck.tf
+++ b/infra/ecs_main_healthcheck.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "healthcheck" {
 
   depends_on = [
     # The target group must have been associated with the listener first
-    "aws_alb_listener.healthcheck",
+    aws_alb_listener.healthcheck,
   ]
 }
 
@@ -82,7 +82,7 @@ resource "aws_ecs_task_definition" "healthcheck" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }
@@ -193,7 +193,7 @@ resource "aws_alb" "healthcheck" {
   }
 
   depends_on = [
-    "aws_s3_bucket_policy.alb_access_logs",
+    aws_s3_bucket_policy.alb_access_logs,
   ]
 }
 

--- a/infra/ecs_main_mlflow.tf
+++ b/infra/ecs_main_mlflow.tf
@@ -47,7 +47,7 @@ resource "aws_ecs_service" "mlflow" {
   }
 
   depends_on = [
-    "aws_lb_listener.mlflow",
+    aws_lb_listener.mlflow,
   ]
 }
 
@@ -87,7 +87,7 @@ resource "aws_ecs_task_definition" "mlflow_service" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_prometheus.tf
+++ b/infra/ecs_main_prometheus.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_service" "prometheus" {
 
   depends_on = [
     # The target group must have been associated with the listener first
-    "aws_alb_listener.prometheus",
+    aws_alb_listener.prometheus,
   ]
 }
 
@@ -83,7 +83,7 @@ resource "aws_ecs_task_definition" "prometheus" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }
@@ -194,7 +194,7 @@ resource "aws_alb" "prometheus" {
   }
 
   depends_on = [
-    "aws_s3_bucket_policy.alb_access_logs",
+    aws_s3_bucket_policy.alb_access_logs,
   ]
 }
 

--- a/infra/ecs_main_sentryproxy.tf
+++ b/infra/ecs_main_sentryproxy.tf
@@ -67,7 +67,7 @@ resource "aws_ecs_task_definition" "sentryproxy" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_main_superset.tf
+++ b/infra/ecs_main_superset.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_service" "superset" {
   }
 
   depends_on = [
-    "aws_lb_listener.superset_443",
+    aws_lb_listener.superset_443,
   ]
 }
 
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "superset_service" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_matchbox_matchbox.tf
+++ b/infra/ecs_matchbox_matchbox.tf
@@ -73,7 +73,7 @@ resource "aws_ecs_task_definition" "matchbox_service" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_jupyterlab_python.tf
+++ b/infra/ecs_notebooks_jupyterlab_python.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "jupyterlabpython" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_task_definition" "notebook" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_remote_desktop.tf
+++ b/infra/ecs_notebooks_remote_desktop.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "remotedesktop" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_superset.tf
+++ b/infra/ecs_notebooks_superset.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "superset" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_theia.tf
+++ b/infra/ecs_notebooks_theia.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "theia" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_notebooks_vscode.tf
+++ b/infra/ecs_notebooks_vscode.tf
@@ -36,7 +36,7 @@ resource "aws_ecs_task_definition" "vscode" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_pgadmin.tf
+++ b/infra/ecs_pgadmin.tf
@@ -39,7 +39,7 @@ resource "aws_ecs_task_definition" "pgadmin" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_rstudio.tf
+++ b/infra/ecs_rstudio.tf
@@ -39,7 +39,7 @@ resource "aws_ecs_task_definition" "rstudio" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_rstudio_rv4.tf
+++ b/infra/ecs_rstudio_rv4.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_task_definition" "rstudio_rv4" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/ecs_user_provided.tf
+++ b/infra/ecs_user_provided.tf
@@ -24,7 +24,7 @@ resource "aws_ecs_task_definition" "user_provided" {
 
   lifecycle {
     ignore_changes = [
-      "revision",
+      revision,
     ]
   }
 }

--- a/infra/environment-template/versions.tf
+++ b/infra/environment-template/versions.tf
@@ -1,4 +1,10 @@
-
 terraform {
-  required_version = ">= 1.3.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.89"
+    }
+  }
+
+  required_version = ">= 1.11"
 }

--- a/infra/rds_admin.tf
+++ b/infra/rds_admin.tf
@@ -28,9 +28,9 @@ resource "aws_db_instance" "admin" {
 
   lifecycle {
     ignore_changes = [
-      "snapshot_identifier",
-      "final_snapshot_identifier",
-      "engine_version",
+      snapshot_identifier,
+      final_snapshot_identifier,
+      engine_version,
     ]
   }
 }

--- a/infra/rds_datasets.tf
+++ b/infra/rds_datasets.tf
@@ -15,7 +15,7 @@ resource "aws_rds_cluster" "datasets" {
 
   timeouts {}
   lifecycle {
-    ignore_changes = ["master_password", "engine_version"]
+    ignore_changes = [master_password, engine_version]
   }
 }
 
@@ -31,7 +31,7 @@ resource "aws_rds_cluster_instance" "datasets" {
   monitoring_interval          = var.datasets_rds_cluster_instance_monitoring_interval
 
   lifecycle {
-    ignore_changes = ["engine_version"]
+    ignore_changes = [engine_version]
   }
 }
 

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -1,10 +1,10 @@
 data "aws_route53_zone" "aws_route53_zone" {
-  provider = "aws.route53"
+  provider = aws.route53
   name     = var.aws_route53_zone
 }
 
 resource "aws_route53_record" "admin" {
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = var.admin_domain
   type     = "A"
@@ -21,7 +21,7 @@ resource "aws_route53_record" "admin" {
 }
 
 resource "aws_route53_record" "applications" {
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = "*.${var.admin_domain}"
   type     = "A"
@@ -52,7 +52,7 @@ resource "aws_acm_certificate_validation" "admin" {
 }
 
 resource "aws_route53_record" "healthcheck" {
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = var.healthcheck_domain
   type     = "A"
@@ -82,7 +82,7 @@ resource "aws_acm_certificate_validation" "healthcheck" {
 }
 
 resource "aws_route53_record" "prometheus" {
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = var.prometheus_domain
   type     = "A"
@@ -113,7 +113,7 @@ resource "aws_acm_certificate_validation" "prometheus" {
 
 resource "aws_route53_record" "gitlab" {
   count    = var.gitlab_on ? 1 : 0
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = var.gitlab_domain
   type     = "A"
@@ -131,7 +131,7 @@ resource "aws_route53_record" "gitlab" {
 
 resource "aws_route53_record" "superset_internal" {
   count    = var.superset_on ? 1 : 0
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = var.superset_internal_domain
   type     = "A"
@@ -149,7 +149,7 @@ resource "aws_route53_record" "superset_internal" {
 
 resource "aws_route53_record" "mlflow_internal" {
   count    = var.mlflow_on ? length(var.mlflow_instances) : 0
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = "mlflow--${var.mlflow_instances_long[count.index]}--internal.${var.admin_domain}"
   type     = "A"
@@ -163,7 +163,7 @@ resource "aws_route53_record" "mlflow_internal" {
 
 resource "aws_route53_record" "mlflow_data_flow" {
   count    = var.mlflow_on ? length(var.mlflow_instances) : 0
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = "mlflow--${var.mlflow_instances_long[count.index]}--data-flow.${var.admin_domain}"
   type     = "A"
@@ -192,7 +192,7 @@ resource "aws_acm_certificate_validation" "superset_internal" {
 
 resource "aws_route53_record" "arango" {
   count    = var.arango_on ? 1 : 0
-  provider = "aws.route53"
+  provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id
   name     = "arango.${var.admin_domain}"
   type     = "A"


### PR DESCRIPTION
Update references to versions of terraform and aws provider to latest and silence a warning that has been present since terraform v0.11

```
│ Warning: Quoted references are deprecated
│ 
│   on ../../data-workspace/infra/ecs_main_admin.tf line 224, in resource "aws_ecs_task_definition" "admin_celery":
│  224:       "revision",
│ 
│ In this context, references are expected literally rather than in quotes. Terraform 0.11 and earlier required quotes, but quoted references are now deprecated and will be removed in a
│ future version of Terraform. Remove the quotes surrounding this reference to silence this warning.
│ 
│ (and 52 more similar warnings elsewhere)
```