### PR TITLE
infra: remove unused VPC peering with GOV.UK PaaS

### DIFF
--- a/infra/0701-datasets--vpc.tf
+++ b/infra/0701-datasets--vpc.tf
@@ -92,21 +92,6 @@ resource "aws_route53_resolver_firewall_rule" "datasets_block_otherwise" {
   priority                = 200
 }
 
-resource "aws_vpc_peering_connection" "datasets_to_paas" {
-  count       = var.paas_cidr_block != "" ? 1 : 0
-  peer_vpc_id = var.paas_vpc_id
-  vpc_id      = aws_vpc.datasets.id
-  auto_accept = true
-
-  accepter {
-    allow_remote_vpc_dns_resolution = false
-  }
-
-  tags = {
-    Name = "${var.prefix}-datasets-to-paas"
-  }
-}
-
 resource "aws_vpc_peering_connection" "datasets_to_main" {
   peer_vpc_id = aws_vpc.datasets.id
   vpc_id      = aws_vpc.main.id

--- a/infra/0702-datasets-postgresql--rds.tf
+++ b/infra/0702-datasets-postgresql--rds.tf
@@ -128,19 +128,6 @@ resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_notebooks"
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_paas" {
-  count       = var.paas_cidr_block != "" ? 1 : 0
-  description = "ingress-postgres-from-paas"
-
-  security_group_id = aws_security_group.datasets.id
-  cidr_blocks       = ["${var.paas_cidr_block}"]
-
-  type      = "ingress"
-  from_port = aws_rds_cluster_instance.datasets.port
-  to_port   = aws_rds_cluster_instance.datasets.port
-  protocol  = "tcp"
-}
-
 resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_superset" {
   description = "ingress-postgres-from-superset"
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1981,19 +1981,6 @@ resource "aws_security_group_rule" "elasticsearch_ingress_from_admin" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "elasticsearch_ingress_from_paas" {
-  count       = var.paas_cidr_block != "" ? 1 : 0
-  description = "ingress-elasticsearch-https-from-paas-ie-data-flow"
-
-  security_group_id = aws_security_group.datasets.id
-  cidr_blocks       = [var.paas_cidr_block]
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
 resource "aws_security_group_rule" "ecr_api_ingress_https_from_flower" {
   description = "ingress-https-from-flower-service"
 

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,10 +1,3 @@
-resource "aws_route" "pcx_datasets_to_paas" {
-  count                     = var.paas_cidr_block != "" ? 1 : 0
-  route_table_id            = aws_route_table.datasets.id
-  destination_cidr_block    = var.paas_cidr_block
-  vpc_peering_connection_id = aws_vpc_peering_connection.datasets_to_paas[0].id
-}
-
 resource "aws_route" "pcx_datasets_to_main" {
   route_table_id            = aws_route_table.datasets.id
   destination_cidr_block    = aws_vpc.main.cidr_block


### PR DESCRIPTION
## What

This removes the now-unused VPC peering connection (and assocaited resources) used when Airflow was running in GOV.UK PaaS and need to communicate.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is to keep the Terraform and infrastructure tidy

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
