### PR TITLE
Cleanup: Group SG

### DIFF
--- a/infra/0916-tools-sentry-proxy--ecs.tf
+++ b/infra/0916-tools-sentry-proxy--ecs.tf
@@ -176,3 +176,12 @@ data "aws_iam_policy_document" "sentryproxy_task_ecs_tasks_assume_role" {
     }
   }
 }
+
+
+module "sentryproxy_to_internet_https" {
+  source = "./modules/security_group_client_server_connections"
+
+  client_security_groups = [aws_security_group.sentryproxy_service]
+  server_ipv4_cidrs      = ["0.0.0.0/0"]
+  ports                  = [443]
+}

--- a/infra/1010-gitlab--ecr.tf
+++ b/infra/1010-gitlab--ecr.tf
@@ -6,3 +6,12 @@ resource "aws_ecr_lifecycle_policy" "gitlab_expire_untagged_after_one_day" {
   repository = aws_ecr_repository.gitlab.name
   policy     = data.aws_ecr_lifecycle_policy_document.expire_untagged_after_one_day.json
 }
+
+module "gitlab_outgoing_https_ecr_api" {
+  count  = var.gitlab_on ? 1 : 0
+  source = "./modules/security_group_client_server_connections"
+
+  client_security_groups = [aws_security_group.gitlab_service[count.index]]
+  server_security_groups = [aws_security_group.ecr_api]
+  ports                  = [443]
+}

--- a/infra/1503-sagemaker--vpc-endpoints.tf
+++ b/infra/1503-sagemaker--vpc-endpoints.tf
@@ -98,3 +98,12 @@ data "aws_iam_policy_document" "sns_endpoint_policy" {
     ]
   }
 }
+
+module "sagemaker_to_endpoints_https" {
+  count = var.sagemaker_on ? 1 : 0
+  source = "./modules/security_group_client_server_connections"
+
+  client_security_groups = [aws_security_group.sagemaker[0]]
+  server_security_groups = [aws_security_group.sagemaker_endpoints[0]]
+  ports = [443]
+}

--- a/infra/1503-sagemaker--vpc-endpoints.tf
+++ b/infra/1503-sagemaker--vpc-endpoints.tf
@@ -107,3 +107,12 @@ module "sagemaker_to_endpoints_https" {
   server_security_groups = [aws_security_group.sagemaker_endpoints[0]]
   ports                  = [443]
 }
+
+module "sagemaker_to_s3_endpoint" {
+  count  = var.sagemaker_on ? 1 : 0
+  source = "./modules/security_group_client_server_connections"
+
+  client_security_groups = [aws_security_group.sagemaker[0]]
+  server_prefix_list_ids = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
+  ports                  = [443]
+}

--- a/infra/1503-sagemaker--vpc-endpoints.tf
+++ b/infra/1503-sagemaker--vpc-endpoints.tf
@@ -98,21 +98,3 @@ data "aws_iam_policy_document" "sns_endpoint_policy" {
     ]
   }
 }
-
-module "sagemaker_to_endpoints_https" {
-  count  = var.sagemaker_on ? 1 : 0
-  source = "./modules/security_group_client_server_connections"
-
-  client_security_groups = [aws_security_group.sagemaker[0]]
-  server_security_groups = [aws_security_group.sagemaker_endpoints[0]]
-  ports                  = [443]
-}
-
-module "sagemaker_to_s3_endpoint" {
-  count  = var.sagemaker_on ? 1 : 0
-  source = "./modules/security_group_client_server_connections"
-
-  client_security_groups = [aws_security_group.sagemaker[0]]
-  server_prefix_list_ids = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
-  ports                  = [443]
-}

--- a/infra/1503-sagemaker--vpc-endpoints.tf
+++ b/infra/1503-sagemaker--vpc-endpoints.tf
@@ -100,10 +100,10 @@ data "aws_iam_policy_document" "sns_endpoint_policy" {
 }
 
 module "sagemaker_to_endpoints_https" {
-  count = var.sagemaker_on ? 1 : 0
+  count  = var.sagemaker_on ? 1 : 0
   source = "./modules/security_group_client_server_connections"
 
   client_security_groups = [aws_security_group.sagemaker[0]]
   server_security_groups = [aws_security_group.sagemaker_endpoints[0]]
-  ports = [443]
+  ports                  = [443]
 }

--- a/infra/1504-sagemaker--deployments.tf
+++ b/infra/1504-sagemaker--deployments.tf
@@ -314,3 +314,13 @@ module "mistral_7b_instruct_deployment" {
   s3_output_path          = module.iam[0].default_sagemaker_bucket_regional_domain_name
   environment_name_prefix = var.prefix
 }
