### PR TITLE
remove redundant sagemaker policies

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -124,41 +124,6 @@ data "aws_iam_policy_document" "notebook_task_execution" {
     ]
   }
 
-  dynamic "statement" {
-
-    for_each = var.sagemaker_on ? [1] : []
-
-    content {
-      actions = [
-        "sagemaker:DescribeEndpoint",
-        "sagemaker:DescribeEndpointConfig",
-        "sagemaker:DescribeModel",
-        "sagemaker:InvokeEndpointAsync",
-        "sagemaker:ListEndpoints",
-        "sagemaker:ListEndpointConfigs",
-        "sagemaker:ListModels",
-      ]
-
-      resources = [
-        "*",
-      ]
-    }
-  }
-
-  dynamic "statement" {
-
-    for_each = var.sagemaker_on ? [1] : []
-
-    content {
-      actions = [
-        "ec2:*VpcEndpoint*"
-      ]
-      resources = [
-        "*",
-      ]
-    }
-  }
-
   statement {
     actions = [
       "ecr:GetAuthorizationToken",


### PR DESCRIPTION
removing IAM policy that is granting permissions for sagemaker endpoints
removing IAM policy that is grantinc permissions for VPC endpoints

these permissions were on the task exection role which is assumed by ECS infra and ECS ifra doesn't make sagemaker calls