### PR TITLE
remove SageMaker security group rules

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -560,67 +560,6 @@ resource "aws_security_group_rule" "notebooks_egress_arango_lb" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "sagemaker_endpoint_ingress_to_notebooks" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "ingress-from-sagemaker-endpoints"
-
-  security_group_id        = aws_security_group.notebooks.id
-  source_security_group_id = aws_security_group.sagemaker_endpoints[0].id
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "sagemaker_endpoint_egress_to_notebooks" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "egress-to-sagemaker-endpoints"
-
-  security_group_id        = aws_security_group.notebooks.id
-  source_security_group_id = aws_security_group.sagemaker_endpoints[0].id
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "notebooks_egress_sagemaker_vpc" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "egress-sagemaker-vpc"
-
-  security_group_id = aws_security_group.notebooks.id
-  cidr_blocks       = ["0.0.0.0/0"]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "TCP"
-}
-
-resource "aws_security_group_rule" "notebooks_ingress_sagemaker_vpc" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "egress-sagemaker-vpc"
-
-  security_group_id = aws_security_group.notebooks.id
-  cidr_blocks       = [aws_vpc.sagemaker[0].cidr_block]
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "TCP"
-}
-
-
 ###########################
 ## To test SageMaker VPC ##
 ###########################


### PR DESCRIPTION
Removing SageMaker ingress and egress security group rules because they are not needed.