### PR TITLE
feat: add Matchbox client API root variable to tools

### DIFF
--- a/infra/ecs_main_admin.tf
+++ b/infra/ecs_main_admin.tf
@@ -107,6 +107,10 @@ locals {
     arango_db__host     = ""
     arango_db__password = ""
     arango_db__port     = ""
+    }, var.matchbox_on ? {
+    matchbox_client_api_root = "http://matchbox.${var.admin_domain}:8000"
+    } : {
+    matchbox_client_api_root = ""
     }
   )
 }

--- a/infra/ecs_main_admin_container_definitions.json
+++ b/infra/ecs_main_admin_container_definitions.json
@@ -965,6 +965,10 @@
         "value": "eu-west-2"
       },
       {
+        "name": "APPLICATION_SPAWNER_OPTIONS__FARGATE__TOOL__MATCHBOX_CLIENT_API_ROOT",
+        "value": "${matchbox_client_api_root}"
+      },
+      {
         "name": "APPLICATION_ROOT_DOMAIN",
         "value": "${root_domain}"
       },


### PR DESCRIPTION
## What

This is the infrastructure side of https://github.com/uktrade/data-workspace-frontend/pull/3522, populating an environment variable in tools.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is so the Matchbox client library can more easily communicate with Matchbox.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
