### PR TITLE
refactor: move VPC endpoint to more appropriate file

### DIFF
--- a/infra/0202-core--vpc-endpoints.tf
+++ b/infra/0202-core--vpc-endpoints.tf
@@ -139,6 +139,15 @@ data "aws_iam_policy_document" "aws_vpc_endpoint_cloudwatch_monitoring" {
   }
 }
 
+resource "aws_vpc_endpoint" "ecs" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecs"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = ["${aws_security_group.ecs.id}"]
+  subnet_ids          = ["${aws_subnet.private_with_egress.*.id[0]}"]
+  private_dns_enabled = true
+}
+
 resource "aws_vpc_endpoint" "sagemaker_runtime_endpoint_main" {
   count              = var.sagemaker_on ? 1 : 0
   vpc_id             = aws_vpc.main.id

--- a/infra/0401-datasets--vpc.tf
+++ b/infra/0401-datasets--vpc.tf
@@ -163,15 +163,6 @@ resource "aws_route_table_association" "datasets_quicksight" {
   route_table_id = aws_route_table.datasets.id
 }
 
-resource "aws_vpc_endpoint" "ecs" {
-  vpc_id              = aws_vpc.main.id
-  service_name        = "com.amazonaws.${data.aws_region.aws_region.name}.ecs"
-  vpc_endpoint_type   = "Interface"
-  security_group_ids  = ["${aws_security_group.ecs.id}"]
-  subnet_ids          = ["${aws_subnet.private_with_egress.*.id[0]}"]
-  private_dns_enabled = true
-}
-
 resource "aws_vpc_endpoint" "datasets_s3_endpoint" {
   count           = var.arango_on ? 1 : 0
   vpc_id          = aws_vpc.datasets.id


### PR DESCRIPTION
## What

This moves the ECS endpoint definition to the "core" section

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is done because the ECS endpoint is on the main vpc, which is defined in "core"

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
