### PR TITLE
refactor: added missing "p" to "mb_api_ai_key"

### DIFF
--- a/infra/ecs_matchbox_matchbox.tf
+++ b/infra/ecs_matchbox_matchbox.tf
@@ -13,7 +13,7 @@ locals {
     mb__postgres__user       = "${aws_rds_cluster.matchbox[i].master_username}"
     mb__postgres__password   = "${random_string.aws_db_instance_matchbox_password[i].result}"
     mb__postgres__database   = "${aws_rds_cluster.matchbox[i].database_name}"
-    mb__api__ai_key          = "${var.matchbox_api_key}"
+    mb__api__api_key         = "${var.matchbox_api_key}"
     sentry_matchbox_dsn      = "${var.sentry_matchbox_dsn}"
     matchbox_datadog_api_key = "${var.matchbox_datadog_api_key}"
     datadog_container_image  = "${aws_ecr_repository.datadog.repository_url}:7"

--- a/infra/ecs_matchbox_matchbox_container_definitions.json
+++ b/infra/ecs_matchbox_matchbox_container_definitions.json
@@ -51,7 +51,7 @@
       },
       {
         "name": "MB__API__API_KEY",
-        "value": "${mb__api__ai_key}"
+        "value": "${mb__api__api_key}"
       },
       {
         "name": "SENTRY_MATCHBOX_DSN",


### PR DESCRIPTION
## What

Added missing "p" to "mb_api_ai_key" in "infra/ecs_matchbox…_matchbox.tf" and "infra/ecs_matchbox_matchbox_container_definitions.json"

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
