### PR TITLE
infra: reduce gitlab deregistration delay

### DIFF
--- a/infra/1003-gitlab--lb.tf
+++ b/infra/1003-gitlab--lb.tf
@@ -37,13 +37,14 @@ resource "aws_lb_listener" "gitlab_22" {
 }
 
 resource "aws_lb_target_group" "gitlab_80" {
-  count              = var.gitlab_on ? 1 : 0
-  name_prefix        = "gl80-"
-  port               = "80"
-  vpc_id             = aws_vpc.main.id
-  target_type        = "ip"
-  protocol           = "TCP"
-  preserve_client_ip = true
+  count                = var.gitlab_on ? 1 : 0
+  name_prefix          = "gl80-"
+  port                 = "80"
+  vpc_id               = aws_vpc.main.id
+  target_type          = "ip"
+  protocol             = "TCP"
+  preserve_client_ip   = true
+  deregistration_delay = 5
 
   health_check {
     protocol            = "TCP"
@@ -58,13 +59,14 @@ resource "aws_lb_target_group" "gitlab_80" {
 }
 
 resource "aws_lb_target_group" "gitlab_22" {
-  count              = var.gitlab_on ? 1 : 0
-  name_prefix        = "gl22-"
-  port               = "22"
-  vpc_id             = aws_vpc.main.id
-  target_type        = "ip"
-  protocol           = "TCP"
-  preserve_client_ip = true
+  count                = var.gitlab_on ? 1 : 0
+  name_prefix          = "gl22-"
+  port                 = "22"
+  vpc_id               = aws_vpc.main.id
+  target_type          = "ip"
+  protocol             = "TCP"
+  preserve_client_ip   = true
+  deregistration_delay = 5
 
   health_check {
     protocol            = "TCP"


### PR DESCRIPTION
## What

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->
This reduces the deregistration delay for GitLab's target groups from the default 5 minutes to 5 seconds.

## Why

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->
This is to reduce the time it takes to deploy a new GitLab. This is all acceptable from a user point of view because the deregistration delay is only applicable when a GitLab instance is shutting down and in our setup this means downtime anyway.

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [ ] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [ ] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [ ] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
