### PR TITLE
docs: explain that the security_groups.tf file is legacy

### DIFF
--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -1,3 +1,24 @@
+###################################################################################################
+#
+# IMPORTANT
+#
+# This file is "legacy". Unless an urgent change is needed, do not change this file other than to
+# remove security groups or rules.
+#
+# Instead:
+#
+# 1. Place definitions of security groups close to the definition of the resources that are
+#    assigned them. In most cases the same file as the resource is defined is appropriate. In the
+#    rare case that there is no resource, a "--sg.tf" file should be created for this.
+#
+# 2. Place security groups rules next to the security group definition of the _client_ side of
+#    the relationship, i.e. the one that needs the egress rule. In the rare case that there is
+#    no client security group, for example if exposing a server to a CIDR, then a separate file
+#    ending in "--sg.tf" file should be made for these rules (possibly via a prefix list).
+#
+###################################################################################################
+
+
 resource "aws_security_group" "dns_rewrite_proxy" {
   name        = "${var.prefix}-dns-rewrite-proxy"
   description = "${var.prefix}-dns-rewrite-proxy"


### PR DESCRIPTION
## What

This adds a big comment to the top of security_groups.tf explaining that it should not be used.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is to encourage a better structure in future

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
