### PR TITLE
refactor: moving providers from main to 0102-providers

### DIFF
--- a/infra/0102-providers.tf
+++ b/infra/0102-providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {}
+provider "aws" {
+  alias = "route53"
+}
+provider "aws" {
+  alias = "mirror"
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,12 +1,3 @@
-provider "aws" {}
-provider "aws" {
-  alias = "route53"
-}
-provider "aws" {
-  alias = "mirror"
-}
-
-
 locals {
   admin_container_name   = "jupyterhub-admin"
   admin_container_port   = "8000"


### PR DESCRIPTION
## What

Move Providers to 0102-providers from main.tf

## Why

We are attempting to tidy up the structure of the data workspace terraform to follow the agreed format laid out in [this confluence page](https://uktrade.atlassian.net/wiki/spaces/DE/pages/4702437398/Data+Workspace+Terraform+Plan).

## Links

[Relevant Fb Pitch
](https://trello.com/c/SuoCrhZw/632-speed-security-and-reusability-tidy-the-data-workspace-terraform)

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
