### PR TITLE
security: tighten SageMaker security groups

### DIFF
--- a/infra/sagemaker.tf
+++ b/infra/sagemaker.tf
@@ -38,10 +38,6 @@ resource "aws_security_group_rule" "ingress_sagemaker_vpc_endpoint_notebooks_vpc
   protocol  = "tcp"
 }
 
-###############################
-## To test new SageMaker VPC ##
-###############################
-
 resource "aws_security_group" "sagemaker_endpoints" {
   count = var.sagemaker_on ? 1 : 0
 
@@ -56,20 +52,6 @@ resource "aws_security_group" "sagemaker_endpoints" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_security_group_rule" "sagemaker_vpc_endpoint_egress" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-egress-notebooks-to-sagemaker-vpc"
-
-  security_group_id = aws_security_group.sagemaker_endpoints[0].id
-  cidr_blocks       = ["0.0.0.0/0"]
-
-  type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
 }
 
 # SageMaker Execution Role Output

--- a/infra/sagemaker_llm_resources.tf
+++ b/infra/sagemaker_llm_resources.tf
@@ -39,7 +39,7 @@ module "gpt_neo_125m_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn
@@ -90,7 +90,7 @@ module "flan_t5_780m_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn
@@ -141,7 +141,7 @@ module "phi_2_3b_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn
@@ -194,7 +194,7 @@ module "llama_3_3b_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn
@@ -247,7 +247,7 @@ module "llama_3_3b_instruct_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn
@@ -299,7 +299,7 @@ module "mistral_7b_instruct_deployment" {
 
   # These variables do not change between LLMs
   source                  = "./modules/sagemaker_deployment"
-  security_group_ids      = [aws_security_group.sagemaker[0].id, aws_security_group.sagemaker_endpoints[0].id]
+  security_group_ids      = [aws_security_group.sagemaker[0].id]
   subnets                 = aws_subnet.sagemaker_private_without_egress.*.id
   aws_account_id          = data.aws_caller_identity.aws_caller_identity.account_id
   sns_success_topic_arn   = module.sagemaker_output_mover[0].sns_success_topic_arn

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -560,10 +560,6 @@ resource "aws_security_group_rule" "notebooks_egress_arango_lb" {
   protocol  = "tcp"
 }
 
-###########################
-## To test SageMaker VPC ##
-###########################
-
 resource "aws_security_group" "sagemaker" {
 
   count = var.sagemaker_on ? 1 : 0
@@ -581,22 +577,7 @@ resource "aws_security_group" "sagemaker" {
   }
 }
 
-resource "aws_security_group_rule" "sagemaker_endpoint_ingress_to_sagemaker_vpc" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "ingress-from-sagemaker-endpoints"
-
-  security_group_id        = aws_security_group.sagemaker[0].id
-  source_security_group_id = aws_security_group.sagemaker_endpoints[0].id
-
-  type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "sagemaker_endpoint_egress_to_sagemaker_vpc" {
+resource "aws_security_group_rule" "sagemaker_egress_to_sagemaker_endpoints" {
 
   count = var.sagemaker_on ? 1 : 0
 
@@ -606,8 +587,38 @@ resource "aws_security_group_rule" "sagemaker_endpoint_egress_to_sagemaker_vpc" 
   source_security_group_id = aws_security_group.sagemaker_endpoints[0].id
 
   type      = "egress"
-  from_port = "0"
-  to_port   = "65535"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "sagemaker_egress_to_s3_endpoint" {
+
+  count = var.sagemaker_on ? 1 : 0
+
+  description = "egress-to-s3"
+
+  security_group_id = aws_security_group.sagemaker[0].id
+  prefix_list_ids   = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
+
+  type      = "egress"
+  from_port = "443"
+  to_port   = "443"
+  protocol  = "tcp"
+}
+
+resource "aws_security_group_rule" "sagemaker_endpoint_egress_to_sagemaker_vpc" {
+
+  count = var.sagemaker_on ? 1 : 0
+
+  description = "ingress-from-sagemaker"
+
+  security_group_id        = aws_security_group.sagemaker_endpoints[0].id
+  source_security_group_id = aws_security_group.sagemaker[0].id
+
+  type      = "ingress"
+  from_port = "443"
+  to_port   = "443"
   protocol  = "tcp"
 }
 

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1070,7 +1070,7 @@ resource "aws_vpc_endpoint" "sns_endpoint_sagemaker" {
   service_name       = "com.amazonaws.eu-west-2.sns"
   vpc_endpoint_type  = "Interface"
   subnet_ids         = aws_subnet.sagemaker_private_without_egress.*.id
-  security_group_ids = [aws_security_group.sagemaker_endpoints[0].id, aws_security_group.sagemaker[0].id]
+  security_group_ids = [aws_security_group.sagemaker_endpoints[0].id]
   tags = {
     Environment = var.prefix
     Name        = "sns-endpoint"


### PR DESCRIPTION
- Makes sure that the models have one security group, and the VPC endpoints relating to SageMaker have another, so they can be controlled separately.
- Tightens the allowed port for sagemaker to communicate with endpoints to just 443, and only to endpoints
- Removes unnecessary egress on the endpoint security group, since endpoints as far as I know do not initiate connections, which is what egress allows