### PR TITLE
ci: upgrade Ubuntu in linting

### DIFF
--- a/.github/workflows/lint-terraform-python.yml
+++ b/.github/workflows/lint-terraform-python.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint Terraform
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"


### PR DESCRIPTION
## What

This upgrade Ubuntu in GitHub actions for the linting job

## Why

This is because the older version is under brownout and will be completely removed soon.

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
