### PR TITLE
infra: disable (non functional) GitLab upload object storage

### DIFF
--- a/infra/1011-gitlab--ecs.tf
+++ b/infra/1011-gitlab--ecs.tf
@@ -84,7 +84,7 @@ resource "aws_ecs_task_definition" "gitlab" {
             gitlab_rails['db_username'] = '${aws_rds_cluster.gitlab[count.index].master_username}'
             gitlab_rails['db_password'] = '${random_string.aws_db_instance_gitlab_password.result}'
             gitlab_rails['db_database'] = '${aws_rds_cluster.gitlab[count.index].database_name}'
-            gitlab_rails['uploads_object_store_enabled'] = true
+            gitlab_rails['uploads_object_store_enabled'] = false
             gitlab_rails['uploads_object_store_remote_directory'] = 'uploads'
             gitlab_rails['uploads_object_store_connection'] = {
               'provider' => 'AWS',


### PR DESCRIPTION
## What

This disables the object storage for GitLab uploads

<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

The bucket is empty - it was never actually functional. However, having it enabled now appears to break forks of projects with avatars. Forking such projects results in an error mentioning that the bucket "uploads.<bucket name>" does not exist. This is right, the bucket is just <bucket name>, so it's odd (maybe a bug with GitLab?)

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

<!---
## Links

Links to give more detail or background, e.g. a ticket in JIRA or Trello, a release or commit in another repository. But all text above should be standalone: don't assume the reader can or will access any external links.

e.g.
See: [Description](https://example.com/)
--->

## Checklist

<!--- The commands `git commit --amend`, `git rebase -i` and `git push origin feat/my-change --force-with-lease` can be useful in acheiving the following -->

* [x] Each commit in the PR is [atomic](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#atomic-commits). In many cases a single commit in the PR is appropriate.
* [x] Each commit has a [good message](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), with a body and not just a title, ideally adhering to the [Conventional Commit Specification](https://www.conventionalcommits.org/en/v1.0.0/).
* [x] I have self-reviewed the PR - looking at the code changes and descriptions of all its commits.
