### PR TITLE
security: remove GitLab ECS service access to ECR

### DIFF
--- a/infra/1010-gitlab--ecr.tf
+++ b/infra/1010-gitlab--ecr.tf
@@ -6,12 +6,3 @@ resource "aws_ecr_lifecycle_policy" "gitlab_expire_untagged_after_one_day" {
   repository = aws_ecr_repository.gitlab.name
   policy     = data.aws_ecr_lifecycle_policy_document.expire_untagged_after_one_day.json
 }
-
-module "gitlab_outgoing_https_ecr_api" {
-  count  = var.gitlab_on ? 1 : 0
-  source = "./modules/security_group_client_server_connections"
-
-  client_security_groups = [aws_security_group.gitlab_service[count.index]]
-  server_security_groups = [aws_security_group.ecr_api]
-  ports                  = [443]
-}


### PR DESCRIPTION
## What

This removes GitLab's security-group level access to ECR. Note that this removes access from the service itself (i.e. from inside the running Docker container), and not the EC2 instance that pulls the Docker image from ECR.

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is a belt-and-braces/swiss cheese change - doesn't close an actual known security vulnerability for several reasons, but since GitLab shouldn't be able to communicate with ECR, removing the security group rules that allows it to.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
