### PR TITLE
fix: use name rather than ID of security group in rule for_each

### DIFF
--- a/infra/modules/security_group_client_server_connections/main.tf
+++ b/infra/modules/security_group_client_server_connections/main.tf
@@ -90,7 +90,7 @@ variable "protocol" {
 
 locals {
   server_security_group_ports = {
-    for tuple in setproduct(var.client_security_groups, var.server_security_groups, var.ports) : "${tuple[0].id}.${tuple[1].id}.${tuple[2]}" => {
+    for tuple in setproduct(var.client_security_groups, var.server_security_groups, var.ports) : "${tuple[0].name}.${tuple[1].name}.${tuple[2]}" => {
       client_security_group_id   = tuple[0].id
       client_security_group_name = tuple[0].name
       server_security_group_id   = tuple[1].id
@@ -129,7 +129,7 @@ resource "aws_vpc_security_group_ingress_rule" "server_security_group_from_clien
 
 locals {
   server_cidr_ports = {
-    for tuple in setproduct(var.client_security_groups, var.server_ipv4_cidrs, var.ports) : "${tuple[0].id}.${tuple[1]}.${tuple[2]}" => {
+    for tuple in setproduct(var.client_security_groups, var.server_ipv4_cidrs, var.ports) : "${tuple[0].name}.${tuple[1]}.${tuple[2]}" => {
       client_security_group_id = tuple[0].id
       server_ipv4_cidr         = tuple[1]
       port                     = tuple[2]
@@ -154,7 +154,7 @@ resource "aws_vpc_security_group_egress_rule" "client_to_server_cidr" {
 
 locals {
   server_prefix_list_id_ports = {
-    for tuple in setproduct(var.client_security_groups, var.server_prefix_list_ids, var.ports) : "${tuple[0].id}.${tuple[1]}.${tuple[2]}" => {
+    for tuple in setproduct(var.client_security_groups, var.server_prefix_list_ids, var.ports) : "${tuple[0].name}.${tuple[1]}.${tuple[2]}" => {
       client_security_group_id = tuple[0].id
       server_prefix_list_id    = tuple[1]
       port                     = tuple[2]


### PR DESCRIPTION
## What

This changes the variables that the _keys_ for for_each in security_group_client_server_connections that security group rules are made from. Specifically, it uses the names of security groups rather than IDs.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

While this less robust, since it can result in security group rules being (very briefly) dropped and re-created if a security group is renamed, without this you can get the error if applying the Terraform where the security groups have not yet been created:

> The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.

Since names are always hard-coded and so known before apply, this change avoids such errors.

An alternative to this approach is to use count rather than for_each, but I suspect this is even less robust, because just changing the order of groups/ports etc, a suspected more common occurance, would result in rules getting (briefly) dropped and re-created.

Another alternative to this approach is to always create security groups first. However, this means that applying Terraform is no longer a one stage process, making deployments forever more complicated.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
