### PR TITLE
refactor: remove unused SageMaker security group rules and peering

### DIFF
--- a/infra/sagemaker.tf
+++ b/infra/sagemaker.tf
@@ -33,50 +33,8 @@ resource "aws_security_group_rule" "ingress_sagemaker_vpc_endpoint_notebooks_vpc
   cidr_blocks       = [aws_vpc.notebooks.cidr_block]
 
   type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "egress_sagemaker_vpc_endpoint_notebooks_vpc" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-from-notebooks-vpc"
-
-  security_group_id = aws_security_group.sagemaker_vpc_endpoints_main[0].id
-  cidr_blocks       = [aws_vpc.notebooks.cidr_block]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "ingress_sagemaker_vpc_endpoint_sagemaker_vpc" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-from-sagemaker-vpc"
-
-  security_group_id = aws_security_group.sagemaker_vpc_endpoints_main[0].id
-  cidr_blocks       = [aws_vpc.sagemaker[0].cidr_block]
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "egress_sagemaker_vpc_endpoints_sagemaker_vpc" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-from-sagemaker-vpc"
-
-  security_group_id = aws_security_group.sagemaker_vpc_endpoints_main[0].id
-  cidr_blocks       = [aws_vpc.sagemaker[0].cidr_block]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
+  from_port = "443"
+  to_port   = "443"
   protocol  = "tcp"
 }
 
@@ -100,34 +58,6 @@ resource "aws_security_group" "sagemaker_endpoints" {
   }
 }
 
-resource "aws_security_group_rule" "notebooks_endpoint_ingress_sagemaker_test" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-sagemaker-to-notebooks-vpc"
-
-  security_group_id = aws_security_group.sagemaker_endpoints[0].id
-  cidr_blocks       = [aws_vpc.notebooks.cidr_block]
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "notebooks_endpoint_egress_sagemaker_test" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-egress-notebooks-to-sagemaker-vpc"
-
-  security_group_id = aws_security_group.sagemaker_endpoints[0].id
-  cidr_blocks       = [aws_vpc.notebooks.cidr_block]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
 resource "aws_security_group_rule" "sagemaker_vpc_endpoint_egress" {
   count = var.sagemaker_on ? 1 : 0
 
@@ -135,83 +65,6 @@ resource "aws_security_group_rule" "sagemaker_vpc_endpoint_egress" {
 
   security_group_id = aws_security_group.sagemaker_endpoints[0].id
   cidr_blocks       = ["0.0.0.0/0"]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-
-
-resource "aws_security_group" "main_to_sagemaker" {
-  count = var.sagemaker_on ? 1 : 0
-
-  name        = "${var.prefix}-main-to-sagemaker-endpoints"
-  description = "${var.prefix}-sagemaker-access-VPC-endpoints-in-main"
-  vpc_id      = aws_vpc.main.id
-
-  tags = {
-    Name = "${var.prefix}-sagemaker-endpoints-main"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "sagemaker_to_main_ingress" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-sagemaker-to-main-vpc"
-
-  security_group_id = aws_security_group.main_to_sagemaker[0].id
-  cidr_blocks       = [aws_vpc.sagemaker[0].cidr_block]
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "sagemaker_to_main_egress" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-egress-sagemaker-to-main-vpc"
-
-  security_group_id = aws_security_group.main_to_sagemaker[0].id
-  cidr_blocks       = [aws_vpc.sagemaker[0].cidr_block]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-
-#### Used to allow access to VPC endpoints in Main
-
-resource "aws_security_group_rule" "main_ingress_sagemaker_endpoints" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-sagemaker-to-main-vpc"
-
-  security_group_id = aws_security_group.sagemaker_endpoints[0].id
-  cidr_blocks       = [aws_vpc.main.cidr_block]
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "sagemaker_endpoints_egress_main" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-egress-notebooks-to-main-vpc"
-
-  security_group_id = aws_security_group.sagemaker_endpoints[0].id
-  cidr_blocks       = [aws_vpc.main.cidr_block]
 
   type      = "egress"
   from_port = "0"

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -878,31 +878,6 @@ resource "aws_subnet" "sagemaker_private_without_egress" {
   }
 }
 
-##################################################################
-### VPC Peering Connections from SageMaker to Main & Notebooks ###
-##################################################################
-
-resource "aws_vpc_peering_connection" "main_to_sagemaker" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  peer_vpc_id = aws_vpc.sagemaker[0].id
-  vpc_id      = aws_vpc.main.id
-  auto_accept = true
-
-  accepter {
-    allow_remote_vpc_dns_resolution = true
-  }
-
-  requester {
-    allow_remote_vpc_dns_resolution = true
-  }
-
-  tags = {
-    Name = "${var.prefix}-main-to-sagemaker"
-  }
-}
-
 resource "aws_route_table" "sagemaker" {
 
   count = var.sagemaker_on ? 1 : 0


### PR DESCRIPTION
This removes the peering connection between the SageMaker VPC and the Main VPC (we thought we did this earlier, but only removed some routes), removes some unnecessary security group rules, and tightens the rule between the SageMaker endpoints in the Notebooks VPC and the main VPC.