### PR TITLE
API Key variable added to matchbox container

### DIFF
--- a/infra/ecs_matchbox_matchbox.tf
+++ b/infra/ecs_matchbox_matchbox.tf
@@ -13,6 +13,7 @@ locals {
     mb__postgres__user       = "${aws_rds_cluster.matchbox[i].master_username}"
     mb__postgres__password   = "${random_string.aws_db_instance_matchbox_password[i].result}"
     mb__postgres__database   = "${aws_rds_cluster.matchbox[i].database_name}"
+    mb__api__ai_key          = "${var.matchbox_api_key}"
     sentry_matchbox_dsn      = "${var.sentry_matchbox_dsn}"
     matchbox_datadog_api_key = "${var.matchbox_datadog_api_key}"
     datadog_container_image  = "${aws_ecr_repository.datadog.repository_url}:7"

--- a/infra/ecs_matchbox_matchbox_container_definitions.json
+++ b/infra/ecs_matchbox_matchbox_container_definitions.json
@@ -50,6 +50,10 @@
         "value": "mb"
       },
       {
+        "name": "MB__API__API_KEY",
+        "value": "${mb__api__ai_key}"
+      },
+      {
         "name": "SENTRY_MATCHBOX_DSN",
         "value": "${sentry_matchbox_dsn}"
       },

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -368,6 +368,11 @@ variable "matchbox_datadog_environment" {
   default = ""
 }
 
+variable "matchbox_api_key" {
+  type    = string
+  default = ""
+}
+
 locals {
   admin_container_name   = "jupyterhub-admin"
   admin_container_port   = "8000"


### PR DESCRIPTION
## What

We are adding basic API Key authentication to write endpoints for the Matchbox API container. This PR adds the API Key to the Matchbox API container as an environment variable. 

## Why

To reduce write endpoint access to a more limited set of users. 

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
