### PR TITLE
TF-235: Increasing uptime of LLMs and abstracting

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -313,6 +313,36 @@ variable "sagemaker_mistral_7b_instruct" {
   default = false
 }
 
+variable "sagemaker_gpt_neo_125m_scale_up_cooldown" {
+  type    = number
+  default = 900
+}
+variable "sagemaker_flan_t3_780m_scaleup_cooldown" {
+  type    = number
+  default = 900
+}
+
+variable "sagemaker_phi_2_3b_scaleup_cooldown" {
+  type    = number
+  default = 900
+}
+
+variable "sagemaker_llama_3_3b_scaleup_cooldown" {
+  type    = number
+  default = 900
+}
+
+variable "sagemaker_llama_3_3b_instruct_scaleup_cooldown" {
+  type    = number
+  default = 900
+}
+
+variable "sagemaker_mistral_7b_instruct_scaleup_cooldown" {
+  type    = number
+  default = 900
+}
+
+
 variable "matchbox_on" {
   type    = bool
   default = false

--- a/infra/sagemaker_llm_resources.tf
+++ b/infra/sagemaker_llm_resources.tf
@@ -11,7 +11,7 @@ module "gpt_neo_125m_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g5.2xlarge" # 8 vCPU and 1 GPU and 32 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900
+  scale_up_cooldown     = var.sagemaker_gpt_neo_125m_scale_up_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
@@ -62,7 +62,7 @@ module "flan_t5_780m_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g5.2xlarge" # 8 vCPU and 1 GPU and 32 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900
+  scale_up_cooldown     = var.sagemaker_flan_t3_780m_scaleup_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
@@ -114,7 +114,7 @@ module "phi_2_3b_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g5.xlarge" # 4 vCPU and 1 GPU and 16 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900
+  scale_up_cooldown     = var.sagemaker_phi_2_3b_scaleup_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
@@ -165,7 +165,7 @@ module "llama_3_3b_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g6.xlarge" # 4 vCPU and 1 GPU and 16 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900 * 4
+  scale_up_cooldown     = var.sagemaker_llama_3_3b_scaleup_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
@@ -218,7 +218,7 @@ module "llama_3_3b_instruct_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g6.xlarge" # 4 vCPU and 1 GPU and 16 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900 * 4
+  scale_up_cooldown     = var.sagemaker_llama_3_3b_instruct_scaleup_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",
@@ -271,7 +271,7 @@ module "mistral_7b_instruct_deployment" {
   model_uri_compression = "None"
   instance_type         = "ml.g5.12xlarge" # 48 vCPU and 4 GPU and 192 GB-RAM
   max_capacity          = 2
-  scale_up_cooldown     = 900 * 4
+  scale_up_cooldown     = var.sagemaker_mistral_7b_instruct_scaleup_cooldown
   scale_down_cooldown   = 0
   environment_variables = {
     "ENDPOINT_SERVER_TIMEOUT" : "3600",


### PR DESCRIPTION
Updates as required for sagemaker https://uktrade.atlassian.net/browse/TF-235?atlOrigin=eyJpIjoiMDIzMGU4Y2FiZTMyNDk1ODljYmJiNDg5MTM0NzYxYjgiLCJwIjoiaiJ9

Because the variables that set the uptime of the LLMs on each invoke are set in data-workspace repo, they can’t be varied by environment. There is an interest to vary these so that instead of 60mins uptime as set in dev-a then the production environment should be 15mins. The way this can be achieved is to set within data-workspace code that these are externally set variables, and then set the values within data-workspace-deploy instead. Then can be 60mins in dev-a and 15mins in prod. This MR resolves this by abstracting this.