### PR TITLE
remove vpc endpoint access for sagemaker

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -257,20 +257,6 @@ data "aws_iam_policy_document" "notebook_s3_access_template" {
       ]
     }
   }
-
-  dynamic "statement" {
-
-    for_each = var.sagemaker_on ? [1] : []
-
-    content {
-      actions = [
-        "ec2:*VpcEndpoint*"
-      ]
-      resources = [
-        "*",
-      ]
-    }
-  }
 }
 
 resource "aws_vpc_endpoint" "s3" {


### PR DESCRIPTION
from notebook_s3_access_template policy, to restrict tools from doing anything on vpcs