### PR TITLE
fix: finding tag of DNS rewrite proxy

### DIFF
--- a/infra/0611-tools-dns-rewrite-proxy--ecs.tf
+++ b/infra/0611-tools-dns-rewrite-proxy--ecs.tf
@@ -93,7 +93,7 @@ data "external" "dns_rewrite_proxy_current_tag" {
 
   query = {
     cluster_name   = "${aws_ecs_cluster.main_cluster.name}"
-    service_name   = "${var.prefix}-dns-rewrite-proxy" # Manually specified to avoid a cycle
+    service_name   = "${var.prefix}-dns-rewrite-proxy-new" # Manually specified to avoid a cycle
     container_name = "${local.dns_rewrite_proxy_container_name}"
   }
 }


### PR DESCRIPTION
## What

This fixes finding the current tag of the DNS rewrite proxy, introduced since the legacy DNS rewrite proxy was removed.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

Without this it would revert to "latest", even if that's not the right tag. Not sure why this didn't come up before - maybe the legacy service still existed via the API - a lot of things in AWS are eventually consistent.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
