### PR TITLE
Update of count type on boolean var

### DIFF
--- a/infra/ecs_matchbox_matchbox.tf
+++ b/infra/ecs_matchbox_matchbox.tf
@@ -371,7 +371,7 @@ resource "aws_cloudwatch_log_group" "matchbox" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "matchbox" {
-  count           = var.cloudwatch_subscription_filter != "" && var.matchbox_on ? 1 : 0
+  count           = var.cloudwatch_subscription_filter && var.matchbox_on ? 1 : 0
   name            = "${var.prefix}-matchbox"
   log_group_name  = aws_cloudwatch_log_group.matchbox[count.index].name
   filter_pattern  = ""


### PR DESCRIPTION
## What

The cloudwatch_subscription_filter variable is set as a boolean, and the count statement for the matchbox aws_cloudwatch_log_subscription_filter  has been updated to reflect this. 

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
