### PR TITLE
refactor: move Superset security group rules to client side

### DIFF
--- a/infra/0702-datasets-postgresql--rds.tf
+++ b/infra/0702-datasets-postgresql--rds.tf
@@ -102,27 +102,3 @@ resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_admin" {
   to_port   = aws_rds_cluster_instance.datasets.port
   protocol  = "tcp"
 }
-
-resource "aws_security_group_rule" "datasets_db_ingress_postgres_from_superset" {
-  description = "ingress-postgres-from-superset"
-
-  security_group_id        = aws_security_group.datasets.id
-  source_security_group_id = aws_security_group.superset_service.id
-
-  type      = "ingress"
-  from_port = aws_rds_cluster_instance.datasets.port
-  to_port   = aws_rds_cluster_instance.datasets.port
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "superset_service_egress_postgres_datasets_db" {
-  description = "egress-postgres-datasets-db"
-
-  security_group_id        = aws_security_group.superset_service.id
-  source_security_group_id = aws_security_group.datasets.id
-
-  type      = "egress"
-  from_port = "5432"
-  to_port   = "5432"
-  protocol  = "tcp"
-}

--- a/infra/security_groups.tf
+++ b/infra/security_groups.tf
@@ -97,18 +97,6 @@ resource "aws_security_group_rule" "sentryproxy_egress_https" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "sentryproxy_ingress_http_superset" {
-  description = "ingress-http-superset"
-
-  security_group_id        = aws_security_group.sentryproxy_service.id
-  source_security_group_id = aws_security_group.superset_service.id
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
 resource "aws_security_group" "admin_alb" {
   name        = "${var.prefix}-admin-alb"
   description = "${var.prefix}-admin-alb"
@@ -664,17 +652,6 @@ resource "aws_security_group_rule" "ecr_api_ingress_https_from_mirrors_sync" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "ecr_api_ingress_https_from_superset" {
-  description = "ingress-https-from-superset"
-
-  security_group_id        = aws_security_group.ecr_api.id
-  source_security_group_id = aws_security_group.superset_service.id
-
-  type      = "ingress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 resource "aws_security_group_rule" "ecr_api_ingress_https_from_healthcheck" {
   description = "ingress-https-from-healthcheck-service"
@@ -1237,46 +1214,6 @@ resource "aws_security_group" "superset_db" {
   }
 }
 
-# Connections to ECR and CloudWatch. ECR needs S3, and its VPC endpoint type
-# does not have an IP range or security group to limit access to
-resource "aws_security_group_rule" "superset_egress_https_all" {
-  description = "egress-https-to-all"
-
-  security_group_id = aws_security_group.superset_service.id
-  cidr_blocks       = ["0.0.0.0/0"]
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "superset_db_ingress_postgres_superset_service" {
-  description = "ingress-postgress-superset-service"
-
-  security_group_id        = aws_security_group.superset_db.id
-  source_security_group_id = aws_security_group.superset_service.id
-
-  type      = "ingress"
-  from_port = "5432"
-  to_port   = "5432"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group" "superset_service" {
-  name        = "${var.prefix}-superset-service"
-  description = "${var.prefix}-superset-service"
-  vpc_id      = aws_vpc.notebooks.id
-
-  tags = {
-    Name = "${var.prefix}-superset-service"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_security_group_rule" "superset_service_ingress_http_superset_lb" {
   description = "ingress-superset-lb"
 
@@ -1289,29 +1226,6 @@ resource "aws_security_group_rule" "superset_service_ingress_http_superset_lb" {
   protocol  = "tcp"
 }
 
-resource "aws_security_group_rule" "superset_service_egress_postgres_superset_db" {
-  description = "egress-postgres-superset-db"
-
-  security_group_id        = aws_security_group.superset_service.id
-  source_security_group_id = aws_security_group.superset_db.id
-
-  type      = "egress"
-  from_port = "5432"
-  to_port   = "5432"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "superset_service_egress_https_to_ecr_api" {
-  description = "egress-https-to-ecr-api"
-
-  security_group_id        = aws_security_group.superset_service.id
-  source_security_group_id = aws_security_group.ecr_api.id
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
 
 resource "aws_security_group_rule" "prometheus_service_egress_https_to_ecr_api" {
   description = "egress-https-to-ecr-api"
@@ -1335,30 +1249,6 @@ resource "aws_security_group_rule" "sentryproxy_service_egress_https_to_ecr_api"
   from_port = "443"
   to_port   = "443"
   protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "superset_service_egress_https_to_cloudwatch" {
-  description = "egress-https-to-cloudwatch"
-
-  security_group_id        = aws_security_group.superset_service.id
-  source_security_group_id = aws_security_group.cloudwatch.id
-
-  type      = "egress"
-  from_port = "443"
-  to_port   = "443"
-  protocol  = "tcp"
-}
-
-resource "aws_security_group_rule" "superset_service_egress_dns_udp_to_dns_rewrite_proxy" {
-  description = "egress-dns-to-dns-rewrite-proxy"
-
-  security_group_id = aws_security_group.superset_service.id
-  cidr_blocks       = ["${aws_subnet.private_with_egress.*.cidr_block[0]}"]
-
-  type      = "egress"
-  from_port = "53"
-  to_port   = "53"
-  protocol  = "udp"
 }
 
 resource "aws_security_group" "superset_lb" {


### PR DESCRIPTION
## What

This moves the Superset security group rules to its client side, and uses our internal module to define them.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is in keeping with what is now the convention

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
