### PR TITLE
security: tighten up policy on ECS endpoint

### DIFF
--- a/infra/0202-core--vpc-endpoints.tf
+++ b/infra/0202-core--vpc-endpoints.tf
@@ -109,12 +109,12 @@ resource "aws_vpc_endpoint" "cloudwatch_monitoring" {
   security_group_ids = ["${aws_security_group.cloudwatch.id}"]
   subnet_ids         = ["${aws_subnet.private_with_egress.*.id[0]}"]
 
-  policy = data.aws_iam_policy_document.aws_vpc_endpoint_cloudwatch_monitoring.json
+  policy = data.aws_iam_policy_document.allow_only_current_account.json
 
   private_dns_enabled = true
 }
 
-data "aws_iam_policy_document" "aws_vpc_endpoint_cloudwatch_monitoring" {
+data "aws_iam_policy_document" "allow_only_current_account" {
   statement {
     principals {
       type        = "AWS"
@@ -145,6 +145,7 @@ resource "aws_vpc_endpoint" "ecs" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = ["${aws_security_group.ecs.id}"]
   subnet_ids          = ["${aws_subnet.private_with_egress.*.id[0]}"]
+  policy              = data.aws_iam_policy_document.allow_only_current_account.json
   private_dns_enabled = true
 }
 


### PR DESCRIPTION
## What

This tightens up the policy on the ECS endpoint


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This makes sure that it can only be used by users/roles in our account.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
