### PR TITLE
feat: Matchbox CodeBuild triggerable from GitHub merge or releases

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -415,6 +415,26 @@ variable "matchbox_github_source_url" {
   default = "https://github.com/uktrade/matchbox.git"
 }
 
+variable "matchbox_codeconnection_arn" {
+  type    = string
+  default = ""
+}
+
+variable "matchbox_deploy_on_github_merge" {
+  type    = bool
+  default = false
+}
+
+variable "matchbox_deploy_on_github_merge_pattern" {
+  type    = string
+  default = "refs/heads/main"
+}
+
+variable "matchbox_deploy_on_github_release" {
+  type    = bool
+  default = false
+}
+
 locals {
   admin_container_name   = "jupyterhub-admin"
   admin_container_port   = "8000"


### PR DESCRIPTION
## What

This adds the ability for Matchbox's CodeBuild project to be triggered from GitHub merge or release, configurable per environment.

It does require the "CodeConnection" to GitHub to be setup manually for the account Matchbox is deployed to. As far as I can tell, there is no way around this being a manual step.


## Why

This should allow the team to deploy Matchbox more easily in a more CD way

## Checklist


* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
