### PR TITLE
refactor: module for security group rules

### DIFF
--- a/infra/0702-datasets-postgresql--rds.tf
+++ b/infra/0702-datasets-postgresql--rds.tf
@@ -65,19 +65,6 @@ resource "aws_security_group_rule" "admin_service_egress_postgres_to_datasets_db
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "notebooks_egress_postgres_to_datasets_db" {
-  description = "egress-postgres-to-datasets-db"
-
-  security_group_id        = aws_security_group.notebooks.id
-  source_security_group_id = aws_security_group.datasets.id
-
-  type      = "egress"
-  from_port = aws_rds_cluster_instance.datasets.port
-  to_port   = aws_rds_cluster_instance.datasets.port
-  protocol  = "tcp"
-}
-
-
 resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_airflow_dag_processor" {
   description = "ingress-postgres-from-airflow"
 
@@ -109,18 +96,6 @@ resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_admin" {
 
   security_group_id        = aws_security_group.datasets.id
   source_security_group_id = aws_security_group.admin_service.id
-
-  type      = "ingress"
-  from_port = aws_rds_cluster_instance.datasets.port
-  to_port   = aws_rds_cluster_instance.datasets.port
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_notebooks" {
-  description = "ingress-postgres-from-notebooks"
-
-  security_group_id        = aws_security_group.datasets.id
-  source_security_group_id = aws_security_group.notebooks.id
 
   type      = "ingress"
   from_port = aws_rds_cluster_instance.datasets.port

--- a/infra/1501-sagemaker.tf
+++ b/infra/1501-sagemaker.tf
@@ -24,27 +24,6 @@ resource "aws_security_group" "sagemaker_vpc_endpoints_main" {
   }
 }
 
-resource "aws_security_group_rule" "ingress_sagemaker_vpc_endpoint_notebooks_vpc" {
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "endpoint-ingress-from-notebooks-vpc"
-
-  security_group_id        = aws_security_group.sagemaker_vpc_endpoints_main[0].id
-  source_security_group_id = aws_security_group.notebooks.id
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-
-  depends_on = [
-    # Security groups rules referencing security groups in different VPCs need the peering
-    # connection setup first, and although oddly named, this connection links the notebooks and
-    # main VPCs
-    aws_vpc_peering_connection.jupyterhub
-  ]
-}
-
 resource "aws_security_group" "sagemaker_endpoints" {
   count = var.sagemaker_on ? 1 : 0
 

--- a/infra/modules/security_group_client_server_connections/main.tf
+++ b/infra/modules/security_group_client_server_connections/main.tf
@@ -1,0 +1,132 @@
+#################
+# Input variables
+
+variable "client_security_groups" {
+  description = "The security groups on the client-side of the connections, needing egress rules"
+  type = list(object({
+    id   = string
+    name = string
+  }))
+}
+
+variable "server_security_groups" {
+  description = "The security groups on the server-side of the connections, needing ingress rules"
+  type = list(object({
+    id   = string
+    name = string
+  }))
+  default = []
+}
+
+variable "server_ipv4_cidrs" {
+  description = "The IPv4 CIDR ranges on the server-side of the connections"
+  type        = list(string)
+  default     = []
+}
+
+variable "server_prefix_list_ids" {
+  description = "The IDs of the prefix list of the server-side of the connections"
+  type        = list(string)
+  default     = []
+}
+
+variable "ports" {
+  type    = list(number)
+  default = []
+}
+
+variable "protocol" {
+  description = "The ports used by the connections"
+  type        = string
+  default     = "tcp"
+}
+
+
+###########################################
+# For servers specificed by security groups
+
+locals {
+  server_security_group_ports = {
+    for tuple in setproduct(var.client_security_groups, var.server_security_groups, var.ports) : "${tuple[0].id}.${tuple[1].id}.${tuple[2]}" => {
+      client_security_group_id   = tuple[0].id
+      client_security_group_name = tuple[0].name
+      server_security_group_id   = tuple[1].id
+      server_security_group_name = tuple[1].name
+      port                       = tuple[2]
+    }
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "client_to_server_security_group" {
+  for_each = local.server_security_group_ports
+
+  ip_protocol                  = var.protocol
+  security_group_id            = each.value.client_security_group_id
+  referenced_security_group_id = each.value.server_security_group_id
+  from_port                    = each.value.port
+  to_port                      = each.value.port
+
+  description = "${each.value.port}-to-${each.value.server_security_group_name}"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "server_security_group_from_client" {
+  for_each = local.server_security_group_ports
+
+  security_group_id            = each.value.server_security_group_id
+  referenced_security_group_id = each.value.client_security_group_id
+  ip_protocol                  = var.protocol
+  from_port                    = each.value.port
+  to_port                      = each.value.port
+
+  description = "${each.value.port}-from-${each.value.client_security_group_name}"
+}
+
+#################################
+# For servers specificed by CIDRs
+
+locals {
+  server_cidr_ports = {
+    for tuple in setproduct(var.client_security_groups, var.server_ipv4_cidrs, var.ports) : "${tuple[0].id}.${tuple[1]}.${tuple[2]}" => {
+      client_security_group_id = tuple[0].id
+      server_ipv4_cidr         = tuple[1]
+      port                     = tuple[2]
+    }
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "client_to_server_cidr" {
+  for_each = local.server_cidr_ports
+
+  security_group_id = each.value.client_security_group_id
+  cidr_ipv4         = each.value.server_ipv4_cidr
+  ip_protocol       = var.protocol
+  from_port         = each.value.port
+  to_port           = each.value.port
+
+  description = "${each.value.port}-to-${each.value.server_ipv4_cidr}"
+}
+
+########################################
+# For servers specificed by prefix lists
+
+locals {
+  server_prefix_list_id_ports = {
+    for tuple in setproduct(var.client_security_groups, var.server_prefix_list_ids, var.ports) : "${tuple[0].id}.${tuple[1]}.${tuple[2]}" => {
+      client_security_group_id = tuple[0].id
+      server_prefix_list_id    = tuple[1]
+      port                     = tuple[2]
+    }
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "client_to_server_prefix_list" {
+  for_each = local.server_prefix_list_id_ports
+
+  security_group_id = each.value.client_security_group_id
+  prefix_list_id    = each.value.server_prefix_list_id
+  ip_protocol       = var.protocol
+  from_port         = each.value.port
+  to_port           = each.value.port
+
+  description = "${each.value.port}-to-${each.value.server_prefix_list_id}"
+}


### PR DESCRIPTION
## What

This adds a module for security group rules, and also makes the tools/notebooks tasks use them.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is done to:

1. Reduce verbosity of the security group rules. And specifically the module
    - Avoids having to manually create both ingress and egress rules on both sides
    - Avoids having to specific the protocol, which is almost always tcp
   - Allows creation of rules "in bulk", e.g. if a client has to talk to multiple servers.

2. Avoid confusion about what ports in what direction need to be opened. Security groups are stateful and allow data _back_ through a connection (with the exception of QuickSight's security group which is different), but this is often forgotten

3. Make it really clear what tools/notebooks can connect to. All definition of
       the security group rules are in one place, and (relatively) concise.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
