### PR TITLE
infra: increase the version of GitLab Redis

### DIFF
--- a/infra/1007-gitlab--elasticache.tf
+++ b/infra/1007-gitlab--elasticache.tf
@@ -5,10 +5,11 @@ resource "aws_elasticache_cluster" "gitlab_redis" {
   node_type            = "cache.t2.micro"
   num_cache_nodes      = 1
   parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.6"
+  engine_version       = "7.1"
   port                 = 6379
   subnet_group_name    = aws_elasticache_subnet_group.gitlab[count.index].name
   security_group_ids   = ["${aws_security_group.gitlab_redis[count.index].id}"]
+  apply_immediately    = true
 }
 
 resource "aws_elasticache_subnet_group" "gitlab" {


### PR DESCRIPTION
## What

 This increases the from of GitLab Redis from 5.0.6 to 7.1, and sets changes to be applied immediately.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is because GitLab 16 seems to require a version of Redis >= 6, and applies immediately because that is what we want/expect, to not have to wait until a maintenance window.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
