### PR TITLE
feat: GitLab Docker tag set per environment

### DIFF
--- a/infra/0101-variables.tf
+++ b/infra/0101-variables.tf
@@ -136,6 +136,10 @@ variable "gitlab_on" {
   type    = bool
   default = true
 }
+variable "gitlab_tag" {
+  type    = string
+  default = "master"
+}
 variable "gitlab_ip_whitelist" {
   type = list(any)
 }

--- a/infra/1011-gitlab--ecs.tf
+++ b/infra/1011-gitlab--ecs.tf
@@ -151,7 +151,7 @@ resource "aws_ecs_task_definition" "gitlab" {
           "value" = aws_secretsmanager_secret.gitlab[count.index].name
       }],
       "essential" = true,
-      "image"     = "${aws_ecr_repository.gitlab.repository_url}:master",
+      "image"     = "${aws_ecr_repository.gitlab.repository_url}:${var.gitlab_tag}",
       "logConfiguration" = {
         "logDriver" = "awslogs",
         "options" = {


### PR DESCRIPTION
## What

This adds a variable, gitlab_tag, so the GitLab Docker tag can be set per environment.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is make it easier to test/deploy different versions of GitLab in different environments at the same time (and hopefully revert changes if necessary).

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
