### PR TITLE
refactor: move data element of Route53 zone to core

### DIFF
--- a/infra/0204-core--route53.tf
+++ b/infra/0204-core--route53.tf
@@ -1,0 +1,4 @@
+data "aws_route53_zone" "aws_route53_zone" {
+  provider = aws.route53
+  name     = var.aws_route53_zone
+}

--- a/infra/route_53.tf
+++ b/infra/route_53.tf
@@ -1,8 +1,3 @@
-data "aws_route53_zone" "aws_route53_zone" {
-  provider = aws.route53
-  name     = var.aws_route53_zone
-}
-
 resource "aws_route53_record" "healthcheck" {
   provider = aws.route53
   zone_id  = data.aws_route53_zone.aws_route53_zone.zone_id


### PR DESCRIPTION
## What

This moves the data block that fetches the main Route53 zone into core.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is part of the ongoing work to tidy up the Terraform

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