+
+module "sagemaker_outgoing_https" {
+  count  = var.sagemaker_on ? 1 : 0
+  source = "./modules/security_group_client_server_connections"
+
+  client_security_groups = [aws_security_group.sagemaker[0]]
+  server_security_groups = [aws_security_group.sagemaker_endpoints[0]]
+  server_prefix_list_ids = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
+  ports                  = [443]
+}

--- a/infra/1504-sagemaker--deployments.tf
+++ b/infra/1504-sagemaker--deployments.tf
@@ -324,3 +324,19 @@ module "sagemaker_outgoing_https" {
   server_prefix_list_ids = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
   ports                  = [443]
 }
+
+resource "aws_security_group" "sagemaker" {
+  count = var.sagemaker_on ? 1 : 0
+
+  name        = "${var.prefix}-sagemaker"
+  description = "${var.prefix}-sagemaker"
+  vpc_id      = aws_vpc.sagemaker[0].id
+
+  tags = {
+    Name = "${var.prefix}-sagemaker"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -262,18 +262,6 @@ resource "aws_security_group_rule" "admin_service_egress_http_to_gitlab_service"
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "gitlab_service_egress_https_to_ecr_api" {
-  count       = var.gitlab_on ? 1 : 0
-  description = "egress-https-to-ecr-api"
-
-  security_group_id        = aws_security_group.gitlab_service[count.index].id
-  source_security_group_id = aws_security_group.ecr_api.id
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 resource "aws_security_group_rule" "admin_service_egress_https_to_cloudwatch" {
   description = "egress-https-to-cloudwatch"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -452,21 +452,6 @@ resource "aws_security_group" "sagemaker" {
   }
 }
 
-resource "aws_security_group_rule" "sagemaker_egress_to_sagemaker_endpoints" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "sagemaker-egress-to-sagemaker-endpoints"
-
-  security_group_id        = aws_security_group.sagemaker[0].id
-  source_security_group_id = aws_security_group.sagemaker_endpoints[0].id
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
 resource "aws_security_group_rule" "sagemaker_egress_to_s3_endpoint" {
 
   count = var.sagemaker_on ? 1 : 0

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -85,17 +85,6 @@ resource "aws_security_group" "sentryproxy_service" {
   }
 }
 
-resource "aws_security_group_rule" "sentryproxy_egress_https" {
-  description = "egress-https"
-
-  security_group_id = aws_security_group.sentryproxy_service.id
-  cidr_blocks       = ["0.0.0.0/0"]
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 resource "aws_security_group" "admin_alb" {
   name        = "${var.prefix}-admin-alb"

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -424,24 +424,6 @@ resource "aws_security_group_rule" "notebooks_ingress_http_from_prometheus" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group" "sagemaker" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  name        = "${var.prefix}-sagemaker"
-  description = "${var.prefix}-sagemaker"
-  vpc_id      = aws_vpc.sagemaker[0].id
-
-  tags = {
-    Name = "${var.prefix}-sagemaker"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-
 resource "aws_security_group_rule" "sagemaker_endpoint_ingress_to_sagemaker_vpc" {
 
   count = var.sagemaker_on ? 1 : 0

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -424,20 +424,6 @@ resource "aws_security_group_rule" "notebooks_ingress_http_from_prometheus" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "sagemaker_endpoint_ingress_to_sagemaker_vpc" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "ingress-from-sagemaker-to-sagemaker-endpoints"
-
-  security_group_id        = aws_security_group.sagemaker_endpoints[0].id
-  source_security_group_id = aws_security_group.sagemaker[0].id
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 #######################
 

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -441,20 +441,6 @@ resource "aws_security_group" "sagemaker" {
   }
 }
 
-resource "aws_security_group_rule" "sagemaker_egress_to_s3_endpoint" {
-
-  count = var.sagemaker_on ? 1 : 0
-
-  description = "sagemaker-egress-to-s3"
-
-  security_group_id = aws_security_group.sagemaker[0].id
-  prefix_list_ids   = [aws_vpc_endpoint.sagemaker_s3[0].prefix_list_id]
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 resource "aws_security_group_rule" "sagemaker_endpoint_ingress_to_sagemaker_vpc" {
 


### PR DESCRIPTION
## What
Replaced hardcoded SG rules with security_group_client_server_connections module for SageMaker, GitLab → ECR, and SentryProxy → internet.

Moved rule definitions to the client side.
## Why

Simplifies the code and reduces duplication.
Follows our updated convention for client-side SG rule ownership.

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
