### PR TITLE
adding a subscription filter to pass cloudwatch logs to datadog

### DIFF
--- a/infra/environment-template/main.tf
+++ b/infra/environment-template/main.tf
@@ -85,7 +85,8 @@ module "jupyterhub" {
   alb_access_logs_bucket = "REPLACE_ME"
   alb_logs_account       = "REPLACE_ME"
 
-  cloudwatch_destination_arn = "REPLACE_ME"
+  cloudwatch_destination_arn         = "REPLACE_ME"
+  cloudwatch_destination_datadog_arn = "REPLACE_ME"
 
   mirrors_data_bucket_name = ""
   mirrors_bucket_name      = "REPLACE_ME"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -85,6 +85,10 @@ variable "alb_access_logs_bucket" {}
 variable "alb_logs_account" {}
 
 variable "cloudwatch_destination_arn" {}
+variable "cloudwatch_destination_datadog_arn" {
+  type    = string
+  default = ""
+}
 
 variable "mirrors_bucket_name" {}
 variable "mirrors_data_bucket_name" {}


### PR DESCRIPTION
## What
Adding a subscription filter to pass cloudwatch logs to datadog.

This is done via firehose datastream, which was setup manually. This datastream
is at account level and can be used across all cloudwatch groups.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
