### PR TITLE
Feature/make matchbox db more performant

### DIFF
--- a/infra/0101-variables.tf
+++ b/infra/0101-variables.tf
@@ -373,6 +373,21 @@ variable "matchbox_instances_long" {
   default = []
 }
 
+variable "matchbox_scaling_min_capacity" {
+  type    = number
+  default = 0
+}
+
+variable "matchbox_scaling_max_capacity" {
+  type    = number
+  default = 64
+}
+
+variable "matchbox_scaling_scaledown_seconds" {
+  type    = number
+  default = 300
+}
+
 variable "matchbox_api_container_resources" {
   description = "Map of specs to use when building the Matchbox API"
   type = object({
@@ -383,11 +398,6 @@ variable "matchbox_api_container_resources" {
     cpu    = 1024
     memory = 8192
   }
-}
-
-variable "matchbox_db_instance_class" {
-  type    = string
-  default = ""
 }
 
 variable "matchbox_postgres_parameters" {
@@ -449,6 +459,11 @@ variable "matchbox_deploy_on_github_merge_pattern" {
 }
 
 variable "matchbox_deploy_on_github_release" {
+  type    = bool
+  default = false
+}
+
+variable "matchbox_performance_insights" {
   type    = bool
   default = false
 }


### PR DESCRIPTION
## What

Allows for faster "just run" procedure on company-pipelines repository [down from 40mins to 30mins] by switching to Aurora Serverless, allowing for high-powered instances during this procedure that then scale down when not in use (to keep costs reasonable).

Coupled with https://github.com/uktrade/data-workspace-deploy/pull/100

## Why

Part of a broader effort to increase speed on both read and write procedures with Aurora Postgres.

[Epic 237](https://uktrade.atlassian.net/browse/MTCHBX-237)

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
