### PR TITLE
feat: improve matchbox datadog config

### DIFF
--- a/infra/ecs_matchbox_matchbox_container_definitions.json
+++ b/infra/ecs_matchbox_matchbox_container_definitions.json
@@ -97,6 +97,10 @@
         "value": "true"
       },
       {
+        "name": "DD_APM_NON_LOCAL_TRAFFIC",
+        "value": "true"
+      },
+      {
         "name": "DD_LOGS_ENABLED",
         "value": "true"
       },
@@ -111,10 +115,6 @@
       {
         "name": "DD_SITE",
         "value": "datadoghq.eu"
-      },
-      {
-        "name": "DD_HOSTNAME",
-        "value": "127.0.0.1"
       }
     ],
     "essential": true,


### PR DESCRIPTION
## What

Speculative improvements to matchbox datadog config:

- Removing DD_HOST since I think the agent can detect this fine
- Enabling DD_APM_NON_LOCAL_TRAFFIC since that is apparently needed for multi-container environments
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

To try to get more data into Datadog from Matchbox

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
