### PR TITLE
fix: codebuild compute types and apt-key port

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -442,27 +442,34 @@ variable "tools_github_source_url" {
 
 variable "tools" {
   type = list(object({
-    name          = string,
-    docker_target = string,
+    name                   = string,
+    docker_target          = string,
+    codebuild_compute_type = string,
   }))
   default = [{
-    name          = "vscode",
-    docker_target = "python-vscode",
+    name                   = "vscode",
+    docker_target          = "python-vscode",
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
     }, {
-    name          = "jupyterlab-python",
-    docker_target = "python-jupyterlab",
+    name                   = "jupyterlab-python",
+    docker_target          = "python-jupyterlab",
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
     }, {
-    name          = "theia",
-    docker_target = "python-theia",
+    name                   = "theia",
+    docker_target          = "python-theia",
+    codebuild_compute_type = "BUILD_GENERAL1_MEDIUM"
     }, {
-    name          = "pgadmin",
-    docker_target = "python-pgadmin",
+    name                   = "pgadmin",
+    docker_target          = "python-pgadmin",
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
     }, {
-    name          = "rstudio-rv4",
-    docker_target = "rv4-rstudio",
+    name                   = "rstudio-rv4",
+    docker_target          = "rv4-rstudio",
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
     }, {
-    name          = "remotedesktop",
-    docker_target = "remote-desktop",
+    name                   = "remotedesktop",
+    docker_target          = "remote-desktop",
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
   }]
 }
 

--- a/infra/vscode_codebuild.tf
+++ b/infra/vscode_codebuild.tf
@@ -38,7 +38,7 @@ resource "aws_codebuild_project" "tools" {
   source_version = "main"
 
   environment {
-    compute_type                = "BUILD_GENERAL1_SMALL"
+    compute_type                = var.tools[count.index].codebuild_compute_type
     image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
@@ -208,4 +208,15 @@ resource "aws_vpc_security_group_egress_rule" "tools_codebuild_http_to_all" {
   ip_protocol = "tcp"
   from_port   = "80"
   to_port     = "80"
+}
+
+# Allows apt-key to fetch public keys
+resource "aws_vpc_security_group_egress_rule" "tools_codebuild_pgp_to_all" {
+  count             = length(var.tools)
+  security_group_id = aws_security_group.tools_codebuild[count.index].id
+  cidr_ipv4         = "0.0.0.0/0"
+
+  ip_protocol = "tcp"
+  from_port   = "11371"
+  to_port     = "11371"
 }


### PR DESCRIPTION
## What

Set 'codebuild_compute_type' to 'SMALL' for all tools but set it to 'MEDIUM' for theia to fix codebuild project from failing due to running out of memory.

Created a security group rule to allow codebuild build builds to initiate connections on port '13371' which allows apt-key to work, which is part of R Studio's build.

## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
