### PR TITLE
feat: add internet gateway to matchbox vpc

### DIFF
--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1151,7 +1151,7 @@ resource "aws_route_table" "matchbox" {
   count  = var.matchbox_on ? 1 : 0
   vpc_id = aws_vpc.matchbox[0].id
   tags = {
-    Name = "${var.prefix}-matchbox"
+    Name = "${var.prefix}-matchbox-private"
   }
 }
 
@@ -1166,6 +1166,73 @@ resource "aws_route" "pcx_matchbox_to_notebooks" {
   route_table_id            = aws_route_table.matchbox[0].id
   destination_cidr_block    = aws_vpc.notebooks.cidr_block
   vpc_peering_connection_id = aws_vpc_peering_connection.matchbox_to_notebooks[0].id
+}
+
+resource "aws_route" "matchbox_private_nat_gateway_ipv4" {
+  count                  = var.matchbox_on ? 1 : 0
+  route_table_id         = aws_route_table.matchbox[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.matchbox[0].id
+}
+
+
+resource "aws_route_table" "matchbox_public" {
+  count  = var.matchbox_on ? 1 : 0
+  vpc_id = aws_vpc.matchbox[0].id
+  tags = {
+    Name = "${var.prefix}-matchbox-public"
+  }
+}
+
+resource "aws_subnet" "matchbox_public" {
+  count = var.matchbox_on ? length(var.aws_availability_zones) : 0
+
+  vpc_id     = aws_vpc.matchbox[0].id
+  cidr_block = cidrsubnet(aws_vpc.matchbox[0].cidr_block, var.vpc_matchbox_subnets_num_bits, length(var.aws_availability_zones) + count.index)
+
+  availability_zone = var.aws_availability_zones[count.index]
+
+  tags = {
+    Name = "${var.prefix}-public-matchbox-${var.aws_availability_zones_short[count.index]}"
+  }
+}
+
+resource "aws_route_table_association" "matchbox_public" {
+  count          = var.matchbox_on ? length(var.aws_availability_zones) : 0
+  subnet_id      = aws_subnet.matchbox_public[count.index].id
+  route_table_id = aws_route_table.matchbox_public[0].id
+}
+
+
+resource "aws_internet_gateway" "matchbox" {
+  count  = var.matchbox_on ? 1 : 0
+  vpc_id = aws_vpc.matchbox[0].id
+
+  tags = {
+    Name = "${var.prefix}-matchbox"
+  }
+}
+
+resource "aws_route" "matchbox_public_internet_gateway" {
+  count                  = var.matchbox_on ? 1 : 0
+  route_table_id         = aws_route_table.matchbox_public[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.matchbox[0].id
+}
+
+resource "aws_nat_gateway" "matchbox" {
+  count         = var.matchbox_on ? 1 : 0
+  allocation_id = aws_eip.matchbox[0].id
+  subnet_id     = aws_subnet.matchbox_public[0].id
+
+  tags = {
+    Name = "${var.prefix}-matchbox"
+  }
+}
+
+resource "aws_eip" "matchbox" {
+  count = var.matchbox_on ? 1 : 0
+  vpc   = true
 }
 
 resource "aws_vpc_endpoint" "matchbox_ecr_api_endpoint" {


### PR DESCRIPTION
This adds internet access to the matchbox VPC - done in order for it to be able to send metrics/logs to Datadog.

This is done using the standard public/private subnet pattern: adding a public subnet with an NAT instance that routes to the internet via an internet gateway.