### PR TITLE
adding S3Sync, metrics sidecar container images to build with CodeBuild

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -667,7 +667,7 @@ resource "aws_security_group" "ecr_api" {
 }
 
 resource "aws_security_group_rule" "ecr_api_ingress_https_from_tools_codebuild" {
-  count       = length(var.tools)
+  count       = length(local.tool_builds)
   description = "ingress-https-from-codebuild"
 
   security_group_id        = aws_security_group.ecr_api.id

--- a/infra/vscode_codebuild.tf
+++ b/infra/vscode_codebuild.tf
@@ -1,7 +1,26 @@
+locals {
+  tool_builds = concat([for i, t in var.tools : {
+    name                   = t.name,
+    docker_target          = t.docker_target,
+    codebuild_compute_type = t.codebuild_compute_type
+    tool_ecr_repo          = aws_ecr_repository.tools[i]
+    }], [{
+    name                   = "s3sync",
+    docker_target          = "s3sync"
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
+    tool_ecr_repo          = aws_ecr_repository.s3sync
+    }], [{
+    name                   = "metrics",
+    docker_target          = "metrics"
+    codebuild_compute_type = "BUILD_GENERAL1_SMALL"
+    tool_ecr_repo          = aws_ecr_repository.metrics
+  }])
+}
+
 resource "aws_codebuild_project" "tools" {
-  count        = length(var.tools)
-  name         = "${var.prefix}-${var.tools[count.index].name}"
-  description  = "${var.prefix}-${var.tools[count.index].name}"
+  count        = length(local.tool_builds)
+  name         = "${var.prefix}-${local.tool_builds[count.index].name}"
+  description  = "${var.prefix}-${local.tool_builds[count.index].name}"
   service_role = aws_iam_role.tools_codebuild[count.index].arn
 
   artifacts {
@@ -22,23 +41,23 @@ resource "aws_codebuild_project" "tools" {
       phases:
         build:
           commands:
-            - aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${aws_ecr_repository.tools[count.index].repository_url}
+            - aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${local.tool_builds[count.index].tool_ecr_repo.repository_url}
             - docker buildx create --use --name builder --driver docker-container
             - |
               docker buildx build --builder builder \
                 --file Dockerfile \
                 --build-arg GIT_COMMIT=$${CODEBUILD_SOURCE_VERSION} \
-                --push -t ${aws_ecr_repository.tools[count.index].repository_url}:master \
-                --cache-from type=registry,ref=${aws_ecr_repository.tools[count.index].repository_url}:cache \
-                --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${aws_ecr_repository.tools[count.index].repository_url}:cache \
-                --target ${var.tools[count.index].docker_target} \
+                --push -t ${local.tool_builds[count.index].tool_ecr_repo.repository_url}:master \
+                --cache-from type=registry,ref=${local.tool_builds[count.index].tool_ecr_repo.repository_url}:cache \
+                --cache-to mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${local.tool_builds[count.index].tool_ecr_repo.repository_url}:cache \
+                --target ${local.tool_builds[count.index].docker_target} \
                 .
     EOT
   }
   source_version = "main"
 
   environment {
-    compute_type                = var.tools[count.index].codebuild_compute_type
+    compute_type                = local.tool_builds[count.index].codebuild_compute_type
     image                       = "aws/codebuild/amazonlinux2-x86_64-standard:5.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
@@ -63,8 +82,8 @@ resource "aws_codebuild_project" "tools" {
 }
 
 resource "aws_iam_role" "tools_codebuild" {
-  count = length(var.tools)
-  name  = "${var.prefix}-${var.tools[count.index].name}-codebuild"
+  count = length(local.tool_builds)
+  name  = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -82,8 +101,8 @@ resource "aws_iam_role" "tools_codebuild" {
 }
 
 resource "aws_iam_role_policy" "tools_codebuild" {
-  count = length(var.tools)
-  name  = "${var.prefix}-${var.tools[count.index].name}-codebuild"
+  count = length(local.tool_builds)
+  name  = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
   role  = aws_iam_role.tools_codebuild[count.index].id
 
   policy = jsonencode({
@@ -113,7 +132,7 @@ resource "aws_iam_role_policy" "tools_codebuild" {
       {
         Effect = "Allow",
         Resource = [
-          aws_ecr_repository.tools[count.index].arn,
+          local.tool_builds[count.index].tool_ecr_repo.arn,
         ],
         Action = [
           "ecr:BatchCheckLayerAvailability",
@@ -172,25 +191,25 @@ resource "aws_iam_role_policy" "tools_codebuild" {
 
 
 resource "aws_cloudwatch_log_group" "tools_codebuild" {
-  count             = length(var.tools)
-  name              = "${var.prefix}-${var.tools[count.index].name}-codebuild"
+  count             = length(local.tool_builds)
+  name              = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
   retention_in_days = "3653"
 }
 
 resource "aws_security_group" "tools_codebuild" {
-  count       = length(var.tools)
-  name        = "${var.prefix}-${var.tools[count.index].name}-codebuild"
-  description = "${var.prefix}-${var.tools[count.index].name}-codebuild"
+  count       = length(local.tool_builds)
+  name        = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
+  description = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
   vpc_id      = aws_vpc.main.id
 
   tags = {
-    Name = "${var.prefix}-${var.tools[count.index].name}-codebuild"
+    Name = "${var.prefix}-${local.tool_builds[count.index].name}-codebuild"
   }
 }
 
 # Allows the Docker build to pull in packages from the outside world, e.g. PyPI
 resource "aws_vpc_security_group_egress_rule" "tools_codebuild_https_to_all" {
-  count             = length(var.tools)
+  count             = length(local.tool_builds)
   security_group_id = aws_security_group.tools_codebuild[count.index].id
   cidr_ipv4         = "0.0.0.0/0"
 
@@ -201,7 +220,7 @@ resource "aws_vpc_security_group_egress_rule" "tools_codebuild_https_to_all" {
 
 # Allows install of Debian packages which are via HTTP
 resource "aws_vpc_security_group_egress_rule" "tools_codebuild_http_to_all" {
-  count             = length(var.tools)
+  count             = length(local.tool_builds)
   security_group_id = aws_security_group.tools_codebuild[count.index].id
   cidr_ipv4         = "0.0.0.0/0"
 
@@ -212,7 +231,7 @@ resource "aws_vpc_security_group_egress_rule" "tools_codebuild_http_to_all" {
 
 # Allows apt-key to fetch public keys
 resource "aws_vpc_security_group_egress_rule" "tools_codebuild_pgp_to_all" {
-  count             = length(var.tools)
+  count             = length(local.tool_builds)
   security_group_id = aws_security_group.tools_codebuild[count.index].id
   cidr_ipv4         = "0.0.0.0/0"
 


### PR DESCRIPTION
## What
This PR adds sidecar containers S3Sync and metrics to build with CodeBuild

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
Moving away from Jenkins

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
