### PR TITLE
Update policy for ECR and DKR endpoints to permit all actions within same AWS account

### DIFF
--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -448,241 +448,27 @@ resource "aws_vpc_endpoint" "ecr_api" {
 }
 
 data "aws_iam_policy_document" "aws_vpc_endpoint_ecr" {
-  # Contains policies for both ECR and DKR endpoints, as recommended
 
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.admin_task.arn}"]
-    }
-
-    actions = [
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecr:PutImage",
-    ]
-
-    resources = [
-      "${aws_ecr_repository.user_provided.arn}",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.admin_task.arn}"]
-    }
-
-    actions = [
-      "ecs:DescribeTaskDefinition",
-    ]
-
-    resources = [
-      # ECS doesn't provide more-specific permission for DescribeTaskDefinition
-      "*",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.admin_task.arn}"]
-    }
-
-    actions = [
-      "ecs:RegisterTaskDefinition",
-    ]
-
-    resources = [
-      # ECS doesn't provide more-specific permission for RegisterTaskDefinition
-      "*",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.admin_task.arn}"]
-    }
-
-    actions = [
-      "ecs:StopTask",
-    ]
-
-    condition {
-      test     = "ArnEquals"
-      variable = "ecs:cluster"
-      values = [
-        "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:cluster/${aws_ecs_cluster.notebooks.name}",
-      ]
-    }
-
-    resources = [
-      "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task/*",
-    ]
-  }
-
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["${aws_iam_role.admin_task.arn}"]
-    }
-
-    actions = [
-      "ecs:DescribeTasks",
-    ]
-
-    condition {
-      test     = "ArnEquals"
-      variable = "ecs:cluster"
-      values = [
-        "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:cluster/${aws_ecs_cluster.notebooks.name}",
-      ]
-    }
-
-    resources = [
-      "arn:aws:ecs:${data.aws_region.aws_region.name}:${data.aws_caller_identity.aws_caller_identity.account_id}:task/*",
-    ]
-  }
-
-  # For Fargate to start tasks
   statement {
     principals {
       type        = "AWS"
       identifiers = ["*"]
     }
 
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalAccount"
+      values = [
+        "${data.aws_caller_identity.aws_caller_identity.account_id}"
+      ]
+    }
+
     actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage",
-      "ecr:GetDownloadUrlForLayer"
+      "*"
     ]
 
     resources = [
       "*",
     ]
-  }
-
-  /* For ECS to fetch images */
-  statement {
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    actions = [
-      "ecr:BatchGetImage",
-      "ecr:GetDownloadUrlForLayer",
-    ]
-
-    resources = [
-      "${aws_ecr_repository.admin.arn}",
-      "${aws_ecr_repository.jupyterlab_python.arn}",
-      "${aws_ecr_repository.rstudio.arn}",
-      "${aws_ecr_repository.rstudio_rv4.arn}",
-      "${aws_ecr_repository.pgadmin.arn}",
-      "${aws_ecr_repository.remotedesktop.arn}",
-      "${aws_ecr_repository.theia.arn}",
-      "${aws_ecr_repository.vscode.arn}",
-      "${aws_ecr_repository.s3sync.arn}",
-      "${aws_ecr_repository.metrics.arn}",
-      "${aws_ecr_repository.sentryproxy.arn}",
-      "${aws_ecr_repository.dns_rewrite_proxy.arn}",
-      "${aws_ecr_repository.healthcheck.arn}",
-      "${aws_ecr_repository.prometheus.arn}",
-      "${aws_ecr_repository.gitlab.arn}",
-      "${aws_ecr_repository.mirrors_sync.arn}",
-      "${aws_ecr_repository.mirrors_sync_cran_binary.arn}",
-      "${aws_ecr_repository.superset.arn}",
-      "${aws_ecr_repository.airflow.arn}",
-      "${aws_ecr_repository.flower.arn}",
-      "${aws_ecr_repository.mlflow.arn}",
-      "${aws_ecr_repository.datadog.arn}",
-    ]
-  }
-
-  dynamic "statement" {
-    for_each = var.matchbox_on ? [0] : []
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = ["*"]
-      }
-
-      actions = [
-        "ecr:BatchGetImage",
-        "ecr:GetDownloadUrlForLayer",
-      ]
-
-      resources = [
-        "${aws_ecr_repository.matchbox[0].arn}",
-      ]
-    }
-  }
-
-  # For GitLab runner to login and get base images
-  dynamic "statement" {
-    for_each = var.gitlab_on ? aws_iam_role.gitlab_runner[*].arn : []
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = [statement.value]
-      }
-      actions = [
-        "ecr:GetAuthorizationToken",
-      ]
-
-      resources = [
-        "*",
-      ]
-    }
-  }
-
-  dynamic "statement" {
-    for_each = var.gitlab_on ? aws_iam_role.gitlab_runner[*].arn : []
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = [statement.value]
-      }
-
-      actions = [
-        "ecr:BatchGetImage",
-        "ecr:GetDownloadUrlForLayer",
-      ]
-
-      resources = [
-        "${aws_ecr_repository.visualisation_base.arn}",
-      ]
-    }
-  }
-
-  # For GitLab runner to login and push user-provided images
-  dynamic "statement" {
-    for_each = var.gitlab_on ? aws_iam_role.gitlab_runner[*].arn : []
-    content {
-      principals {
-        type        = "AWS"
-        identifiers = [statement.value]
-      }
-
-      actions = [
-        "ecr:BatchCheckLayerAvailability",
-        "ecr:GetDownloadUrlForLayer",
-        "ecr:GetRepositoryPolicy",
-        "ecr:DescribeRepositories",
-        "ecr:ListImages",
-        "ecr:DescribeImages",
-        "ecr:BatchGetImage",
-        "ecr:InitiateLayerUpload",
-        "ecr:UploadLayerPart",
-        "ecr:CompleteLayerUpload",
-        "ecr:PutImage",
-      ]
-      resources = [
-        "${aws_ecr_repository.user_provided.arn}",
-      ]
-    }
   }
 }


### PR DESCRIPTION
## What

This PR updates the policies for the VPC endpoint that permits the use of both DKR and AWS APIs, such that any actions are permitted on this endpoint, provided they originate from within the same AWS account

## Why

This avoids the need to update the endpoints policies every time we make a relevant change. No role/user in Data Workspace will be able to do more than they were allowed to before as a result of this change, given their identity-based policies applied to them.

It also more strongly enforces the rule that this endpoint should not be used by other AWS accounts

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
