### PR TITLE
fix: restore SageMaker access without access to other accounts

### DIFF
--- a/infra/ecs_notebooks_notebook.tf
+++ b/infra/ecs_notebooks_notebook.tf
@@ -253,7 +253,7 @@ data "aws_iam_policy_document" "notebook_s3_access_template" {
       ]
 
       resources = [
-        "arn:aws:sagemaker:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:*/*",
+        "*",
       ]
     }
   }
@@ -457,7 +457,7 @@ data "aws_iam_policy_document" "jupyterhub_notebook_task_boundary" {
       ]
 
       resources = [
-        "arn:aws:sagemaker:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:*/*",
+        "*",
       ]
     }
   }

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1055,6 +1055,9 @@ resource "aws_vpc_endpoint" "sagemaker_api_endpoint_main" {
 }
 
 data "aws_iam_policy_document" "sagemaker_vpc_endpoint_policy" {
+  # Prevents access to other AWS accounts through the VPC endpoint. There are policies on the
+  # roles themselves that restrict the actions and/or resources
+
   count = var.sagemaker_on ? 1 : 0
   statement {
     principals {
@@ -1062,17 +1065,16 @@ data "aws_iam_policy_document" "sagemaker_vpc_endpoint_policy" {
       identifiers = ["*"]
     }
     actions = [
-      "sagemaker:DescribeEndpoint",
-      "sagemaker:DescribeEndpointConfig",
-      "sagemaker:DescribeModel",
-      "sagemaker:InvokeEndpointAsync",
-      "sagemaker:ListEndpoints",
-      "sagemaker:ListEndpointConfigs",
-      "sagemaker:ListModels",
+      "*",
     ]
     resources = [
-      "arn:aws:sagemaker:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:*/*",
+      "*",
     ]
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::${data.aws_caller_identity.aws_caller_identity.account_id}:role/*"]
+    }
   }
 }
 


### PR DESCRIPTION
Recent changes incorrectly used specific resources in SageMaker actions in an attempt to restrict access from tools to other AWS Accounts.

However, various SageMaker actions only support "*" as the resource, so access has to be restricted using another mechanism - for example using a ConditionKey on the Principal. This is what this change does.

It also slightly opens up the policy on the SageMaker VPC Endpoint to allow all actions. This is done to keep the terraform/policy code minimal, and doesn't actually increase what users(via their AWS role) can do, because they still have an identity-based policy that restricts that.