### PR TITLE
security: remove unnecessary QuickSight security group rule

### DIFF
--- a/infra/1202-quicksight--sg.tf
+++ b/infra/1202-quicksight--sg.tf
@@ -12,6 +12,15 @@ resource "aws_security_group" "quicksight" {
   }
 }
 
+# QuickSight makes the connection to the datasets database rather than vice versa, so we need the
+# usual egress rule on QuickSight's security group, and ingress rule on the database security
+# group. HOWEVER, strangely we also need an _ingress_ rule on QuickSight's security group. This is
+# because, from https://docs.aws.amazon.com/quicksight/latest/user/vpc-inbound-rules.html
+#
+# > The security group attached to the QuickSight network interface behaves differently than most
+# > security groups, because it isn't stateful. [...] To make it work [...] make sure to add an
+# > inbound rule that explicitly authorizes the return traffic from the database host.
+
 resource "aws_security_group_rule" "quicksight_ingress_all_from_datasets_db" {
   description = "ingress-all-from-datasets-db"
 
@@ -43,18 +52,6 @@ resource "aws_security_group_rule" "datasets_db_ingress_all_from_quicksight" {
   source_security_group_id = aws_security_group.quicksight.id
 
   type      = "ingress"
-  from_port = "0"
-  to_port   = "65535"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "datasets_db_egress_all_to_quicksight" {
-  description = "egress-all-to-quicksight"
-
-  security_group_id        = aws_security_group.datasets.id
-  source_security_group_id = aws_security_group.quicksight.id
-
-  type      = "egress"
   from_port = "0"
   to_port   = "65535"
   protocol  = "tcp"


### PR DESCRIPTION
## What

This removes an unnecessary QuickSight security group rule, that theoretically would allow the datasets database to initiate connections to QuickSight. I strongly suspect this is already impossible/would acheive nothing already.

It also adds a comment to explain why there is an unusual security group rule remaining that would not typically be needed for a client -> server connection.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is done to be as secure as possible - standard minimisation of privilege/swiss-cheese type of change. For the avoidance of doubt, I strongly suspect even without this change it is already impossible for the database to initial such a connection, certainly for a user to initiate such a connection, and also impossible if such a connection were possible to use the connection for anything.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
